### PR TITLE
Kemanik duplicate tst 100

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_536.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_536.xml
@@ -43,7 +43,6 @@
   <oval-def:criteria operator="OR">
     <oval-def:criteria operator="AND">
       <oval-def:extend_definition comment="Windows Media Player 6.4 is installed." definition_ref="oval:org.mitre.oval:def:6408" />
-      <oval-def:criterion comment="Media Player 8 (v6.4) is installed." test_ref="oval:org.mitre.oval:tst:100" />
       <oval-def:criterion comment="Dxmasf.dll version is less than 6.4.9.1133" test_ref="oval:org.mitre.oval:tst:96" />
     </oval-def:criteria>
     <oval-def:criteria operator="AND">

--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_6.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_6.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6" deprecated="true "version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\MediaPlayer\PlayerUpgrade</key>
   <name>PlayerVersion</name>

--- a/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_108.xml
+++ b/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_108.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:108" version="3">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:108" deprecated="true" version="3">
   <value operation="pattern match">^6[,\.]4.*$</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_100.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_100.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Media Player 8 (v6.4) is installed." id="oval:org.mitre.oval:tst:100" version="3">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Media Player 8 (v6.4) is installed." id="oval:org.mitre.oval:tst:100" deprecated="true" version="3">
   <object object_ref="oval:org.mitre.oval:obj:6" />
   <state state_ref="oval:org.mitre.oval:ste:108" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:tst:100](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:100) and [oval:org.mitre.oval:tst:10296](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:10296) are duplicates. [oval:org.mitre.oval:tst:10296](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:10296)  was taken as a basic. [oval:org.mitre.oval:tst:100](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:100), [oval:org.mitre.oval:obj:6](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6) and [oval:org.mitre.oval:ste:108](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:108) should be deprecated. 

Criterion [oval:org.mitre.oval:tst:100](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:100) should be deleted from [oval:org.mitre.oval:def:536](https://ovaldb.altx-soft.ru/Definition.aspx?id=oval:org.mitre.oval:def:536) because it is overabundant.


<contributor organization="ALTX-SOFT">Maria Mikhno</contributor>