### PR TITLE
Added new script:  add_to_repository.py

### DIFF
--- a/scripts/add_to_repository.py
+++ b/scripts/add_to_repository.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env/ python3
+"""Locates all OVAL elements in the file, regardless of the organization of the file, and for each
+element that has meaningful changes, adds/updates the repository
+
+
+Authors: Gunnar Engelbach <Gunnar.Engelbach@ThreatGuard.com>
+
+
+TODO:
+- Check for OVAL IDs in elements that are not repository IDs and update them
+"""
+
+
+import argparse
+import os
+from lxml import etree
+
+import lib_repo
+import lib_xml
+
+
+verbose = False
+force = False
+schema_path = ""
+SCHEMA_VERSION = "5.11.1"
+NS_MAP = { 'def': "http://oval.mitre.org/XMLSchema/oval-definitions-5", "oval": "http://oval.mitre.org/XMLSchema/oval-common-5",
+            "xsi": "http://www.w3.org/2001/XMLSchema-instance" }
+
+def main():
+    """
+    Breaks the OVAL file into its constituent elements and writes each of those into the repository
+    """
+    
+    global verbose
+    global force
+    global schema_path
+    
+    
+    parser = argparse.ArgumentParser(description='Separates a file into its component parts and saves them to the repository.')
+    program_options = parser.add_argument_group('options')
+    program_options.add_argument('files', metavar='<FILE>', nargs='+', help='The file or files to process')
+    program_options.add_argument('-f', '--force', required=False, action="store_true", help='Ignore the check for unchanged items and write all elements to the repository')
+    program_options.add_argument('-v', '--verbose', required=False, action="store_true", help='Enable more verbose messages')
+    
+    args = parser.parse_args()
+    options = vars(args)
+
+    if options['verbose']:
+        verbose = True
+    else:
+        verbose = False
+        
+    if options['force']:
+        force = True
+    else:
+        force = False
+        
+    schema_path = lib_repo.get_oval_def_schema(SCHEMA_VERSION)
+        
+    files = args.files
+    if files is None or len(files) < 1:
+        print("\n ## Error:  must include at least one file name")
+        return
+        
+    for file in files:
+        if not submit_contents(file):
+            print("\n### Error in file '{0}' -- processing halted".format(file))
+        
+        
+        
+def submit_contents(path):
+    
+    if path is None or not os.path.isfile(path):
+        return False
+    
+    global verbose
+    
+    if verbose:
+        print("\n :: Processing file {0}".format(path))
+    
+
+    element_list = find_all_elements(path)
+    if element_list is None or len(element_list) < 1:
+        if verbose:
+            print("\n >>> Not processing file '{0}':  no OVAL elements found")
+        return True
+    else:
+        if verbose:
+            print("  ++ Found {0} OVAL elements to process".format(len(element_list)))
+    
+    # First do a schema validation of all elements.  We won't write any changes
+    # if any of the elements do not pass validation
+    if verbose:
+        print("  +++ Doing schema/schematron validation...")
+    for element in element_list:
+        # Do schema validation
+        try:
+            lib_xml.schema_validate(element, schema_path, use_cached_schema=True)
+        except:
+            if verbose:
+                print("\n ## Error:  element {0} failed schema validation".format(element.get("id")))
+            return False
+         
+        #Do schematron validation
+#         try:
+#             lib_xml.schematron_validate_tree(element, schema_path)
+#         except:
+#             if verbose:
+#                 print("\n ## Error:  element {0} failed schematron validation".format(element.get("id")))
+#             return False
+
+    if verbose:
+        print("    ++++ Validation passed for all elements.\n")
+        
+    return process_elements(element_list)
+    
+    
+    
+def find_all_elements(path):
+    
+    if path is None or not os.path.isfile(path):
+        return False
+    
+    global verbose
+    
+    
+    try:
+        tree = etree.parse(path)
+    except Exception:
+        if verbose:
+            print("\n ## Error parsing file contents -- not processing this file")
+        return False
+    
+    element_list = []
+    
+    # Find all OVAL elements in the file.  They will have the tag names of 
+    # 'definition', '*_test', '*_object', '*_state', and '*_variable'
+    for element in tree.iter("*"):
+        if element.tag.endswith("definition") and not element.tag.endswith("_definition"):
+            element_list.append(element)
+        if element.tag.endswith("_test"):
+            element_list.append(element)
+        if element.tag.endswith("_object"):
+            element_list.append(element)
+        if element.tag.endswith("_state"):
+            element_list.append(element)
+        if element.tag.endswith("_variable"):
+            element_list.append(element)
+            
+    return element_list
+            
+            
+            
+def process_elements(element_list):
+    
+    if element_list is None:
+        return True
+    
+    global verbose
+    global force
+    global schema_path
+    
+    file_list = []
+    
+    for element in element_list:
+        ovalid = element.get("id")
+        
+        filepath = lib_repo.get_element_repository_path(element)
+        if not filepath or filepath is None:
+            if verbose:
+                print(" ###  Unable to determine repository location for '{0}'".format(ovalid))
+            return False
+        
+        if os.path.isfile(filepath):
+            if verbose:
+                print("    ++ Element '{0}' already exists.  Checking for changes...".format(ovalid))
+            original = lib_xml.load_standalone_element(filepath)
+            if original is not None:
+                changes = lib_xml.get_element_change_status(element, original)
+                if changes == 2:
+                    print("      +++ Changes found:  updating")
+                else:
+                    if verbose:
+                        print("      +++ No meaningful changes:  skipping".format(ovalid))
+                    continue
+        elif verbose:
+            print("     ++++ New element '{0}':\n      ---> adding to repository as '{1}".format(ovalid, filepath))
+    
+        
+        #Write the element to its own file
+        file_list.append(filepath)
+        save_element(element, filepath)
+        
+    print("\n +++ Files added or updated by this submission:")
+    for file in file_list:
+        print("   ---> {0}".format(file))
+    
+    return True
+        
+
+def save_element(element, path):
+    
+    if element is None:
+        return
+    
+    if not path or path is None:
+        return
+    
+    parent = os.path.dirname(path)
+    if not os.path.isdir(parent):
+        os.makedirs(parent, mode=0o755, exist_ok=True)
+        os.chmod(parent, 0o0755)
+        
+    try:
+        # Pretty up the element
+        indent(element)
+        # Create a new ElementTree with this element as the root
+        tree = etree.ElementTree(element)
+        # Write the full tree to a file
+        tree.write(path, xml_declaration=True, encoding="UTF-8", method="xml")
+        os.chmod(path, 0o0664)
+        return True
+    except:
+        return False
+    
+
+
+
+def indent(elem, level=0):
+    i = "\n" + level*"  "
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + "  "
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for elem in elem:
+            indent(elem, level+1)
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i    
+        
+        
+
+if __name__ == '__main__':
+    main()

