### PR TITLE
Kemanik dpkginfo test duplicates

### DIFF
--- a/repository/tests/linux/dpkginfo_test/83000/oval_org.mitre.oval_tst_83746.xml
+++ b/repository/tests/linux/dpkginfo_test/83000/oval_org.mitre.oval_tst_83746.xml
@@ -1,4 +1,4 @@
 <dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="abrowser DPKG is earlier than 3.0.4+nobinonly-0ubuntu0.8.10.1" id="oval:org.mitre.oval:tst:83746" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:25312" />
+  <object object_ref="oval:org.mitre.oval:obj:17123" />
   <state state_ref="oval:org.mitre.oval:ste:21807" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/83000/oval_org.mitre.oval_tst_83762.xml
+++ b/repository/tests/linux/dpkginfo_test/83000/oval_org.mitre.oval_tst_83762.xml
@@ -1,4 +1,4 @@
 <dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="abrowser DPKG is earlier than 3.0.5+nobinonly-0ubuntu0.8.10.1" id="oval:org.mitre.oval:tst:83762" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:25312" />
+  <object object_ref="oval:org.mitre.oval:obj:17123" />
   <state state_ref="oval:org.mitre.oval:ste:22070" />
 </dpkginfo_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:25312](https://github.com/CISecurity/OVALRepo/blob/11115a29de0380df0d80aaa282b587c49c9448c2/repository/objects/linux/dpkginfo_object/25000/oval_org.mitre.oval_obj_25312.xml) and [oval:org.mitre.oval:obj:17123](https://github.com/CISecurity/OVALRepo/blob/11115a29de0380df0d80aaa282b587c49c9448c2/repository/objects/linux/dpkginfo_object/17000/oval_org.mitre.oval_obj_17123.xml) are duplicates. The object that was used in less quantity of tests was replaced with the another object.
