### PR TITLE
Kemanik duplicate tst 3257

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_267.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_267.xml
@@ -30,10 +30,10 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
+  <oval-def:criteria>
     <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:3750" />
     <oval-def:criterion comment="Win2K/XP/2003 service pack 1 is installed" test_ref="oval:org.mitre.oval:tst:3342" />
-    <oval-def:criterion comment="64-Bit (ia64 architecture) version of Windows is installed" negate="true" test_ref="oval:org.mitre.oval:tst:3257" />
+    <oval-def:criterion comment="a version of Windows for the ia64 architecture is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2747" />
     <oval-def:criterion comment="the version of umpnpmgr.dll is less than 5.1.2600.1711" test_ref="oval:org.mitre.oval:tst:3367" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_497.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_497.xml
@@ -40,10 +40,10 @@
       <oval-def:min_schema_version>5.4</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
+  <oval-def:criteria>
     <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:3750" />
     <oval-def:criterion comment="Win2K/XP/2003/Vista/2008 service pack 2 is installed" test_ref="oval:org.mitre.oval:tst:3019" />
-    <oval-def:criterion comment="64-Bit (ia64 architecture) version of Windows is installed" negate="true" test_ref="oval:org.mitre.oval:tst:3257" />
+    <oval-def:criterion comment="a version of Windows for the ia64 architecture is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2747" />
     <oval-def:criterion comment="the version of umpnpmgr.dll is less than 5.1.2600.2710" test_ref="oval:org.mitre.oval:tst:3964" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_618.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_618.xml
@@ -33,7 +33,7 @@
   <oval-def:criteria operator="AND">
     <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:3750" />
     <oval-def:criterion comment="Win2K/XP/2003 service pack 1 is installed" test_ref="oval:org.mitre.oval:tst:3342" />
-    <oval-def:criterion comment="64-Bit (ia64 architecture) version of Windows is installed" negate="true" test_ref="oval:org.mitre.oval:tst:3257" />
+    <oval-def:criterion comment="a version of Windows for the ia64 architecture is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2747" />
     <oval-def:criterion comment="the version of rdpwd.sys is less than 5.1.2600.1698" test_ref="oval:org.mitre.oval:tst:3742" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/objects/windows/registry_object/2000/oval_org.mitre.oval_obj_2113.xml
+++ b/repository/objects/windows/registry_object/2000/oval_org.mitre.oval_obj_2113.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2113" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2113" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SYSTEM\CurrentControlSet\Control\Session Manager\Environment</key>
   <name>PROCESSOR_ARCHITECTURE</name>

--- a/repository/states/windows/registry_state/3000/oval_org.mitre.oval_ste_3485.xml
+++ b/repository/states/windows/registry_state/3000/oval_org.mitre.oval_ste_3485.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:3485" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:3485" deprecated="true" version="1">
   <value>ia64</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3257.xml
+++ b/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3257.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="64-Bit (ia64 architecture) version of Windows is installed" id="oval:org.mitre.oval:tst:3257" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="64-Bit (ia64 architecture) version of Windows is installed" id="oval:org.mitre.oval:tst:3257" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:2113" />
   <state state_ref="oval:org.mitre.oval:ste:3485" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:tst:3257](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:3257) and [oval:org.mitre.oval:tst:2747](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2747) are duplicates. oval:org.mitre.oval:tst:2747 is most useful and correct. The definitions that used  [oval:org.mitre.oval:tst:3257](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:3257) were modified. [oval:org.mitre.oval:tst:3257](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:3257), [oval:org.mitre.oval:obj:2113](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:2113) and [oval:org.mitre.oval:ste:3485](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:3485) should be deprecated.