### PR TITLE
Bug fixes.  Basically works now.  How accurately is another matter...

### DIFF
--- a/scripts/lib_oval.py
+++ b/scripts/lib_oval.py
@@ -496,10 +496,8 @@ class OvalDocument(object):
         # Depending on the ID type, find the parent for it or create that parent if it doesn't exist
         # Then append the current element
         if oval_type == OvalDefinition.DEFINITION:
-            print (">>>> Add definition: ", ovalid)
             parent = root.find("def:definitions", OvalDocument.NS_DEFAULT)
             if parent is None:
-                print("   >>>> Adding definitions element")
                 parent = Element("{" + OvalDocument.NS_DEFAULT.get("def") + "}definitions")
                 root.append(parent)
                 

--- a/scripts/lib_repo.py
+++ b/scripts/lib_repo.py
@@ -126,6 +126,7 @@ def get_element_repository_path(element):
         return None
     
     
+    
 
 def get_schema_short_name(element):
     """The schema short name reveals is a stand-in for the platform that this element is for and can be derived from the namespace URI

--- a/scripts/oval_decomposition.py
+++ b/scripts/oval_decomposition.py
@@ -128,8 +128,16 @@ def writeFile(path, element, verbose=False):
     # Create a new ElementTree with this element as the root
     tree = ElementTree(e)
     # And finally, write the full tree to a file including the xml declaration
+    parent = os.path.dirname(path)
+    if not os.path.isdir(parent):
+        try :
+            os.makedirs(parent, 755, True)
+        except:
+            return False
+    
     tree.write(path, "UTF-8", True)
 #     xml.etree.ElementTree.dump(tree)
+    return True
     
         
 

--- a/scripts/submission_qa.py
+++ b/scripts/submission_qa.py
@@ -482,9 +482,9 @@ def save_element(element, path):
     if not path or path is None:
         return
     
-    dir = os.path.dirname(path)
-    if not os.path.isdir(dir):
-        os.makedirs(dir, 755, True)
+    parent = os.path.dirname(path)
+    if not os.path.isdir(parent):
+        os.makedirs(parent, 755, True)
         
         
     try:


### PR DESCRIPTION
The QA script is now usable, but still in need of work.  Some of the highlights:

 * Does not prune out elements from the submission that are semantically the same as existing elements.  Which means that things like version updating (and for all affected) will happen when it shouldn't
 * For new elements, does not look for existing elements that are semantically the same.  And might not want to because that's a whole bunch of checking right there
 * The search to find affected elements returns a much higher number than seems reasonable
 * The validation step returns almost immediately, leading me to suspect that it isn't really validating
 * It doesn't really check the correctness/completeness of definition metadata
 * It doesn't set the repository/status metadata for definitions


So, yeah, much yet to do and I'm out of time for now.