### PR TITLE
Kemanik duplicate tst 9193

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_842.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_842.xml
@@ -34,7 +34,7 @@
   <oval-def:criteria operator="AND">
     <oval-def:criteria comment="Software section" operator="AND">
       <oval-def:criteria comment="Windows Media Services 4.1 is installed on Microsoft Windows 2000 Server" operator="AND">
-        <oval-def:criterion comment="Windows Media Services 4.1 is installed" test_ref="oval:org.mitre.oval:tst:1602" />
+        <oval-def:criterion comment="HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NetShow!Version exists and is 4.1" test_ref="oval:org.mitre.oval:tst:9193" />
         <oval-def:criteria comment="Windows 2000 Server is installed" operator="AND">
           <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3085" />
           <oval-def:criteria comment="Windows NT server product option" operator="OR">

--- a/repository/objects/windows/registry_object/1000/oval_org.mitre.oval_obj_1078.xml
+++ b/repository/objects/windows/registry_object/1000/oval_org.mitre.oval_obj_1078.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1078" version="2">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1078" deprecated="true" version="2">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\NetShow</key>
   <name>Version</name>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1454.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1454.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1454" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1454" deprecated="true" version="1">
   <value>4.1</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1602.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1602.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows Media Services 4.1 is installed" id="oval:org.mitre.oval:tst:1602" version="2">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows Media Services 4.1 is installed" id="oval:org.mitre.oval:tst:1602" deprecated="true" version="2">
   <object object_ref="oval:org.mitre.oval:obj:1078" />
   <state state_ref="oval:org.mitre.oval:ste:1454" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:tst:1602](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1602) and [oval:org.mitre.oval:tst:9193](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:9193) are duplicates. [oval:org.mitre.oval:tst:9193](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:9193) was taken as a basic. [oval:org.mitre.oval:tst:1602](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1602) , [oval:org.mitre.oval:obj:1078](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:1078) and  [oval:org.mitre.oval:ste:1454](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:1454) should be deprecated.