### PR TITLE
Kemanik registry obj duplicates

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_12271.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_12271.xml
@@ -25,8 +25,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
+  <oval-def:criteria>
     <oval-def:extend_definition comment="PHP is installed" definition_ref="oval:org.mitre.oval:def:12410" />
-    <oval-def:criterion comment="Check if the version of PHP is less than 5.3.4" test_ref="oval:org.mitre.oval:tst:41865" />
+    <oval-def:criterion comment="Check if the version of PHP is less than 5.3.4" test_ref="oval:org.mitre.oval:tst:42273" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_12334.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_12334.xml
@@ -25,8 +25,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
+  <oval-def:criteria>
     <oval-def:extend_definition comment="PHP is installed" definition_ref="oval:org.mitre.oval:def:12410" />
-    <oval-def:criterion comment="Check if the version of PHP is less than 5.3.4" test_ref="oval:org.mitre.oval:tst:41865" />
+    <oval-def:criterion comment="Check if the version of PHP is less than 5.3.4" test_ref="oval:org.mitre.oval:tst:42273" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_12589.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_12589.xml
@@ -27,8 +27,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
+  <oval-def:criteria>
     <oval-def:extend_definition comment="PHP is installed" definition_ref="oval:org.mitre.oval:def:12410" />
-    <oval-def:criterion comment="Check if the version of PHP is less than 5.3.4" test_ref="oval:org.mitre.oval:tst:41865" />
+    <oval-def:criterion comment="Check if the version of PHP is less than 5.3.4" test_ref="oval:org.mitre.oval:tst:42273" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_24137.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_24137.xml
@@ -32,21 +32,21 @@
   <oval-def:criteria operator="OR">
     <oval-def:criteria comment="Check vulnerable OpenSSL" operator="AND">
       <oval-def:criteria comment="Check vulnerable versions of OpenSSL" operator="OR">
-        <oval-def:criterion comment="Check if the version of OpenSSL 0.9.1с before 0.9.8za" test_ref="oval:org.mitre.oval:tst:115122" />
+        <oval-def:criterion comment="Check if the version of OpenSSL 0.9.1c before 0.9.8za" test_ref="oval:org.mitre.oval:tst:115122" />
         <oval-def:criterion comment="Check if the version of OpenSSL 1.0.0 before 1.0.0m" test_ref="oval:org.mitre.oval:tst:114595" />
       </oval-def:criteria>
       <oval-def:criterion comment="OpenSSL is installed" test_ref="oval:org.mitre.oval:tst:113869" />
     </oval-def:criteria>
     <oval-def:criteria comment="Check vulnerable OpenSSL (32_bit)" operator="AND">
       <oval-def:criteria comment="Check vulnerable versions of OpenSSL (32_bit)" operator="OR">
-        <oval-def:criterion comment="Check if the version of OpenSSL 0.9.1с before 0.9.8za (32_bit)" test_ref="oval:org.mitre.oval:tst:115181" />
+        <oval-def:criterion comment="Check if the version of OpenSSL 0.9.1c before 0.9.8za (32_bit)" test_ref="oval:org.mitre.oval:tst:115181" />
         <oval-def:criterion comment="Check if the version of OpenSSL 1.0.0 before 1.0.0m (32_bit)" test_ref="oval:org.mitre.oval:tst:114995" />
       </oval-def:criteria>
       <oval-def:criterion comment="OpenSSL (32_bit) is installed" test_ref="oval:org.mitre.oval:tst:113875" />
     </oval-def:criteria>
