### PR TITLE
Kemanik duplicate obj 123

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_229.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_229.xml
@@ -47,9 +47,9 @@
       <oval-def:min_schema_version>5.4</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
+  <oval-def:criteria>
     <oval-def:criterion comment="the installed operating system is part of the Microsoft Windows family" test_ref="oval:org.mitre.oval:tst:99" />
-    <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:2" />
+    <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3085" />
     <oval-def:criterion comment="SP4 or later Installed" test_ref="oval:org.mitre.oval:tst:3073" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_85.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_85.xml
@@ -32,8 +32,8 @@
       <oval-def:min_schema_version>5.4</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
+  <oval-def:criteria>
     <oval-def:criterion comment="the installed operating system is part of the Microsoft Windows family" test_ref="oval:org.mitre.oval:tst:99" />
-    <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:2" />
+    <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3085" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_160.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_160.xml
@@ -30,8 +30,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:4033" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:2761" />
     <oval-def:criterion comment="Win2K/XP/2003 service pack 1 is installed" test_ref="oval:org.mitre.oval:tst:3342" />
     <oval-def:criterion comment="the version of umpnpmgr.dll is less than 5.2.3790.2477" test_ref="oval:org.mitre.oval:tst:3535" />
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_180.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_180.xml
@@ -35,9 +35,9 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
+  <oval-def:criteria>
     <oval-def:criteria comment="Windows 2000 Service Pack 4 (or later) is installed" operator="AND">
-      <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3381" />
+      <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3085" />
       <oval-def:criterion comment="SP4 or later Installed" test_ref="oval:org.mitre.oval:tst:3073" />
     </oval-def:criteria>
     <oval-def:criterion comment="the version of rdpwd.sys is less than 5.0.2195.7055" test_ref="oval:org.mitre.oval:tst:3633" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_256.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_256.xml
@@ -40,8 +40,8 @@
       <oval-def:min_schema_version>5.4</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:3750" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:2838" />
     <oval-def:criterion comment="Win2K/XP/2003/Vista/2008 service pack 2 is installed" test_ref="oval:org.mitre.oval:tst:3019" />
     <oval-def:criterion comment="the version of spoolsv.exe is less than 5.1.2600.2696" test_ref="oval:org.mitre.oval:tst:3950" />
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_267.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_267.xml
@@ -30,8 +30,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:3750" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:2838" />
     <oval-def:criterion comment="Win2K/XP/2003 service pack 1 is installed" test_ref="oval:org.mitre.oval:tst:3342" />
     <oval-def:criterion comment="64-Bit (ia64 architecture) version of Windows is installed" negate="true" test_ref="oval:org.mitre.oval:tst:3257" />
     <oval-def:criterion comment="the version of umpnpmgr.dll is less than 5.1.2600.1711" test_ref="oval:org.mitre.oval:tst:3367" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_346.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_346.xml
@@ -30,8 +30,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:4033" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:2761" />
     <oval-def:criterion comment="Win2K/XP/2003 service pack 1 is installed" test_ref="oval:org.mitre.oval:tst:3342" />
     <oval-def:criterion comment="the version of rdpwd.sys is less than 5.2.3790.2465" test_ref="oval:org.mitre.oval:tst:3760" />
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_376.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_376.xml
@@ -40,8 +40,8 @@
       <oval-def:min_schema_version>5.4</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:3750" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:2838" />
     <oval-def:criterion comment="Win2K/XP/2003/Vista/2008 service pack 2 is installed" test_ref="oval:org.mitre.oval:tst:3019" />
     <oval-def:criterion comment="the version of rdpwd.sys is less than 5.1.2600.2695" test_ref="oval:org.mitre.oval:tst:3639" />
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_474.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_474.xml
@@ -24,8 +24,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3381" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3085" />
     <oval-def:criterion comment="the version of umpnpmgr.dll is less than 5.0.2195.7057" test_ref="oval:org.mitre.oval:tst:3723" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_497.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_497.xml
@@ -40,8 +40,8 @@
       <oval-def:min_schema_version>5.4</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:3750" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:2838" />
     <oval-def:criterion comment="Win2K/XP/2003/Vista/2008 service pack 2 is installed" test_ref="oval:org.mitre.oval:tst:3019" />
     <oval-def:criterion comment="64-Bit (ia64 architecture) version of Windows is installed" negate="true" test_ref="oval:org.mitre.oval:tst:3257" />
     <oval-def:criterion comment="the version of umpnpmgr.dll is less than 5.1.2600.2710" test_ref="oval:org.mitre.oval:tst:3964" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_609.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_609.xml
@@ -35,8 +35,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:4033" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:2761" />
     <oval-def:criterion comment="Win2K/XP/2003 is patched" negate="true" test_ref="oval:org.mitre.oval:tst:3429" />
     <oval-def:criterion comment="the version of rdpwd.sys is less than 5.2.3790.348" test_ref="oval:org.mitre.oval:tst:3978" />
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_618.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_618.xml
@@ -30,8 +30,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:3750" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:2838" />
     <oval-def:criterion comment="Win2K/XP/2003 service pack 1 is installed" test_ref="oval:org.mitre.oval:tst:3342" />
     <oval-def:criterion comment="64-Bit (ia64 architecture) version of Windows is installed" negate="true" test_ref="oval:org.mitre.oval:tst:3257" />
     <oval-def:criterion comment="the version of rdpwd.sys is less than 5.1.2600.1698" test_ref="oval:org.mitre.oval:tst:3742" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_783.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_783.xml
