### PR TITLE
Kemanik duplicates obj 26037

### DIFF
--- a/repository/objects/windows/file_object/26000/oval_org.mitre.oval_obj_26773.xml
+++ b/repository/objects/windows/file_object/26000/oval_org.mitre.oval_obj_26773.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of xlsrv.dll in Microsoft Office 2013 Excel Services" id="oval:org.mitre.oval:obj:26773" version="1">
-  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1658" />
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1682" />
   <filename>xlsrv.dll</filename>
 </file_object>

--- a/repository/objects/windows/file_object/29000/oval_org.mitre.oval_obj_29038.xml
+++ b/repository/objects/windows/file_object/29000/oval_org.mitre.oval_obj_29038.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of ascalc.dll in Microsoft Office 2013" id="oval:org.mitre.oval:obj:29038" version="1">
-  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1658" />
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1682" />
   <filename>ascalc.dll</filename>
 </file_object>

--- a/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26037.xml
+++ b/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26037.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object that holds the install location of SharePoint Server 2013" id="oval:org.mitre.oval:obj:26037" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object that holds the install location of SharePoint Server 2013" id="oval:org.mitre.oval:obj:26037" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Office15.OSERVER</key>
   <name>InstallLocation</name>

--- a/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26495.xml
+++ b/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26495.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds the install location of sharepoint server 2010" id="oval:org.mitre.oval:obj:26495" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds the install location of sharepoint server 2013" id="oval:org.mitre.oval:obj:26495" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Office15.OSERVER</key>
   <name>InstallLocation</name>

--- a/repository/variables/oval_org.mitre.oval_var_1658.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1658.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the bin directory of Excel Services in SharePoint Server 2013" datatype="string" id="oval:org.mitre.oval:var:1658" version="1">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the bin directory of Excel Services in SharePoint Server 2013" datatype="string" id="oval:org.mitre.oval:var:1658" deprecated="true" version="1">
   <oval-def:concat>
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:26037" />
     <oval-def:literal_component>\15.0\bin</oval-def:literal_component>

--- a/repository/variables/oval_org.mitre.oval_var_1902.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1902.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to VisioGraphicsServer\bin" datatype="string" id="oval:org.mitre.oval:var:1902" version="1">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:26037" />
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:26495" />
     <oval-def:literal_component>\15.0\WebServices\Shared\VisioGraphicsServer\Bin</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:26495](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26495) and [oval:org.mitre.oval:obj:26037](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26037) are duplicates.The object [oval:org.mitre.oval:obj:26495](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26495) was chosen as a basic because it used in a larger number of definitions. [oval:org.mitre.oval:var:1658](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1658) and [oval:org.mitre.oval:var:1682](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1682) are duplicates.The object [oval:org.mitre.oval:var:1682](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1682) was chosen as a basic because it uses [oval:org.mitre.oval:obj:26495](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26495). [oval:org.mitre.oval:obj:26037](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26037) and [oval:org.mitre.oval:var:1658](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1658) should be deprecated because they were replaced with their duplicates.