### PR TITLE
Oval submission for Solaris 10

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_1440.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_1440.xml
@@ -16,7 +16,6 @@
         <oval-def:status_change date="2007-07-18T15:57:49.640-04:00">ACCEPTED</oval-def:status_change>
       </oval-def:dates>
       <oval-def:status>ACCEPTED</oval-def:status>
-      <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_1926.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_1926.xml
@@ -16,7 +16,6 @@
         <oval-def:status_change date="2007-07-18T15:57:51.357-04:00">ACCEPTED</oval-def:status_change>
       </oval-def:dates>
       <oval-def:status>ACCEPTED</oval-def:status>
-      <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20151001.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20151001.xml
@@ -1,0 +1,28 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20151001" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Critical Patch Update October 2015</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>Sun Solaris 10</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-2642" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2642" source="CVE" />
+    <oval-def:description>Critical Patch Update October 2015</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-01-29T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criteria comment="Patch 120719-07 or later installed" operator="AND">
+      <oval-def:extend_definition comment="Solaris 10 (SPARC) is installed" definition_ref="oval:org.mitre.oval:def:1440" />
+      <oval-def:criterion comment="Patch 120719-07 or later installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20151001" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Patch 120720-07 or later installed" operator="AND">
+      <oval-def:extend_definition comment="Solaris 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:1926" />
+      <oval-def:criterion comment="Patch 120720-07 or later installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20151002" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20151002.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20151002.xml
@@ -1,0 +1,28 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20151002" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Critical Patch Update July 2015</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>Sun Solaris 10</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4869" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4869" source="CVE" />
+    <oval-def:description>Critical Patch Update July 2015</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-01-29T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criteria comment="Patch 150400-27 or later installed" operator="AND">
+      <oval-def:extend_definition comment="Solaris 10 (SPARC) is installed" definition_ref="oval:org.mitre.oval:def:1440" />
+      <oval-def:criterion comment="Patch 150400-27 or later installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20151003" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Patch 150401-27 or later installed" operator="AND">
+      <oval-def:extend_definition comment="Solaris 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:1926" />
+      <oval-def:criterion comment="Patch 150401-27 or later installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20151004" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/objects/solaris/patch54_object/20151000/oval_com.hp.temp.oval_obj_20151001.xml
+++ b/repository/objects/solaris/patch54_object/20151000/oval_com.hp.temp.oval_obj_20151001.xml
@@ -1,0 +1,5 @@
+<patch54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris" id="oval:com.hp.temp.oval:obj:20151001" version="0">
+  <behaviors supersedence="true" />
+  <base datatype="int">120719</base>
+  <version datatype="int">07</version>
+</patch54_object>

--- a/repository/objects/solaris/patch54_object/20151000/oval_com.hp.temp.oval_obj_20151002.xml
+++ b/repository/objects/solaris/patch54_object/20151000/oval_com.hp.temp.oval_obj_20151002.xml
@@ -1,0 +1,5 @@
+<patch54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris" id="oval:com.hp.temp.oval:obj:20151002" version="0">
+  <behaviors supersedence="true" />
+  <base datatype="int">120720</base>
+  <version datatype="int">07</version>
+</patch54_object>

--- a/repository/objects/solaris/patch54_object/20151000/oval_com.hp.temp.oval_obj_20151003.xml
+++ b/repository/objects/solaris/patch54_object/20151000/oval_com.hp.temp.oval_obj_20151003.xml
@@ -1,0 +1,5 @@
+<patch54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris" id="oval:com.hp.temp.oval:obj:20151003" version="0">
+  <behaviors supersedence="true" />
+  <base datatype="int">150400</base>
+  <version datatype="int">27</version>
+</patch54_object>

--- a/repository/objects/solaris/patch54_object/20151000/oval_com.hp.temp.oval_obj_20151004.xml
+++ b/repository/objects/solaris/patch54_object/20151000/oval_com.hp.temp.oval_obj_20151004.xml
@@ -1,0 +1,5 @@
+<patch54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris" id="oval:com.hp.temp.oval:obj:20151004" version="0">
+  <behaviors supersedence="true" />
+  <base datatype="int">150401</base>
+  <version datatype="int">27</version>
+</patch54_object>

--- a/repository/objects/unix/uname_object/2000/oval_org.mitre.oval_obj_2759.xml
+++ b/repository/objects/unix/uname_object/2000/oval_org.mitre.oval_obj_2759.xml
@@ -1,2 +1,2 @@
 <ns0:uname_object xmlns:ns0="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="The single uname object." id="oval:org.mitre.oval:obj:2759" version="1" />
-    
+	

--- a/repository/tests/solaris/patch54_test/20151000/oval_com.hp.temp.oval_tst_20151001.xml
+++ b/repository/tests/solaris/patch54_test/20151000/oval_com.hp.temp.oval_tst_20151001.xml
@@ -1,0 +1,3 @@
+<patch54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris" check="at least one" check_existence="at_least_one_exists" comment="Patch 120719-07 or later installed" id="oval:com.hp.temp.oval:tst:20151001" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20151001" />
+</patch54_test>

--- a/repository/tests/solaris/patch54_test/20151000/oval_com.hp.temp.oval_tst_20151002.xml
+++ b/repository/tests/solaris/patch54_test/20151000/oval_com.hp.temp.oval_tst_20151002.xml
@@ -1,0 +1,3 @@
+<patch54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris" check="at least one" check_existence="at_least_one_exists" comment="Patch 120720-07 or later installed" id="oval:com.hp.temp.oval:tst:20151002" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20151002" />
+</patch54_test>

--- a/repository/tests/solaris/patch54_test/20151000/oval_com.hp.temp.oval_tst_20151003.xml
+++ b/repository/tests/solaris/patch54_test/20151000/oval_com.hp.temp.oval_tst_20151003.xml
@@ -1,0 +1,3 @@
+<patch54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris" check="at least one" check_existence="at_least_one_exists" comment="Patch 150400-27 or later installed" id="oval:com.hp.temp.oval:tst:20151003" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20151003" />
+</patch54_test>

--- a/repository/tests/solaris/patch54_test/20151000/oval_com.hp.temp.oval_tst_20151004.xml
+++ b/repository/tests/solaris/patch54_test/20151000/oval_com.hp.temp.oval_tst_20151004.xml
@@ -1,0 +1,3 @@
+<patch54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris" check="at least one" check_existence="at_least_one_exists" comment="Patch 150401-27 or later installed" id="oval:com.hp.temp.oval:tst:20151004" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20151004" />
+</patch54_test>


### PR DESCRIPTION
Oval definitions for security advisories released on Oct 20 for Oracle Solaris 10