### PR TITLE
Update oval_org.mitre.oval_def_29058.xml

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_29058.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_29058.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:org.mitre.oval:def:29058" version="3" class="inventory">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" deprecated="true" id="oval:org.mitre.oval:def:29058" version="3" class="inventory">
   <metadata>
     <title>Windows Media Center is installed</title>
     <affected family="windows">


### PR DESCRIPTION
We have two similar inventory definitions for the Windows Media Center:
- oval:org.mitre.oval:def:29080;
- oval:org.mitre.oval:def:29058;

This definitions (oval:org.mitre.oval:def:29058) has no dependences in other defs. I would like to deprecate this definition.