### PR TITLE
Kemanik duplicate obj 26037

### DIFF
--- a/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26037.xml
+++ b/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26037.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object that holds the install location of SharePoint Server 2013" id="oval:org.mitre.oval:obj:26037" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object that holds the install location of SharePoint Server 2013" id="oval:org.mitre.oval:obj:26037" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Office15.OSERVER</key>
   <name>InstallLocation</name>

--- a/repository/variables/oval_org.mitre.oval_var_1658.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1658.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the bin directory of Excel Services in SharePoint Server 2013" datatype="string" id="oval:org.mitre.oval:var:1658" version="1">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:26037" />
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:26495" />
     <oval-def:literal_component>\15.0\bin</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>

--- a/repository/variables/oval_org.mitre.oval_var_1902.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1902.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to VisioGraphicsServer\bin" datatype="string" id="oval:org.mitre.oval:var:1902" version="1">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:26037" />
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:26495" />
     <oval-def:literal_component>\15.0\WebServices\Shared\VisioGraphicsServer\Bin</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:26037](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26037) and [oval:org.mitre.oval:obj:26495](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26495) are duplicates. [oval:org.mitre.oval:obj:26495](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26495) is taken as basic because it more used. The object [oval:org.mitre.oval:obj:26495](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26495) should be deprecated because it was replaced with it's duplicate.