### PR TITLE
Kemanik duplicate obj 24068

### DIFF
--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23243.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23243.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the install path for Microsoft Exchange Server 2010" id="oval:org.mitre.oval:obj:23243" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the install path for Microsoft Exchange Server 2010" id="oval:org.mitre.oval:obj:23243" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\ExchangeServer\v14\Setup</key>
   <name>MsiInstallPath</name>

--- a/repository/variables/oval_org.mitre.oval_var_1542.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1542.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to exchange server directory" datatype="string" id="oval:org.mitre.oval:var:1542" version="1">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23243" />
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:24068" />
     <oval-def:literal_component>ClientAccess\Owa\Bin\DocumentViewing</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:24068](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24068) and [oval:org.mitre.oval:obj:23243](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23243) are duplicates. [oval:org.mitre.oval:obj:24068](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24068) was taken as a basic. [oval:org.mitre.oval:obj:23243](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23243) should be deprecated.