### PR TITLE
Update oval_org.mitre.oval_obj_24512.xml

### DIFF
--- a/repository/objects/windows/file_object/24000/oval_org.mitre.oval_obj_24512.xml
+++ b/repository/objects/windows/file_object/24000/oval_org.mitre.oval_obj_24512.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the file Mpclient.dll" id="oval:org.mitre.oval:obj:24512" version="3">
-  <path var_ref="oval:org.mitre.oval:var:1746" />
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1746" />
   <filename>Mpclient.dll</filename>
 </file_object>


### PR DESCRIPTION
default var_check="all" was replaced with var_check="at least one" in the object oval:org.mitre.oval:obj:24512 because variable has more than one value.