### PR TITLE
MySQL SQL57 test

### DIFF
--- a/repository/definitions/compliance/oval_org.cisecurity.mysql_def_1027.xml
+++ b/repository/definitions/compliance/oval_org.cisecurity.mysql_def_1027.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='utf-8'?>
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="compliance" id="oval:org.cisecurity.mysql:def:1027" version="0">
+  <metadata>
+    <title>Ensure 'secure_auth' is set to 'On'</title>
+    <affected family="unix">
+      <platform>MySQL Community Server 5.6</platform>
+      <product>MySQL Community Server 5.6</product>
+    </affected>
+    <reference ref_id="xccdf_org.cisecurity.benchmarks_rule_7.2_Ensure_secure_auth_is_set_to_ON" ref_url="http://benchmarks.cisecurity.org" source="xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Oracle_MySQL_Community_Server_5.6_Benchmark" />
+    <description>Ensure 'secure_auth' is set to 'ON'</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2015-07-30T12:55:00.000-04:00">
+          <contributor organization="Center for Internet Security">Adam Montville</contributor>
+        </submitted>
+        <status_change date="2015-07-30T12:55:00.000-04:00">INTERIM</status_change>
+      </dates>
+      <status>INTERIM</status>
+    </oval_repository>
+  </metadata>
+  <criteria>
+    <criterion comment="Ensure 'secure_auth' is set to 'ON'" test_ref="oval:org.cisecurity.mysql:tst:1027" />
+  </criteria>
+</definition>

--- a/repository/objects/independent/sql57_object/2000/oval_org.cisecurity.mysql_obj_1027.xml
+++ b/repository/objects/independent/sql57_object/2000/oval_org.cisecurity.mysql_obj_1027.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sql57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.cisecurity.mysql:obj:1027" version="0">
+  <engine>mysql</engine>
+  <version>5.6</version>
+  <connection_string var_ref="oval:org.cisecurity.mysql:var:2000000" />
+  <sql> SHOW VARIABLES WHERE variable_name = 'secure_auth' </sql>
+</sql57_object>

--- a/repository/states/independent/sql57_state/2000/oval_org.cisecurity.mysql_ste_1027.xml
+++ b/repository/states/independent/sql57_state/2000/oval_org.cisecurity.mysql_ste_1027.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sql57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:ns1="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="xccdf_org.cisecurity.benchmarks_rule_7.2_Ensure_secure_auth_is_set_to_ON" id="oval:org.cisecurity.mysql:ste:1027" version="0">
+  <result datatype="record" entity_check="all">
+    <ns1:field datatype="string" name="variable_value" operation="equals" var_ref="oval:org.cisecurity.mysql:var:1027" />
+  </result>
+</sql57_state>

--- a/repository/tests/independent/sql57_test/2000/oval_org.cisecurity.mysql_tst_1027.xml
+++ b/repository/tests/independent/sql57_test/2000/oval_org.cisecurity.mysql_tst_1027.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sql57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="Ensure 'secure_auth' is set to 'ON'" id="oval:org.cisecurity.mysql:tst:1027" version="0">
+  <object object_ref="oval:org.cisecurity.mysql:obj:1027" />
+  <state state_ref="oval:org.cisecurity.mysql:ste:1027" />
+</sql57_test>


### PR DESCRIPTION
Adding OVAL definition to ensure 'secure_auth' is set to 'On' for MySQL Community Server 5.6.