### PR TITLE
Update oval_org.mitre.oval_var_1684.xml

### DIFF
--- a/repository/variables/oval_org.mitre.oval_var_1684.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1684.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The Microsoft Visual Studio 2010 ...VC\redist\x86\Microsoft.VC100.ATL subdirectory" datatype="string" id="oval:org.mitre.oval:var:1684" version="2">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23506" />
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:7336" />
     <oval-def:literal_component>VC\redist\x86\Microsoft.VC100.ATL</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
The object oval:org.mitre.oval:obj:23506 was replased with oval:org.mitre.oval:obj:7336 because of error  (path does not exist).