### PR TITLE
Kemanik duplicate var 210

### DIFF
--- a/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6223.xml
+++ b/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6223.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6223" version="1">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:425" />
+  <path var_check="all" var_ref="oval:org.mitre.oval:var:210" />
   <filename>owaauth.dll</filename>
 </file_object>

--- a/repository/objects/windows/registry_object/5000/oval_org.mitre.oval_obj_5478.xml
+++ b/repository/objects/windows/registry_object/5000/oval_org.mitre.oval_obj_5478.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="This registry key identifies the exchange services root." id="oval:org.mitre.oval:obj:5478" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="This registry key identifies the exchange services root." id="oval:org.mitre.oval:obj:5478" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Exchange\Setup</key>
   <name>Services</name>

--- a/repository/variables/oval_org.mitre.oval_var_425.xml
+++ b/repository/variables/oval_org.mitre.oval_var_425.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="..." datatype="string" id="oval:org.mitre.oval:var:425" version="1">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="..." datatype="string" id="oval:org.mitre.oval:var:425" deprecated="true" version="1">
   <oval-def:concat>
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:5478" />
     <oval-def:literal_component>\bin</oval-def:literal_component>


### PR DESCRIPTION
[oval:org.mitre.oval:var:210](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:210) and [oval:org.mitre.oval:var:425](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:425) are duplicates. [oval:org.mitre.oval:var:210](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:210)  was taken as a basic. [oval:org.mitre.oval:var:425](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:425), [oval:org.mitre.oval:obj:5478](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:5478) should be deprecated.