### PR TITLE
Adding missing OVAL definitions (AIX inventory).

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_18828.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_18828.xml
@@ -1,0 +1,25 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:org.mitre.oval:def:18828" version="3" class="inventory">
+  <oval-def:metadata>
+    <oval-def:title>IBM AIX 7.1 is installed</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference source="CPE" ref_id="cpe:/o:ibm:aix:7.1"/>
+    <oval-def:description>The operating system installed on the system is IBM AIX 7.1.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2013-11-15T17:30:00.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Chandan M C</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2013-11-21T13:18:01.158-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2013-12-09T04:00:10.385-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2013-12-30T04:00:17.385-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criterion comment="IBM AIX version is greater than or equal 7100-00" test_ref="oval:org.mitre.oval:tst:87141"/>
+    <oval-def:criterion comment="IBM AIX version is less than 8100-00" test_ref="oval:org.mitre.oval:tst:87164"/>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_5267.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_5267.xml
@@ -1,0 +1,36 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:org.mitre.oval:def:5267" version="3" class="inventory">
+    <oval-def:metadata>
+        <oval-def:title>IBM AIX 6.1 is installed</oval-def:title>
+        <oval-def:affected family="unix">
+            <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+        </oval-def:affected>
+        <oval-def:reference source="CPE" ref_id="cpe:/o:ibm:aix:6.1"/>
+        <oval-def:description>The operating system installed on the system is IBM AIX 6.1.</oval-def:description>
+        <oval-def:oval_repository>
+            <oval-def:dates>
+                <oval-def:submitted date="2008-06-12T12:00:00.000-04:00">
+                    <oval-def:contributor organization="Hewlett-Packard">Michael Wood</oval-def:contributor>
+                </oval-def:submitted>
+                <oval-def:modified comment="Use pattern matching for 6.1 test" date="2008-06-12T11:18:00.144-04:00">
+                    <oval-def:contributor organization="Hewlett-Packard">Michael Wood</oval-def:contributor>
+                </oval-def:modified>
+                <oval-def:status_change date="2008-06-20T15:38:35.657-04:00">DRAFT</oval-def:status_change>
+                <oval-def:modified comment="Changed state back so it no longer has contains a pattern_match operation" date="2008-07-08T10:46:00.008-04:00">
+                    <oval-def:contributor organization="Hewlett-Packard">Michael Wood</oval-def:contributor>
+                </oval-def:modified>
+                <oval-def:status_change date="2008-07-28T04:00:10.105-04:00">INTERIM</oval-def:status_change>
+                <oval-def:status_change date="2008-08-18T04:00:22.609-04:00">ACCEPTED</oval-def:status_change>
+                <oval-def:modified comment="EDITED oval:org.mitre.oval:def:5267 - inventory definitions for IBM AIX" date="2013-11-21T13:16:00.051-05:00">
+                    <oval-def:contributor organization="Hewlett-Packard">Chandan M C</oval-def:contributor>
+                </oval-def:modified>
+                <oval-def:status_change date="2013-11-21T13:18:01.723-05:00">INTERIM</oval-def:status_change>
+                <oval-def:status_change date="2013-12-09T04:00:18.894-05:00">ACCEPTED</oval-def:status_change>
+            </oval-def:dates>
+            <oval-def:status>ACCEPTED</oval-def:status>
+        </oval-def:oval_repository>
+    </oval-def:metadata>
+    <oval-def:criteria>
+        <oval-def:criterion comment="IBM AIX version is greater than or equal 6100-00" test_ref="oval:org.mitre.oval:tst:7699"/>
+        <oval-def:criterion comment="IBM AIX version is less than 7100-00" test_ref="oval:org.mitre.oval:tst:8057"/>
+    </oval-def:criteria>
+</oval-def:definition>


### PR DESCRIPTION
Two AIX definitions were missing from the repository.