### PR TITLE
Kemanik duplicate obj 6292

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_1211.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_1211.xml
@@ -55,7 +55,7 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria>
-    <oval-def:criterion comment="Microsoft Office 2007 is installed" test_ref="oval:org.mitre.oval:tst:3839" />
+    <oval-def:criterion comment="Check if SOFTWARE\Microsoft\Office\12.0\Common\InstallRoot exists" test_ref="oval:org.mitre.oval:tst:80914" />
     <oval-def:criterion comment="Office 2007 InstalledPackages exists" test_ref="oval:org.mitre.oval:tst:86676" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_6006.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_6006.xml
@@ -45,6 +45,6 @@
   </oval-def:metadata>
   <oval-def:criteria>
     <oval-def:criterion comment="Excel Viewer 2007 is installed." test_ref="oval:org.mitre.oval:tst:9743" />
-    <oval-def:criterion comment="Registry key HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\12.0\Common\InstallRoot!ENU_GUID exists" test_ref="oval:org.mitre.oval:tst:80686" />
+    <oval-def:criterion comment="Check if SOFTWARE\Microsoft\Office\12.0\Common\InstallRoot exists" test_ref="oval:org.mitre.oval:tst:80914" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/objects/windows/registry_object/1000/oval_org.mitre.oval_obj_1826.xml
+++ b/repository/objects/windows/registry_object/1000/oval_org.mitre.oval_obj_1826.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1826" version="3">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1826" deprecated="true" version="3">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Office\12.0\Common\InstallRoot</key>

--- a/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3839.xml
+++ b/repository/tests/windows/registry_test/3000/oval_org.mitre.oval_tst_3839.xml
@@ -1,3 +1,3 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Microsoft Office 2007 is installed" id="oval:org.mitre.oval:tst:3839" version="4">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Microsoft Office 2007 is installed" id="oval:org.mitre.oval:tst:3839" deprecated="true" version="4">
   <object object_ref="oval:org.mitre.oval:obj:1826" />
 </registry_test>

--- a/repository/tests/windows/registry_test/80000/oval_org.mitre.oval_tst_80686.xml
+++ b/repository/tests/windows/registry_test/80000/oval_org.mitre.oval_tst_80686.xml
@@ -1,3 +1,3 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Registry key HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\12.0\Common\InstallRoot!ENU_GUID exists" id="oval:org.mitre.oval:tst:80686" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Registry key HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\12.0\Common\InstallRoot!ENU_GUID exists" id="oval:org.mitre.oval:tst:80686" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:6292" />
 </registry_test>

--- a/repository/variables/oval_org.mitre.oval_var_1906.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1906.xml
@@ -1,7 +1,7 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Office 2007 ADDINS folder" datatype="string" id="oval:org.mitre.oval:var:1906" version="1">
   <oval-def:concat>
     <oval-def:regex_capture pattern="^(.*[^\\])\\?$">
-      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:1826" />
+      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:6292" />
     </oval-def:regex_capture>
     <oval-def:literal_component>\ADDINS</oval-def:literal_component>
   </oval-def:concat>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:1826](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:1826) and [oval:org.mitre.oval:obj:6292](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6292) are duplicates.  [oval:org.mitre.oval:obj:6292](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6292) is taken as a basic, [oval:org.mitre.oval:obj:1826](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:1826)  should be deprecated.
[oval:org.mitre.oval:tst:80686](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:80686), [oval:org.mitre.oval:tst:3839](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:3839) and  [oval:org.mitre.oval:tst:80914](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:80914) are duplicates. [oval:org.mitre.oval:tst:80914](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:80914) is taken as a basic, the other tests should be deprecated.