### PR TITLE
Kemanik rpminfo test duplicates

### DIFF
--- a/repository/definitions/patch/oval_org.mitre.oval_def_28842.xml
+++ b/repository/definitions/patch/oval_org.mitre.oval_def_28842.xml
@@ -28,6 +28,6 @@ Network (RHN) server for software updates.</oval-def:description>
   </oval-def:metadata>
   <oval-def:criteria>
     <oval-def:extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 5" definition_ref="oval:org.mitre.oval:def:11414" />
-    <oval-def:criterion comment="yum-rhn-plugin is earlier than 0:0.5.3-12.el5_2.9" test_ref="oval:org.mitre.oval:tst:139143" />
+    <oval-def:criterion comment="yum-rhn-plugin is earlier than 0:0.5.3-12.el5_2.9" test_ref="oval:org.mitre.oval:tst:102400" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_10864.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_10864.xml
@@ -32,6 +32,6 @@
       <oval-def:extend_definition comment="CentOS Linux 5.x" definition_ref="oval:org.mitre.oval:def:15802" />
       <oval-def:extend_definition comment="Oracle Linux 5.x" definition_ref="oval:org.mitre.oval:def:15459" />
     </oval-def:criteria>
-    <oval-def:criterion comment="yum-rhn-plugin is earlier than 0:0.5.3-12.el5_2.9" test_ref="oval:org.mitre.oval:tst:37479" />
+    <oval-def:criterion comment="yum-rhn-plugin is earlier than 0:0.5.3-12.el5_2.9" test_ref="oval:org.mitre.oval:tst:102400" />
   </oval-def:criteria>
 </oval-def:definition>


### PR DESCRIPTION
The tests [oval:org.mitre.oval:tst:102400](https://github.com/CISecurity/OVALRepo/blob/11115a29de0380df0d80aaa282b587c49c9448c2/repository/tests/linux/rpminfo_test/102000/oval_org.mitre.oval_tst_102400.xml), [oval:org.mitre.oval:tst:139143](https://github.com/CISecurity/OVALRepo/blob/11115a29de0380df0d80aaa282b587c49c9448c2/repository/tests/linux/rpminfo_test/39000/oval_org.mitre.oval_tst_39143.xml) and [oval:org.mitre.oval:tst:37479](https://github.com/CISecurity/OVALRepo/blob/11115a29de0380df0d80aaa282b587c49c9448c2/repository/tests/linux/rpminfo_test/37000/oval_org.mitre.oval_tst_37479.xml) are duplicates(check="all" or "at least one" does not matter because this package could be only one)