### PR TITLE
kemanik-duplicates-tst-2758

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_4392.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_4392.xml
@@ -22,17 +22,16 @@
         <oval-def:status_change date="2007-11-13T12:01:15.748-05:00">ACCEPTED</oval-def:status_change>
       </oval-def:dates>
       <oval-def:status>ACCEPTED</oval-def:status>
-      <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria operator="AND">
     <oval-def:criteria comment="Software section" operator="AND">
-      <oval-def:criterion comment="Windows Server 2003 is installed" negate="false" test_ref="oval:org.mitre.oval:tst:2761" />
-      <oval-def:criterion comment="the version of nntpsvc.dll is less than 6.0.3790.206" negate="false" test_ref="oval:org.mitre.oval:tst:2759" />
-      <oval-def:criterion comment="the patch WindowsServer2003-KB883935-x86-enu.exe is installed" negate="true" test_ref="oval:org.mitre.oval:tst:326" />
+      <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:2761" />
+      <oval-def:criterion comment="the version of nntpsvc.dll is less than 6.0.3790.206" test_ref="oval:org.mitre.oval:tst:2759" />
+      <oval-def:criterion comment="KB883935 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2758" />
     </oval-def:criteria>
     <oval-def:criteria comment="Configuration section" operator="AND">
-      <oval-def:criterion comment="the NNTP service is enabled" negate="false" test_ref="oval:org.mitre.oval:tst:2757" />
+      <oval-def:criterion comment="the NNTP service is enabled" test_ref="oval:org.mitre.oval:tst:2757" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_5070.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_5070.xml
@@ -22,14 +22,13 @@
         <oval-def:status_change date="2008-03-24T04:00:39.118-04:00">ACCEPTED</oval-def:status_change>
       </oval-def:dates>
       <oval-def:status>ACCEPTED</oval-def:status>
-      <oval-def:min_schema_version>5.4</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria operator="AND">
     <oval-def:criteria comment="Software section" operator="AND">
       <oval-def:extend_definition comment="Microsoft Windows NT is installed" definition_ref="oval:org.mitre.oval:def:36" />
       <oval-def:criterion comment="the version of nntpsvc.dll is less than 5.5.1877.79" test_ref="oval:org.mitre.oval:tst:284" />
-      <oval-def:criterion comment="Patch WindowsNT4OptionPack-KB883935-x86-enu.EXE" negate="true" test_ref="oval:org.mitre.oval:tst:283" />
+      <oval-def:criterion comment="KB883935 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2758" />
     </oval-def:criteria>
     <oval-def:criteria comment="Configuration section" operator="AND">
       <oval-def:criterion comment="the NNTP service is enabled" test_ref="oval:org.mitre.oval:tst:2757" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_5926.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_5926.xml
@@ -35,24 +35,23 @@
         <oval-def:status_change date="2011-05-16T04:03:14.450-04:00">ACCEPTED</oval-def:status_change>
       </oval-def:dates>
       <oval-def:status>ACCEPTED</oval-def:status>
-      <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria operator="AND">
     <oval-def:criteria comment="Software section" operator="AND">
       <oval-def:criteria comment="Windows 2000 Server is installed" operator="AND">
-        <oval-def:criterion comment="Windows 2000 is installed" negate="false" test_ref="oval:org.mitre.oval:tst:3085" />
+        <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3085" />
         <oval-def:criteria comment="Windows NT server product option" operator="OR">
-          <oval-def:criterion comment="this is an NT Server (stand-alone)" negate="false" test_ref="oval:org.mitre.oval:tst:2408" />
-          <oval-def:criterion comment="this is an NT Server (domain controller)" negate="false" test_ref="oval:org.mitre.oval:tst:3035" />
+          <oval-def:criterion comment="this is an NT Server (stand-alone)" test_ref="oval:org.mitre.oval:tst:2408" />
+          <oval-def:criterion comment="this is an NT Server (domain controller)" test_ref="oval:org.mitre.oval:tst:3035" />
         </oval-def:criteria>
       </oval-def:criteria>