@@ -35,8 +35,8 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:4033" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:2761" />
     <oval-def:criterion comment="Win2K/XP/2003 is patched" negate="true" test_ref="oval:org.mitre.oval:tst:3429" />
     <oval-def:criterion comment="the version of umpnpmgr.dll is less than 5.2.3790.360" test_ref="oval:org.mitre.oval:tst:3457" />
   </oval-def:criteria>

--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_123.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_123.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Registry key that hold the current windows os version" id="oval:org.mitre.oval:obj:123" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Registry key that hold the current windows os version" id="oval:org.mitre.oval:obj:123" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
   <name>CurrentVersion</name>

--- a/repository/states/windows/registry_state/0000/oval_org.cisecurity_ste_2.xml
+++ b/repository/states/windows/registry_state/0000/oval_org.cisecurity_ste_2.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if component of Office 2013 is installed" id="oval:org.cisecurity:ste:2" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if component of Office 2013 is installed" id="oval:org.cisecurity:ste:2" deprecated="true" version="1">
   <value operation="pattern match">^.*\\Office15.*$</value>
 </registry_state>

--- a/repository/states/windows/registry_state/3000/oval_org.mitre.oval_ste_3066.xml
+++ b/repository/states/windows/registry_state/3000/oval_org.mitre.oval_ste_3066.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:3066" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:3066" deprecated="true" version="1">
   <value>5.1</value>
 </registry_state>

--- a/repository/states/windows/registry_state/3000/oval_org.mitre.oval_ste_3492.xml
+++ b/repository/states/windows/registry_state/3000/oval_org.mitre.oval_ste_3492.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:3492" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:3492" deprecated="true" version="1">
   <value>5.0</value>
 </registry_state>

--- a/repository/states/windows/registry_state/3000/oval_org.mitre.oval_ste_3591.xml
+++ b/repository/states/windows/registry_state/3000/oval_org.mitre.oval_ste_3591.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:3591" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:3591" deprecated="true" version="1">
   <value>5.2</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_2.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_2.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows 2000 is installed" id="oval:org.mitre.oval:tst:2" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows 2000 is installed" id="oval:org.mitre.oval:tst:2" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:123" />
   <state state_ref="oval:org.mitre.oval:ste:2" />
 </registry_test>

--- a/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_488.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_488.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows XP or Windows Server 2003 is installed" id="oval:org.mitre.oval:tst:488" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:123" />
+  <object object_ref="oval:org.mitre.oval:obj:419" />
   <state state_ref="oval:org.mitre.oval:ste:450" />
 </registry_test>

--- a/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3089.xml
+++ b/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3089.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows NT 4.0 is installed" id="oval:org.mitre.oval:tst:3089" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:123" />
+  <object object_ref="oval:org.mitre.oval:obj:419" />
   <state state_ref="oval:org.mitre.oval:ste:2894" />
 </registry_test>

--- a/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3381.xml
+++ b/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3381.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows 2000 is installed" id="oval:org.mitre.oval:tst:3381" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows 2000 is installed" id="oval:org.mitre.oval:tst:3381" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:123" />
   <state state_ref="oval:org.mitre.oval:ste:3492" />
 </registry_test>

--- a/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3750.xml
+++ b/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3750.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows XP is installed" id="oval:org.mitre.oval:tst:3750" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows XP is installed" id="oval:org.mitre.oval:tst:3750" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:123" />
   <state state_ref="oval:org.mitre.oval:ste:3066" />
 </registry_test>

--- a/repository/tests/windows/registry_test/4000/oval_org.mitre.oval_tst_4033.xml
+++ b/repository/tests/windows/registry_test/4000/oval_org.mitre.oval_tst_4033.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows Server 2003 is installed" id="oval:org.mitre.oval:tst:4033" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows Server 2003 is installed" id="oval:org.mitre.oval:tst:4033" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:123" />
   <state state_ref="oval:org.mitre.oval:ste:3591" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:tst:3085](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:3085), [oval:org.mitre.oval:tst:3381](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:3381) and [oval:org.mitre.oval:tst:2](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2) are duplicates. [oval:org.mitre.oval:tst:3085](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:3085) was taken as a basic.

[oval:org.mitre.oval:tst:4033](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:4033) and [oval:org.mitre.oval:tst:2761](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2761) are duplicates. [oval:org.mitre.oval:tst:2761](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2761) was taken as a basic.

[oval:org.mitre.oval:tst:3750](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:3750) and [oval:org.mitre.oval:tst:2838](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2838) are duplicates. [oval:org.mitre.oval:tst:2838](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2838) was taken as a basic.

[oval:org.mitre.oval:obj:123](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:123) and [oval:org.mitre.oval:obj:419](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:419) are duplicates. [oval:org.mitre.oval:obj:419] (https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:419) was taken as a basic.

The other tests should be deprecated.