### PR TITLE
Kemanik duplicate obj 24244

### DIFF
--- a/repository/objects/windows/registry_object/24000/oval_org.mitre.oval_obj_24244.xml
+++ b/repository/objects/windows/registry_object/24000/oval_org.mitre.oval_obj_24244.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry key that identifies the location of the common files (x86) directory" id="oval:org.mitre.oval:obj:24244" version="2">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry key that identifies the location of the common files (x86) directory" id="oval:org.mitre.oval:obj:24244" deprecated="true" version="2">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion</key>

--- a/repository/objects/windows/registry_object/41000/oval_org.mitre.oval_obj_41921.xml
+++ b/repository/objects/windows/registry_object/41000/oval_org.mitre.oval_obj_41921.xml
@@ -1,6 +1,6 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The registry key that identifies the location of the common files directory" id="oval:org.mitre.oval:obj:41921" version="1">
   <oval-def:set>
     <oval-def:object_reference>oval:org.mitre.oval:obj:281</oval-def:object_reference>
-    <oval-def:object_reference>oval:org.mitre.oval:obj:24244</oval-def:object_reference>
+    <oval-def:object_reference>oval:org.mitre.oval:obj:7442</oval-def:object_reference>
   </oval-def:set>
 </registry_object>

--- a/repository/variables/oval_org.mitre.oval_var_1634.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1634.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The shared Office 2010 directory (32-bit view)" datatype="string" id="oval:org.mitre.oval:var:1634" version="2">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:24244" />
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:7442" />
     <oval-def:literal_component>\Microsoft Shared\OFFICE14</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:24244](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24244) and [oval:org.mitre.oval:obj:7442](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7442) are duplicates.  [oval:org.mitre.oval:obj:7442](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7442) is most useful. Then [oval:org.mitre.oval:obj:24244](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24244) should be deprecated.