### PR TITLE
Kemanik duplicate obj 23474

### DIFF
--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23606.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23606.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the install path for Microsoft Exchange Server 2007" id="oval:org.mitre.oval:obj:23606" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the install path for Microsoft Exchange Server 2007" id="oval:org.mitre.oval:obj:23606" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Exchange\Setup</key>
   <name>MsiInstallPath</name>

--- a/repository/variables/oval_org.mitre.oval_var_1320.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1320.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Object holds the path to Exchange Server 2007" datatype="string" id="oval:org.mitre.oval:var:1320" version="1">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23606" />
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23474" />
     <oval-def:literal_component>ClientAccess\Owa\Bin\DocumentViewing</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:23474](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23474) and [oval:org.mitre.oval:obj:23606](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23606) are duplicates. [oval:org.mitre.oval:obj:23474](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23474) was taken as a basic, [oval:org.mitre.oval:obj:23606](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23606) should be deprecated.