### PR TITLE
Kemanik deprecate

### DIFF
--- a/repository/objects/linux/dpkginfo_object/25000/oval_org.mitre.oval_obj_25312.xml
+++ b/repository/objects/linux/dpkginfo_object/25000/oval_org.mitre.oval_obj_25312.xml
@@ -1,3 +1,3 @@
-<dpkginfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="abrowser package information" id="oval:org.mitre.oval:obj:25312" version="1">
+<dpkginfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="abrowser package information" id="oval:org.mitre.oval:obj:25312" version="1" deprecated="true">
   <name>abrowser</name>
 </dpkginfo_object>

--- a/repository/objects/linux/rpminfo_object/15000/oval_org.mitre.oval_obj_15021.xml
+++ b/repository/objects/linux/rpminfo_object/15000/oval_org.mitre.oval_obj_15021.xml
@@ -1,3 +1,3 @@
-<rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:org.mitre.oval:obj:15021" version="1">
+<rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:org.mitre.oval:obj:15021" version="1" deprecated="true">
   <name>yum-rhn-plugin</name>
 </rpminfo_object>

--- a/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15645.xml
+++ b/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15645.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds the version of PHP installed" id="oval:org.mitre.oval:obj:15645" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds the version of PHP installed" id="oval:org.mitre.oval:obj:15645" version="1" deprecated="true">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\PHP</key>
   <name>Version</name>

--- a/repository/states/linux/rpminfo_state/11000/oval_org.mitre.oval_ste_11068.xml
+++ b/repository/states/linux/rpminfo_state/11000/oval_org.mitre.oval_ste_11068.xml
@@ -1,3 +1,3 @@
-<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:org.mitre.oval:ste:11068" version="1">
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:org.mitre.oval:ste:11068" version="1" deprecated="true">
   <evr datatype="evr_string" operation="less than">0:0.5.3-12.el5_2.9</evr>
 </rpminfo_state>

--- a/repository/states/linux/rpminfo_state/38000/oval_org.mitre.oval_ste_38843.xml
+++ b/repository/states/linux/rpminfo_state/38000/oval_org.mitre.oval_ste_38843.xml
@@ -1,3 +1,3 @@
-<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="version is earlier than 0:0.5.3-12.el5_2.9" id="oval:org.mitre.oval:ste:38843" version="1">
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="version is earlier than 0:0.5.3-12.el5_2.9" id="oval:org.mitre.oval:ste:38843" version="1" deprecated="true">
   <evr datatype="evr_string" operation="less than">0:0.5.3-12.el5_2.9</evr>
 </rpminfo_state>

--- a/repository/tests/linux/rpminfo_test/139000/oval_org.mitre.oval_tst_139143.xml
+++ b/repository/tests/linux/rpminfo_test/139000/oval_org.mitre.oval_tst_139143.xml
@@ -1,4 +1,4 @@
-<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="yum-rhn-plugin is earlier than 0:0.5.3-12.el5_2.9" id="oval:org.mitre.oval:tst:139143" version="1">
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="yum-rhn-plugin is earlier than 0:0.5.3-12.el5_2.9" id="oval:org.mitre.oval:tst:139143" version="1" deprecated="true">
   <object object_ref="oval:org.mitre.oval:obj:15021" />
   <state state_ref="oval:org.mitre.oval:ste:38843" />
 </rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/37000/oval_org.mitre.oval_tst_37479.xml
+++ b/repository/tests/linux/rpminfo_test/37000/oval_org.mitre.oval_tst_37479.xml
@@ -1,4 +1,4 @@
-<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="yum-rhn-plugin is earlier than 0:0.5.3-12.el5_2.9" id="oval:org.mitre.oval:tst:37479" version="1">
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="yum-rhn-plugin is earlier than 0:0.5.3-12.el5_2.9" id="oval:org.mitre.oval:tst:37479" version="1" deprecated="true">
   <object object_ref="oval:org.mitre.oval:obj:15021" />
   <state state_ref="oval:org.mitre.oval:ste:11068" />
 </rpminfo_test>

--- a/repository/tests/windows/registry_test/41000/oval_org.mitre.oval_tst_41865.xml
+++ b/repository/tests/windows/registry_test/41000/oval_org.mitre.oval_tst_41865.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of PHP is less than 5.3.4" id="oval:org.mitre.oval:tst:41865" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of PHP is less than 5.3.4" id="oval:org.mitre.oval:tst:41865" version="1" deprecated="true">
   <object object_ref="oval:org.mitre.oval:obj:15645" />
   <state state_ref="oval:org.mitre.oval:ste:12022" />
 </registry_test>


### PR DESCRIPTION
A lot of duplicates in each section were found. The test/object that used in a more quantity of definitions/tests was taken as a basis and its duplicates should be deprecated to avoid of reusing and increase duplicates.