### PR TITLE
Kemanik duplicate obj 15401

### DIFF
--- a/repository/objects/windows/file_object/15000/oval_org.mitre.oval_obj_15680.xml
+++ b/repository/objects/windows/file_object/15000/oval_org.mitre.oval_obj_15680.xml
@@ -1,3 +1,3 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the full path to Winamp.exe (From CLASS_ROOT)" id="oval:org.mitre.oval:obj:15680" version="3">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the full path to Winamp.exe (From CLASS_ROOT)" id="oval:org.mitre.oval:obj:15680" deprecated="true" version="3">
   <filepath var_check="all" var_ref="oval:org.mitre.oval:var:1646" />
 </file_object>

--- a/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23901.xml
+++ b/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23901.xml
@@ -1,6 +1,6 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Winamp.exe (multiple potential locations)" id="oval:org.mitre.oval:obj:23901" version="2">
   <oval-def:set>
-    <oval-def:object_reference>oval:org.mitre.oval:obj:15680</oval-def:object_reference>
+    <oval-def:object_reference>oval:org.mitre.oval:obj:7573</oval-def:object_reference>
     <oval-def:object_reference>oval:org.mitre.oval:obj:6982</oval-def:object_reference>
   </oval-def:set>
 </file_object>

--- a/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15401.xml
+++ b/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15401.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the UninstallString of Winamp" id="oval:org.mitre.oval:obj:15401" version="3">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the UninstallString of Winamp" id="oval:org.mitre.oval:obj:15401" deprecated="true" version="3">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Winamp</key>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41880.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41880.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Winamp version is less than 5.5.9.3033" id="oval:org.mitre.oval:tst:41880" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:15680" />
+  <object object_ref="oval:org.mitre.oval:obj:7573" />
   <state state_ref="oval:org.mitre.oval:ste:11678" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42231.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42231.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Winamp version is less than 5.6.0.3091" id="oval:org.mitre.oval:tst:42231" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:15680" />
+  <object object_ref="oval:org.mitre.oval:obj:7573" />
   <state state_ref="oval:org.mitre.oval:ste:12130" />
 </file_test>

--- a/repository/variables/oval_org.mitre.oval_var_1646.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1646.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Full path to winamp.exe" datatype="string" id="oval:org.mitre.oval:var:1646" version="3">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Full path to winamp.exe" datatype="string" id="oval:org.mitre.oval:var:1646" deprecated="true" version="3">
   <oval-def:concat>
     <oval-def:regex_capture pattern="^\&quot;(.*)Unins.*\&quot;$">
       <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:15401" />

--- a/repository/variables/oval_org.mitre.oval_var_1827.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1827.xml
@@ -1,7 +1,7 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Path to Winamp system directory" datatype="string" id="oval:org.mitre.oval:var:1827" version="2">
   <oval-def:concat>
     <oval-def:regex_capture pattern="^\&quot;(.*)Unins.*\&quot;$">
-      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:15401" />
+      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:7560" />
     </oval-def:regex_capture>
     <oval-def:literal_component>System</oval-def:literal_component>
   </oval-def:concat>

--- a/repository/variables/oval_org.mitre.oval_var_1907.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1907.xml
@@ -1,7 +1,7 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Path to Winamp plugins directory" datatype="string" id="oval:org.mitre.oval:var:1907" version="3">
   <oval-def:concat>
     <oval-def:regex_capture pattern="^\&quot;(.*)Unins.*\&quot;$">
-      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:15401" />
+      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:7560" />
     </oval-def:regex_capture>
     <oval-def:literal_component>Plugins</oval-def:literal_component>
   </oval-def:concat>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:7573](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7573) and [oval:org.mitre.oval:obj:15680](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15680) are duplicates. Both of them find full path to winamp.exe. [oval:org.mitre.oval:obj:7573](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7573) was chosen as basic because it is more useful. [oval:org.mitre.oval:obj:15401](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15401) and [oval:org.mitre.oval:obj:7560](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7560) are duplicates.   [oval:org.mitre.oval:obj:7560](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7560) was chosen as basic because it is used in [oval:org.mitre.oval:obj:7573](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7573). [oval:org.mitre.oval:obj:15680](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15680), [oval:org.mitre.oval:var:1646](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1646) and [oval:org.mitre.oval:obj:15401](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15401) should be deprecated because they are replaced with it's duplicates in this commit.