-    <oval-def:criterion comment="Check if the version of ssleay32.dll 0.9.1с before 0.9.8za ProgramFilesDir" test_ref="oval:org.mitre.oval:tst:114313" />
-    <oval-def:criterion comment="Check if the version of ssleay32.dll 0.9.1с before 0.9.8za ProgramFilesDir x86" test_ref="oval:org.mitre.oval:tst:114951" />
-    <oval-def:criterion comment="Check if the version of ssleay32.dll 0.9.1с before 0.9.8za under Sytem32 and SysWOW64" test_ref="oval:org.mitre.oval:tst:115136" />
+    <oval-def:criterion comment="Check if the version of ssleay32.dll 0.9.1c before 0.9.8za ProgramFilesDir" test_ref="oval:org.mitre.oval:tst:114313" />
+    <oval-def:criterion comment="Check if the version of ssleay32.dll 0.9.1c before 0.9.8za ProgramFilesDir x86" test_ref="oval:org.mitre.oval:tst:114951" />
+    <oval-def:criterion comment="Check if the version of ssleay32.dll 0.9.1c before 0.9.8za under Sytem32 and SysWOW64" test_ref="oval:org.mitre.oval:tst:115136" />
     <oval-def:criterion comment="Check if the version of ssleay32.dll 1.0.0 before 1.0.0m ProgramFilesDir" test_ref="oval:org.mitre.oval:tst:114936" />
     <oval-def:criterion comment="Check if the version of ssleay32.dll 1.0.0 before 1.0.0m ProgramFilesDir x86" test_ref="oval:org.mitre.oval:tst:115165" />
     <oval-def:criterion comment="Check if the version of ssleay32.dll 1.0.0 before 1.0.0m under Sytem32 and SysWOW64" test_ref="oval:org.mitre.oval:tst:115016" />

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114313.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114313.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ssleay32.dll 0.9.1с before 0.9.8za ProgramFilesDir" id="oval:org.mitre.oval:tst:114313" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ssleay32.dll 0.9.1c before 0.9.8za ProgramFilesDir" id="oval:org.mitre.oval:tst:114313" version="1">
   <object object_ref="oval:org.mitre.oval:obj:38542" />
   <state state_ref="oval:org.mitre.oval:ste:31715" />
   <state state_ref="oval:org.mitre.oval:ste:31519" />

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114951.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114951.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ssleay32.dll 0.9.1с before 0.9.8za ProgramFilesDir x86" id="oval:org.mitre.oval:tst:114951" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ssleay32.dll 0.9.1c before 0.9.8za ProgramFilesDir x86" id="oval:org.mitre.oval:tst:114951" version="1">
   <object object_ref="oval:org.mitre.oval:obj:38707" />
   <state state_ref="oval:org.mitre.oval:ste:31715" />
   <state state_ref="oval:org.mitre.oval:ste:31519" />

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115122.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115122.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of OpenSSL 0.9.1с before 0.9.8za" id="oval:org.mitre.oval:tst:115122" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of OpenSSL 0.9.1c before 0.9.8za" id="oval:org.mitre.oval:tst:115122" version="1">
   <object object_ref="oval:org.mitre.oval:obj:38735" />
   <state state_ref="oval:org.mitre.oval:ste:31715" />
   <state state_ref="oval:org.mitre.oval:ste:31519" />

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115136.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115136.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ssleay32.dll 0.9.1с before 0.9.8za under Sytem32 and SysWOW64" id="oval:org.mitre.oval:tst:115136" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ssleay32.dll 0.9.1c before 0.9.8za under Sytem32 and SysWOW64" id="oval:org.mitre.oval:tst:115136" version="1">
   <object object_ref="oval:org.mitre.oval:obj:39247" />
   <state state_ref="oval:org.mitre.oval:ste:31715" />
   <state state_ref="oval:org.mitre.oval:ste:31519" />

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115181.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115181.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of OpenSSL 0.9.1с before 0.9.8za (32_bit)" id="oval:org.mitre.oval:tst:115181" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of OpenSSL 0.9.1c before 0.9.8za (32_bit)" id="oval:org.mitre.oval:tst:115181" version="1">
   <object object_ref="oval:org.mitre.oval:obj:39008" />
   <state state_ref="oval:org.mitre.oval:ste:31715" />
   <state state_ref="oval:org.mitre.oval:ste:31519" />

--- a/repository/tests/windows/registry_test/42000/oval_org.mitre.oval_tst_42097.xml
+++ b/repository/tests/windows/registry_test/42000/oval_org.mitre.oval_tst_42097.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of PHP is less than 5.2.15" id="oval:org.mitre.oval:tst:42097" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15645" />
+  <object object_ref="oval:org.mitre.oval:obj:15679" />
   <state state_ref="oval:org.mitre.oval:ste:12157" />
 </registry_test>


### PR DESCRIPTION
oval:org.mitre.oval:obj:15679 and oval:org.mitre.oval:obj:15645 are duplicates. The object that was used in less quantity of tests was replaced with the another object. Also tests duplicates were found and replaced oval:org.mitre.oval:tst:42273 and oval:org.mitre.oval:tst:41865