### PR TITLE
Kemanik duplicate obj 23452

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_12061.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_12061.xml
@@ -53,6 +53,6 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria>
-    <oval-def:criterion comment="Microsoft Office 2010 is installed" test_ref="oval:org.mitre.oval:tst:86183" />
+    <oval-def:criterion comment="The registry key that holds the location of Office 2010 Common\InstallRoot\Path exists" test_ref="oval:org.mitre.oval:tst:81399" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/objects/windows/file_object/16000/oval_org.mitre.oval_obj_16025.xml
+++ b/repository/objects/windows/file_object/16000/oval_org.mitre.oval_obj_16025.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Pptview.exe 14" id="oval:org.mitre.oval:obj:16025" version="3">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:1201" />
+  <path var_check="all" var_ref="oval:org.mitre.oval:var:1574" />
   <filename>Pptview.exe</filename>
 </file_object>

--- a/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26353.xml
+++ b/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26353.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Microsoft Office 2010 install path" id="oval:org.mitre.oval:obj:26353" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Microsoft Office 2010 install path" id="oval:org.mitre.oval:obj:26353" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Office\14.0\Common\InstallRoot</key>
   <name>Path</name>

--- a/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26762.xml
+++ b/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26762.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="32 bit Microsoft Office install path" id="oval:org.mitre.oval:obj:26762" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="32 bit Microsoft Office install path" id="oval:org.mitre.oval:obj:26762" deprecated="true" version="1">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Office\14.0\Common\InstallRoot</key>

--- a/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26770.xml
+++ b/repository/objects/windows/registry_object/26000/oval_org.mitre.oval_obj_26770.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Office 2010 set install path" id="oval:org.mitre.oval:obj:26770" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Office 2010 set install path" id="oval:org.mitre.oval:obj:26770" deprecated="true" version="1">
   <oval-def:set>
     <oval-def:object_reference>oval:org.mitre.oval:obj:26353</oval-def:object_reference>
     <oval-def:object_reference>oval:org.mitre.oval:obj:26762</oval-def:object_reference>

--- a/repository/tests/windows/registry_test/86000/oval_org.mitre.oval_tst_86183.xml
+++ b/repository/tests/windows/registry_test/86000/oval_org.mitre.oval_tst_86183.xml
@@ -1,3 +1,3 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Microsoft Office 2010 is installed" id="oval:org.mitre.oval:tst:86183" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Microsoft Office 2010 is installed" id="oval:org.mitre.oval:tst:86183" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:26770" />
 </registry_test>

--- a/repository/variables/oval_org.mitre.oval_var_1201.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1201.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Microsoft Office 14.0 Common InstallRoot" datatype="string" id="oval:org.mitre.oval:var:1201" version="3">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Microsoft Office 14.0 Common InstallRoot" datatype="string" id="oval:org.mitre.oval:var:1201" deprecated="true" version="3">
   <oval-def:regex_capture pattern="^(.*[^\\])\\?$">
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23452" />
   </oval-def:regex_capture>

--- a/repository/variables/oval_org.mitre.oval_var_1348.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1348.xml
@@ -1,7 +1,7 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Office 2010 ADDINS folder" datatype="string" id="oval:org.mitre.oval:var:1348" version="2">
   <oval-def:concat>
     <oval-def:regex_capture pattern="^(.*[^\\])\\?$">
-      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:26770" />
+      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23452" />
     </oval-def:regex_capture>
     <oval-def:literal_component>\ADDINS</oval-def:literal_component>
   </oval-def:concat>


### PR DESCRIPTION
[oval:org.mitre.oval:var:1201](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1201) and [oval:org.mitre.oval:var:1574](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1574) are duplicates. [oval:org.mitre.oval:var:1574](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1574)  was taken as a basic, [oval:org.mitre.oval:var:1201](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:1201) should be deprecated.
[oval:org.mitre.oval:tst:86183](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:86183) and [oval:org.mitre.oval:tst:81399](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:81399) are duplicates. [oval:org.mitre.oval:tst:81399](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:81399) was taken as a basic. [oval:org.mitre.oval:tst:86183](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:86183), [oval:org.mitre.oval:obj:26770](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26770), [oval:org.mitre.oval:obj:26353](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26353), [oval:org.mitre.oval:obj:26762](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26762) should be deprecated.