### PR TITLE
Obj 30359

### DIFF
--- a/repository/objects/windows/file_object/30000/oval_org.mitre.oval_obj_30359.xml
+++ b/repository/objects/windows/file_object/30000/oval_org.mitre.oval_obj_30359.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the information of Setup.exe" id="oval:org.mitre.oval:obj:30359" version="1">
-  <path operation="pattern match" var_check="at least one" var_ref="oval:org.mitre.oval:var:969" />
+  <path operation="pattern match" var_check="at least one" var_ref="oval:org.mitre.oval:var:969"/>
   <filename>Setup.exe</filename>
 </file_object>

--- a/repository/objects/windows/file_object/30000/oval_org.mitre.oval_obj_30359.xml
+++ b/repository/objects/windows/file_object/30000/oval_org.mitre.oval_obj_30359.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the information of Setup.exe" id="oval:org.mitre.oval:obj:30359" version="1">
-  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:969" />
+  <path operation="pattern match" var_check="at least one" var_ref="oval:org.mitre.oval:var:969" />
   <filename>Setup.exe</filename>
 </file_object>

--- a/repository/variables/oval_org.mitre.oval_var_969.xml
+++ b/repository/variables/oval_org.mitre.oval_var_969.xml
@@ -1,6 +1,9 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment=".NET 4.0 Framework client directory" datatype="string" id="oval:org.mitre.oval:var:969" version="1">
-  <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:219" />
-    <oval-def:literal_component>\Microsoft.NET\Framework\v4.0.30319\SetupCache\Client</oval-def:literal_component>
-  </oval-def:concat>
+  <concat>
+	    <literal_component>^</literal_component>
+		<escape_regex>
+        <object_component object_ref="oval:org.mitre.oval:obj:219" item_field="value" />
+		</escape_regex>
+        <literal_component>\\Microsoft.NET\\Framework(64)?\\v4\.0\.30319\\SetupCache(\\Client)?(\\v4.*)?$</literal_component>
+  </concat>
 </oval-def:local_variable>


### PR DESCRIPTION
The object obj:30359 and variable var:969 were changed because in Windows 7 and Server 2008 R2 there is no Client folder but in Server 2008 and Vista it exists. The folder Framework should be checked on 32-bit system and Framework64 on 64-bit. And the last version (\\v4.*) could be or not to be.