--- a/scripts/lib_repo.py
+++ b/scripts/lib_repo.py
@@ -108,6 +108,9 @@ def get_element_repository_path(element):
                 return None
             return root_path + "/definitions/" + defclass + "/" + oval_id_to_path(oval_id)
         
+        elif element_type == "variable":
+            return root_path + "/variables/" + oval_id_to_path(oval_id)
+        
         else:
             platform = get_schema_short_name(element)
             if not platform or platform is None:
@@ -151,7 +154,7 @@ def get_schema_short_name(element):
     try:
         schema = tag.rsplit('}', 1)[0]
         if not '#' in schema:
-            return None
+            return "independent"
         return schema.rsplit('#', 1)[1].strip()
     except Exception:
         return None

--- a/scripts/oval_decomposition.py
+++ b/scripts/oval_decomposition.py
@@ -131,11 +131,13 @@ def writeFile(path, element, verbose=False):
     parent = os.path.dirname(path)
     if not os.path.isdir(parent):
         try :
-            os.makedirs(parent, 755, True)
+            os.makedirs(parent, 0o0755, True)
+            os.chmod(parent, 0o0755)
         except:
             return False
     
     tree.write(path, "UTF-8", True)
+    os.chmod(path, 0o0664)
 #     xml.etree.ElementTree.dump(tree)
     return True
     

--- a/scripts/oval_decomposition.py
+++ b/scripts/oval_decomposition.py
@@ -9,7 +9,6 @@ Authors: Gunnar Engelbach <Gunnar.Engelbach@ThreatGuard.com>
 
 
 TODO:
- - Create missing directories for filepaths when writing them there files
  - Tools for resolving/accepting changes when the OVAL ID for a component refers to an existing item
  - Use the min schema method to determine the minimum schema needed for this definition and add that information to the definition metadata
  - Update the local copy of the whoosh database index with metadata for all the new files

--- a/scripts/submission_qa.py
+++ b/scripts/submission_qa.py
@@ -488,12 +488,12 @@ def save_element(element, path):
         os.chmod(parent, 0o0755)
         
     try:
-        namespace = element.getNamespace()
+        # Pretty up the element
         indent(element)
         # Create a new ElementTree with this element as the root
         tree = etree.ElementTree(element)
         # Write the full tree to a file
-        tree.write(file_or_filename = path, encoding="UTF-8", method="xml", default_namespace = namespace)
+        tree.write(path, xml_declaration=True, encoding="UTF-8", method="xml")
         os.chmod(path, 0o0664)
         return True
     except:

--- a/scripts/submission_qa.py
+++ b/scripts/submission_qa.py
@@ -484,8 +484,8 @@ def save_element(element, path):
     
     parent = os.path.dirname(path)
     if not os.path.isdir(parent):
-        os.makedirs(parent, 755, True)
-        
+        os.makedirs(parent, mode=0o755, True)
+        os.chmod(parent, 0o0755)
         
     try:
         namespace = element.getNamespace()
@@ -494,6 +494,7 @@ def save_element(element, path):
         tree = etree.ElementTree(element)
         # Write the full tree to a file
         tree.write(file_or_filename = path, encoding="UTF-8", method="xml", default_namespace = namespace)
+        os.chmod(path, 0o0664)
         return True
     except:
         return False


### PR DESCRIPTION
Unlike oval_decomposition, this script doesn't care if the input file(s) are valid oval_definitions documents or not, just that they be parseable XML files that contain any number of well-formed OVAL elements.

The script will first do a schema validation on each of the found elements, then drop all elements that already exist in the repository and do not have fundamental changes.  So the resulting repository changes should be only those items that need to be part of a pull request.

This also means that a subsequent run of the submission_qa script will only be dealing with items in git that really do need to be updated.

* Caveat:  all test content I tried always failed on the call to lib_xml.schematron_validate_tree() so that function is currently commented out of the script.