### PR TITLE
Kemanik obj 23790

### DIFF
--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79838.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79838.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.data.edm.powershell.dll is less than 5.0.0.50712" id="oval:org.mitre.oval:tst:79838" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.data.edm.powershell.dll is less than 5.0.0.50712" id="oval:org.mitre.oval:tst:79838" version="2">
   <object object_ref="oval:org.mitre.oval:obj:24022" />
   <state state_ref="oval:org.mitre.oval:ste:20091" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80212.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80212.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.data.services.dll is less than 3.5.30729.6400" id="oval:org.mitre.oval:tst:80212" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.data.services.dll is less than 3.5.30729.6400" id="oval:org.mitre.oval:tst:80212" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23790" />
   <state state_ref="oval:org.mitre.oval:ste:20348" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80642.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80642.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.Data.Services.dll is greater than or equal to 3.5.30729.7000" id="oval:org.mitre.oval:tst:80642" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.Data.Services.dll is greater than or equal to 3.5.30729.7000" id="oval:org.mitre.oval:tst:80642" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23790" />
   <state state_ref="oval:org.mitre.oval:ste:20287" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80809.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80809.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.Data.Services.dll is less than 3.5.30729.7004" id="oval:org.mitre.oval:tst:80809" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.Data.Services.dll is less than 3.5.30729.7004" id="oval:org.mitre.oval:tst:80809" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23790" />
   <state state_ref="oval:org.mitre.oval:ste:20200" />
 </file_test>


### PR DESCRIPTION
Hello,
Four file_tests which used the object obj:23790 were modified. check="all" was replaced with check="at least one" because the object could collect more then one item and the test should be true if at least one item has vulnerable version.