### PR TITLE
Kemanik duplicate obj 39236 obj 23950

### DIFF
--- a/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23683.xml
+++ b/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23683.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of Msoserver.Dll(Web Apps)" id="oval:org.mitre.oval:obj:23683" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of Msoserver.Dll(Web Apps)" id="oval:org.mitre.oval:obj:23683" deprecated="true" version="1">
   <path var_ref="oval:org.mitre.oval:var:1263" />
   <filename>Msoserver.Dll</filename>
 </file_object>

--- a/repository/objects/windows/file_object/39000/oval_org.mitre.oval_obj_39210.xml
+++ b/repository/objects/windows/file_object/39000/oval_org.mitre.oval_obj_39210.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the path to SWORD.DLL" id="oval:org.mitre.oval:obj:39210" version="1">
-  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1938" />
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1458" />
   <filename>SWORD.DLL</filename>
 </file_object>

--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23950.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23950.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the installation path for web apps 2010" id="oval:org.mitre.oval:obj:23950" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the installation path for web apps 2010" id="oval:org.mitre.oval:obj:23950" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Office14.WCSERVER</key>
   <name>InstallLocation</name>

--- a/repository/objects/windows/registry_object/39000/oval_org.mitre.oval_obj_39236.xml
+++ b/repository/objects/windows/registry_object/39000/oval_org.mitre.oval_obj_39236.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds the install location of sharepoint server 2010" id="oval:org.mitre.oval:obj:39236" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds the install location of sharepoint server 2010" id="oval:org.mitre.oval:obj:39236" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Office14.WCSERVER</key>
   <name>InstallLocation</name>

--- a/repository/tests/windows/file_test/125000/oval_org.mitre.oval_tst_125052.xml
+++ b/repository/tests/windows/file_test/125000/oval_org.mitre.oval_tst_125052.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 14.0.7134.5000" id="oval:org.mitre.oval:tst:125052" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23683" />
+  <object object_ref="oval:org.mitre.oval:obj:23967" />
   <state state_ref="oval:org.mitre.oval:ste:34041" />
 </file_test>

--- a/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135610.xml
+++ b/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135610.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 14.0.7140.5000" id="oval:org.mitre.oval:tst:135610" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23683" />
+  <object object_ref="oval:org.mitre.oval:obj:23967" />
   <state state_ref="oval:org.mitre.oval:ste:37210" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137137.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137137.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 14.0.7143.5000" id="oval:org.mitre.oval:tst:137137" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23683" />
+  <object object_ref="oval:org.mitre.oval:obj:23967" />
   <state state_ref="oval:org.mitre.oval:ste:38286" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137599.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137599.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 14.0.7145.5000" id="oval:org.mitre.oval:tst:137599" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23683" />
+  <object object_ref="oval:org.mitre.oval:obj:23967" />
   <state state_ref="oval:org.mitre.oval:ste:38439" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79981.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79981.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Msoserver.Dll is less than 14.0.6123.5001" id="oval:org.mitre.oval:tst:79981" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23683" />
+  <object object_ref="oval:org.mitre.oval:obj:23967" />
   <state state_ref="oval:org.mitre.oval:ste:19510" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80474.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80474.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 14.0.6129.5000 (web apps)" id="oval:org.mitre.oval:tst:80474" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23683" />
+  <object object_ref="oval:org.mitre.oval:obj:23967" />
   <state state_ref="oval:org.mitre.oval:ste:20008" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86842.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86842.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 14.0.7108.5000" id="oval:org.mitre.oval:tst:86842" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23683" />
+  <object object_ref="oval:org.mitre.oval:obj:23967" />
   <state state_ref="oval:org.mitre.oval:ste:24343" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87179.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87179.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 14.0.7106.5000" id="oval:org.mitre.oval:tst:87179" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23683" />
+  <object object_ref="oval:org.mitre.oval:obj:23967" />
   <state state_ref="oval:org.mitre.oval:ste:24088" />
 </file_test>

--- a/repository/variables/oval_org.mitre.oval_var_1263.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1263.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to Converter Directory in Web Apps 2010" datatype="string" id="oval:org.mitre.oval:var:1263" version="1">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to Converter Directory in Web Apps 2010" datatype="string" id="oval:org.mitre.oval:var:1263" deprecated="true" version="1">
   <oval-def:concat>
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23950" />
     <oval-def:literal_component>\14.0\WebServices\ConversionService\Bin\Converter</oval-def:literal_component>

--- a/repository/variables/oval_org.mitre.oval_var_1938.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1938.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Full path to WordServer\Core" datatype="string" id="oval:org.mitre.oval:var:1938" version="1">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Full path to WordServer\Core" datatype="string" id="oval:org.mitre.oval:var:1938" deprecated="true" version="1">
   <oval-def:concat>
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:39236" />
     <oval-def:literal_component>\14.0\WebServices\ConversionService\Bin\Converter</oval-def:literal_component>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:39236](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:39236), [oval:org.mitre.oval:obj:23950](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23950) and [oval:org.mitre.oval:obj:23503](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23503) are duplicates. [oval:org.mitre.oval:obj:23503](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23503) is a basic object because it used in larger number of variables.

[oval:org.mitre.oval:var:1938](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1938), [oval:org.mitre.oval:var:1263](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1263) and  [oval:org.mitre.oval:var:1458](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1458) are duplicates. [oval:org.mitre.oval:var:1458](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1458) is a basic variable because it uses [oval:org.mitre.oval:obj:23503](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23503).

[oval:org.mitre.oval:obj:23683](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23683) and [oval:org.mitre.oval:obj:23967](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23967) are duplicates.  [oval:org.mitre.oval:obj:23967](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23967) is a basic object because it uses [oval:org.mitre.oval:var:1458](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1458).

The other objects and variables should be deprecated.