-      <oval-def:criterion comment="Win2K/XP/2003 service pack 3 (or later) is installed" negate="false" test_ref="oval:org.mitre.oval:tst:3079" />
-      <oval-def:criterion comment="the version of nntpsvc.dll is less than 5.0.2195.6972" negate="false" test_ref="oval:org.mitre.oval:tst:274" />
-      <oval-def:criterion comment="Patch Windows2000-KB883935-x86-ENU.exe Installed" negate="true" test_ref="oval:org.mitre.oval:tst:273" />
+      <oval-def:criterion comment="Win2K/XP/2003 service pack 3 (or later) is installed" test_ref="oval:org.mitre.oval:tst:3079" />
+      <oval-def:criterion comment="the version of nntpsvc.dll is less than 5.0.2195.6972" test_ref="oval:org.mitre.oval:tst:274" />
+      <oval-def:criterion comment="KB883935 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2758" />
     </oval-def:criteria>
     <oval-def:criteria comment="Configuration section" operator="AND">
-      <oval-def:criterion comment="the NNTP service is enabled" negate="false" test_ref="oval:org.mitre.oval:tst:2757" />
+      <oval-def:criterion comment="the NNTP service is enabled" test_ref="oval:org.mitre.oval:tst:2757" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_251.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_251.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:251" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" deprecated="true" id="oval:org.mitre.oval:obj:251" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion\HotFix\KB883935</key>
   <name>Installed</name>

--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_297.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_297.xml
@@ -1,5 +1,5 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:297" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
-  <key operation="equals">SOFTWARE\Microsoft\Windows NT\CurrentVersion\Hotfix\KB883935</key>
-  <name operation="equals">Installed</name>
+  <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion\Hotfix\KB883935</key>
+  <name>Installed</name>
 </registry_object>

--- a/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_271.xml
+++ b/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_271.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:271" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" deprecated="true" id="oval:org.mitre.oval:ste:271" version="1">
   <value datatype="int">1</value>
 </registry_state>

--- a/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_280.xml
+++ b/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_280.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:280" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" deprecated="true" id="oval:org.mitre.oval:ste:280" version="1">
   <value datatype="int">1</value>
 </registry_state>

--- a/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_317.xml
+++ b/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_317.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:317" version="2">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" deprecated="true" id="oval:org.mitre.oval:ste:317" version="2">
   <value datatype="int">1</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_273.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_273.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch Windows2000-KB883935-x86-ENU.exe Installed" id="oval:org.mitre.oval:tst:273" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch Windows2000-KB883935-x86-ENU.exe Installed" deprecated="true" id="oval:org.mitre.oval:tst:273" version="1">
   <object object_ref="oval:org.mitre.oval:obj:251" />
   <state state_ref="oval:org.mitre.oval:ste:271" />
 </registry_test>

--- a/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_283.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_283.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch WindowsNT4OptionPack-KB883935-x86-enu.EXE" id="oval:org.mitre.oval:tst:283" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch WindowsNT4OptionPack-KB883935-x86-enu.EXE" deprecated="true" id="oval:org.mitre.oval:tst:283" version="1">
   <object object_ref="oval:org.mitre.oval:obj:251" />
   <state state_ref="oval:org.mitre.oval:ste:280" />
 </registry_test>

--- a/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_326.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_326.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the patch WindowsServer2003-KB883935-x86-enu.exe is installed" id="oval:org.mitre.oval:tst:326" version="2">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the patch WindowsServer2003-KB883935-x86-enu.exe is installed" deprecated="true" id="oval:org.mitre.oval:tst:326" version="2">
   <object object_ref="oval:org.mitre.oval:obj:297" />
   <state state_ref="oval:org.mitre.oval:ste:317" />
 </registry_test>

--- a/repository/tests/windows/registry_test/2000/oval_org.mitre.oval_tst_2758.xml
+++ b/repository/tests/windows/registry_test/2000/oval_org.mitre.oval_tst_2758.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the patch WindowsServer2003-KB883935-ia64-enu.exe is installed" id="oval:org.mitre.oval:tst:2758" version="2">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="KB883935 is installed" id="oval:org.mitre.oval:tst:2758" version="2">
   <object object_ref="oval:org.mitre.oval:obj:297" />
   <state state_ref="oval:org.mitre.oval:ste:2579" />
 </registry_test>


### PR DESCRIPTION
[This tests](https://ovaldb.altx-soft.ru/OvalItems.aspx?comment=KB883935&elementtype=test) are duplicates. The test [oval:org.mitre.oval:tst:2758](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2758) was taken as a basic. Other should be deprecated. In definitions negate="false" was removed as unnecessary.