### PR TITLE
Kemanik duplicate obj 24352

### DIFF
--- a/repository/objects/windows/registry_object/24000/oval_org.mitre.oval_obj_24352.xml
+++ b/repository/objects/windows/registry_object/24000/oval_org.mitre.oval_obj_24352.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Oracle WebLogic Server is installed" id="oval:org.mitre.oval:obj:24352" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Oracle WebLogic Server is installed" id="oval:org.mitre.oval:obj:24352" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Oracle WebLogic</key>
   <name>DisplayIcon</name>

--- a/repository/tests/windows/registry_test/81000/oval_org.mitre.oval_tst_81220.xml
+++ b/repository/tests/windows/registry_test/81000/oval_org.mitre.oval_tst_81220.xml
@@ -1,3 +1,3 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Oracle WebLogic Server is installed" id="oval:org.mitre.oval:tst:81220" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:24352" />
+  <object object_ref="oval:org.mitre.oval:obj:24310" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:24310](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24310) and [oval:org.mitre.oval:obj:24352](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24352) are duplicates. The object [oval:org.mitre.oval:obj:24310](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24310) was chosen as a basic because it used in a larger number of definitions. [oval:org.mitre.oval:obj:24352](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24352) was replaced with it's duplicate and should be deprecated.