### PR TITLE
Kemanik duplicate tst 597

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
@@ -23,28 +23,28 @@
     <oval-def:criterion comment="Windows 2000 is installed" negate="false" test_ref="oval:org.mitre.oval:tst:3085" />
     <oval-def:criteria comment="Vulnerable versions of DirectX" operator="OR">
       <oval-def:criteria comment="Unpatched DirectX 7.0" operator="AND">
-        <oval-def:criterion comment="DirectX 7.0x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1296" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2195.6927" negate="false" test_ref="oval:org.mitre.oval:tst:1295" />
-        <oval-def:criterion comment="Patch Windows2000-KB839643-x86-ENU.EXE Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1294" />
+        <oval-def:criterion comment="DirectX 7.0x Installed" test_ref="oval:org.mitre.oval:tst:1296" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2195.6927" test_ref="oval:org.mitre.oval:tst:1295" />
+        <oval-def:criterion comment="the patch kb839643 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:597" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 8.0x" operator="AND">
-        <oval-def:criterion comment="DirectX 8.0x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1293" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2258.410" negate="false" test_ref="oval:org.mitre.oval:tst:1292" />
+        <oval-def:criterion comment="DirectX 8.0x Installed" test_ref="oval:org.mitre.oval:tst:1293" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2258.410" test_ref="oval:org.mitre.oval:tst:1292" />
         <oval-def:criterion comment="Patch DirectX80-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1291" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 8.1x" operator="AND">
-        <oval-def:criterion comment="DirectX 8.1x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1290" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.1.2600.891" negate="false" test_ref="oval:org.mitre.oval:tst:1289" />
+        <oval-def:criterion comment="DirectX 8.1x Installed" test_ref="oval:org.mitre.oval:tst:1290" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.1.2600.891" test_ref="oval:org.mitre.oval:tst:1289" />
         <oval-def:criterion comment="Patch DirectX81-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1288" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 8.2x" operator="AND">
-        <oval-def:criterion comment="DirectX 8.2x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1287" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.2.3677.144" negate="false" test_ref="oval:org.mitre.oval:tst:1286" />
+        <oval-def:criterion comment="DirectX 8.2x Installed" test_ref="oval:org.mitre.oval:tst:1287" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.2.3677.144" test_ref="oval:org.mitre.oval:tst:1286" />
         <oval-def:criterion comment="Patch DirectX82-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1285" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 9.0x" operator="AND">
-        <oval-def:criterion comment="DirectX 9.0x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1284" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.3.0.903" negate="false" test_ref="oval:org.mitre.oval:tst:1283" />
+        <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:1284" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.3.0.903" test_ref="oval:org.mitre.oval:tst:1283" />
         <oval-def:criterion comment="Patch DirectX90-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1282" />
       </oval-def:criteria>
     </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
@@ -40,12 +40,12 @@
       <oval-def:criteria comment="Unpatched DirectX 8.2x" operator="AND">
         <oval-def:criterion comment="DirectX 8.2x Installed" test_ref="oval:org.mitre.oval:tst:1287" />
         <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.2.3677.144" test_ref="oval:org.mitre.oval:tst:1286" />
-        <oval-def:criterion comment="Patch DirectX82-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1285" />
+        <oval-def:criterion comment="Patch DirectX82-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:603" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 9.0x" operator="AND">
         <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:1284" />
         <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.3.0.903" test_ref="oval:org.mitre.oval:tst:1283" />
-        <oval-def:criterion comment="Patch DirectX90-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1282" />
+        <oval-def:criterion comment="Patch DirectX90-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:600" />
       </oval-def:criteria>
     </oval-def:criteria>
   </oval-def:criteria>

--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_893.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_893.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:893" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:893" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="equals">SOFTWARE\Microsoft\Windows NT\CurrentVersion\Hotfix\KB839643-DirectX9</key>
   <name operation="equals">Installed</name>

--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_894.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_894.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:894" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:894" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="equals">SOFTWARE\Microsoft\Windows NT\CurrentVersion\Hotfix\KB839643-DirectX82</key>
   <name operation="equals">Installed</name>

--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_897.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_897.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:897" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:897" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="equals">SOFTWARE\Microsoft\Windows NT\CurrentVersion\Hotfix\KB839643</key>
   <name operation="equals">Installed</name>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1151.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1151.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1151" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1151" deprecated="true" version="1">
   <value datatype="int" operation="equals">1</value>
 </registry_state>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1154.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1154.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1154" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1154" deprecated="true" version="1">
   <value datatype="int" operation="equals">1</value>
 </registry_state>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1163.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1163.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1163" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1163" deprecated="true" version="1">
   <value datatype="int" operation="equals">1</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1282.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1282.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch DirectX90-KB839643-x86-ENU Installed" id="oval:org.mitre.oval:tst:1282" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch DirectX90-KB839643-x86-ENU Installed" id="oval:org.mitre.oval:tst:1282" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:893" />
   <state state_ref="oval:org.mitre.oval:ste:1151" />
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1285.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1285.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch DirectX82-KB839643-x86-ENU Installed" id="oval:org.mitre.oval:tst:1285" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch DirectX82-KB839643-x86-ENU Installed" id="oval:org.mitre.oval:tst:1285" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:894" />
   <state state_ref="oval:org.mitre.oval:ste:1154" />
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1294.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1294.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch Windows2000-KB839643-x86-ENU.EXE Installed" id="oval:org.mitre.oval:tst:1294" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch Windows2000-KB839643-x86-ENU.EXE Installed" id="oval:org.mitre.oval:tst:1294" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:897" />
   <state state_ref="oval:org.mitre.oval:ste:1163" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:tst:1294](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1294) and [oval:org.mitre.oval:tst:597](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:597)  are duplicates. The test [oval:org.mitre.oval:tst:597](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:597) was taken as a basic because it used in larger number of definitions. [oval:org.mitre.oval:tst:1294](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1294), [oval:org.mitre.oval:obj:297](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:297) and [oval:org.mitre.oval:ste:1163](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:1163) should be deprecated.