### PR TITLE
Kemanik duplicate obj 23918

### DIFF
--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23918.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23918.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Edition of Microsoft Windows" id="oval:org.mitre.oval:obj:23918" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Edition of Microsoft Windows" id="oval:org.mitre.oval:obj:23918" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
   <name>EditionID</name>

--- a/repository/tests/windows/registry_test/80000/oval_org.mitre.oval_tst_80158.xml
+++ b/repository/tests/windows/registry_test/80000/oval_org.mitre.oval_tst_80158.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if edition of Microsoft Windows 7 is Home Premium" id="oval:org.mitre.oval:tst:80158" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23918" />
+  <object object_ref="oval:org.mitre.oval:obj:24057" />
   <state state_ref="oval:org.mitre.oval:ste:19193" />
 </registry_test>

--- a/repository/tests/windows/registry_test/80000/oval_org.mitre.oval_tst_80159.xml
+++ b/repository/tests/windows/registry_test/80000/oval_org.mitre.oval_tst_80159.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if edition of Microsoft Windows 7 is Starter" id="oval:org.mitre.oval:tst:80159" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23918" />
+  <object object_ref="oval:org.mitre.oval:obj:24057" />
   <state state_ref="oval:org.mitre.oval:ste:19419" />
 </registry_test>

--- a/repository/tests/windows/registry_test/80000/oval_org.mitre.oval_tst_80265.xml
+++ b/repository/tests/windows/registry_test/80000/oval_org.mitre.oval_tst_80265.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if edition of Microsoft Windows 7 is Home Basic" id="oval:org.mitre.oval:tst:80265" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23918" />
+  <object object_ref="oval:org.mitre.oval:obj:24057" />
   <state state_ref="oval:org.mitre.oval:ste:19931" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:24057](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24057) and [oval:org.mitre.oval:obj:23918](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23918) are duplicates. [oval:org.mitre.oval:obj:24057](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24057) is taken as basic because it used in a larger number of tests. The object [oval:org.mitre.oval:obj:23918](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23918) should be deprecated to avoid reusing.