### PR TITLE
Kemanik duplicate obj 499

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
@@ -40,12 +40,12 @@
       <oval-def:criteria comment="Unpatched DirectX 8.2x" operator="AND">
         <oval-def:criterion comment="DirectX 8.2 Installed" test_ref="oval:org.mitre.oval:tst:604" />
         <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.2.3677.144" test_ref="oval:org.mitre.oval:tst:1286" />
-        <oval-def:criterion comment="Patch DirectX82-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1285" />
+        <oval-def:criterion comment="Patch DirectX82-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:603" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 9.0x" operator="AND">
         <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:601" />
         <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.3.0.903" test_ref="oval:org.mitre.oval:tst:1283" />
-        <oval-def:criterion comment="Patch DirectX90-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1282" />
+        <oval-def:criterion comment="Patch DirectX90-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:600" />
       </oval-def:criteria>
     </oval-def:criteria>
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
@@ -19,32 +19,32 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria comment="Software section" operator="AND">
-    <oval-def:criterion comment="Windows 2000 is installed" negate="false" test_ref="oval:org.mitre.oval:tst:3085" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3085" />
     <oval-def:criteria comment="Vulnerable versions of DirectX" operator="OR">
       <oval-def:criteria comment="Unpatched DirectX 7.0" operator="AND">
-        <oval-def:criterion comment="DirectX 7.0x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1296" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2195.6927" negate="false" test_ref="oval:org.mitre.oval:tst:1295" />
+        <oval-def:criterion comment="DirectX 7.0x Installed" test_ref="oval:org.mitre.oval:tst:1296" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2195.6927" test_ref="oval:org.mitre.oval:tst:1295" />
         <oval-def:criterion comment="Patch Windows2000-KB839643-x86-ENU.EXE Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1294" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 8.0x" operator="AND">
-        <oval-def:criterion comment="DirectX 8.0x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1293" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2258.410" negate="false" test_ref="oval:org.mitre.oval:tst:1292" />
+        <oval-def:criterion comment="DirectX 8.0x Installed" test_ref="oval:org.mitre.oval:tst:1293" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2258.410" test_ref="oval:org.mitre.oval:tst:1292" />
         <oval-def:criterion comment="Patch DirectX80-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1291" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 8.1x" operator="AND">
-        <oval-def:criterion comment="DirectX 8.1x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1290" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.1.2600.891" negate="false" test_ref="oval:org.mitre.oval:tst:1289" />
+        <oval-def:criterion comment="DirectX 8.1 Installed" test_ref="oval:org.mitre.oval:tst:6805" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.1.2600.891" test_ref="oval:org.mitre.oval:tst:1289" />
         <oval-def:criterion comment="Patch DirectX81-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1288" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 8.2x" operator="AND">
-        <oval-def:criterion comment="DirectX 8.2x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1287" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.2.3677.144" negate="false" test_ref="oval:org.mitre.oval:tst:1286" />
+        <oval-def:criterion comment="DirectX 8.2 Installed" test_ref="oval:org.mitre.oval:tst:604" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.2.3677.144" test_ref="oval:org.mitre.oval:tst:1286" />
         <oval-def:criterion comment="Patch DirectX82-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1285" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 9.0x" operator="AND">
-        <oval-def:criterion comment="DirectX 9.0x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1284" />
-        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.3.0.903" negate="false" test_ref="oval:org.mitre.oval:tst:1283" />
+        <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:601" />
+        <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.3.0.903" test_ref="oval:org.mitre.oval:tst:1283" />
         <oval-def:criterion comment="Patch DirectX90-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1282" />
       </oval-def:criteria>
     </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1027.xml
@@ -25,7 +25,7 @@
       <oval-def:criteria comment="Unpatched DirectX 7.0" operator="AND">
         <oval-def:criterion comment="DirectX 7.0x Installed" test_ref="oval:org.mitre.oval:tst:1296" />
         <oval-def:criterion comment="File %windir%\system32\dplayx.dll version is less than 5.0.2195.6927" test_ref="oval:org.mitre.oval:tst:1295" />
-        <oval-def:criterion comment="Patch Windows2000-KB839643-x86-ENU.EXE Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1294" />
+         <oval-def:criterion comment="the patch kb839643 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:597" />
       </oval-def:criteria>
       <oval-def:criteria comment="Unpatched DirectX 8.0x" operator="AND">
         <oval-def:criterion comment="DirectX 8.0x Installed" test_ref="oval:org.mitre.oval:tst:1293" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1149.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1149.xml
@@ -45,7 +45,7 @@
       <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
     <oval-def:criteria comment="Standalone DirectX 9 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="DirectX 9.x Installed" test_ref="oval:org.mitre.oval:tst:1120" />
+      <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:601" />
       <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1231.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1231.xml
@@ -50,7 +50,7 @@
       <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
     <oval-def:criteria comment="Standalone DirectX 9 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="DirectX 9.x Installed" test_ref="oval:org.mitre.oval:tst:1120" />
+      <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:601" />
       <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1267.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1267.xml
@@ -40,18 +40,18 @@
   </oval-def:metadata>
   <oval-def:criteria comment="Software section" operator="OR">
     <oval-def:criteria comment="DirectX packaged with Windows 2000,SP4 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="Windows 2000 is installed" negate="false" test_ref="oval:org.mitre.oval:tst:3085" />
-      <oval-def:criterion comment="SP4 or later Installed" negate="false" test_ref="oval:org.mitre.oval:tst:3073" />
-      <oval-def:criterion comment="the version of Quartz.dll is greater than or equal to 6.1.9.726" negate="false" test_ref="oval:org.mitre.oval:tst:1027" />
-      <oval-def:criterion comment="the version of Quartz.dll is less than 6.1.9.732" negate="false" test_ref="oval:org.mitre.oval:tst:1026" />
+      <oval-def:criterion comment="Windows 2000 is installed" test_ref="oval:org.mitre.oval:tst:3085" />
+      <oval-def:criterion comment="SP4 or later Installed" test_ref="oval:org.mitre.oval:tst:3073" />
+      <oval-def:criterion comment="the version of Quartz.dll is greater than or equal to 6.1.9.726" test_ref="oval:org.mitre.oval:tst:1027" />
+      <oval-def:criterion comment="the version of Quartz.dll is less than 6.1.9.732" test_ref="oval:org.mitre.oval:tst:1026" />
     </oval-def:criteria>
     <oval-def:criteria comment="Standalone DirectX 8 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="DirectX 8.x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1173" />
-      <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" negate="false" test_ref="oval:org.mitre.oval:tst:1121" />
+      <oval-def:criterion comment="DirectX 8.x Installed" test_ref="oval:org.mitre.oval:tst:1173" />
+      <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
     <oval-def:criteria comment="Standalone DirectX 9 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="DirectX 9.x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1120" />
-      <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" negate="false" test_ref="oval:org.mitre.oval:tst:1121" />
+      <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:601" />
+      <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1424.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1424.xml
@@ -45,7 +45,7 @@
       <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
     <oval-def:criteria comment="Standalone DirectX 9 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="DirectX 9.x Installed" test_ref="oval:org.mitre.oval:tst:1120" />
+      <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:601" />
       <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1434.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1434.xml
@@ -35,18 +35,18 @@
   </oval-def:metadata>
   <oval-def:criteria comment="Software section" operator="OR">
     <oval-def:criteria comment="DirectX packaged with Windows XP,SP1 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="Windows XP is installed" negate="false" test_ref="oval:org.mitre.oval:tst:2838" />
-      <oval-def:criterion comment="Win2K/XP/2003 service pack 1 is installed" negate="false" test_ref="oval:org.mitre.oval:tst:2843" />
-      <oval-def:criterion comment="the version of Quartz.dll is greater than or equal to 6.4.2600.0" negate="false" test_ref="oval:org.mitre.oval:tst:941" />
-      <oval-def:criterion comment="the version of Quartz.dll is less than 6.4.2600.1738" negate="false" test_ref="oval:org.mitre.oval:tst:940" />
+      <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:2838" />
+      <oval-def:criterion comment="Win2K/XP/2003 service pack 1 is installed" test_ref="oval:org.mitre.oval:tst:2843" />
+      <oval-def:criterion comment="the version of Quartz.dll is greater than or equal to 6.4.2600.0" test_ref="oval:org.mitre.oval:tst:941" />
+      <oval-def:criterion comment="the version of Quartz.dll is less than 6.4.2600.1738" test_ref="oval:org.mitre.oval:tst:940" />
     </oval-def:criteria>
     <oval-def:criteria comment="Standalone DirectX 8 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="DirectX 8.x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1173" />
-      <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" negate="false" test_ref="oval:org.mitre.oval:tst:1121" />
+      <oval-def:criterion comment="DirectX 8.x Installed" test_ref="oval:org.mitre.oval:tst:1173" />
+      <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
     <oval-def:criteria comment="Standalone DirectX 9 has DirectShow Vulnerability" operator="AND">
-      <oval-def:criterion comment="DirectX 9.x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:1120" />
-      <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" negate="false" test_ref="oval:org.mitre.oval:tst:1121" />
+      <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:601" />
+      <oval-def:criterion comment="the version of Quartz.dll is less than 6.3.1.889" test_ref="oval:org.mitre.oval:tst:1121" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_2190.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_2190.xml
@@ -46,7 +46,7 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria comment="Software section" operator="AND">
+  <oval-def:criteria>
     <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:2838" />
     <oval-def:criterion comment="32-Bit version of Windows is installed" test_ref="oval:org.mitre.oval:tst:2748" />
     <oval-def:criteria comment="DirectX without KB839643 Installed" operator="OR">
@@ -64,7 +64,7 @@
         <oval-def:criteria comment="DirectX 8.1 without WindowsXP-KB839643-x86-ENU.EXE Installed on XP Gold" operator="AND">
           <oval-def:criterion comment="the version of dplayx.dll is less than 5.1.2600.148" test_ref="oval:org.mitre.oval:tst:599" />
           <oval-def:criterion comment="Win2K/XP/2003 is patched" negate="true" test_ref="oval:org.mitre.oval:tst:2437" />
-          <oval-def:criterion comment="DirectX 8.1x Installed" test_ref="oval:org.mitre.oval:tst:598" />
+          <oval-def:criterion comment="DirectX 8.1 Installed" test_ref="oval:org.mitre.oval:tst:6805" />
           <oval-def:criterion comment="the patch kb839643 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:597" />
         </oval-def:criteria>
         <oval-def:criteria comment="DirectX 8.1 without WindowsXP-KB839643-x86-ENU.EXE Installed on XP SP1" operator="AND">

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_2413.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_2413.xml
@@ -54,17 +54,15 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria comment="Software section" operator="AND">
+  <oval-def:criteria>
     <oval-def:criteria comment="DirectX 8.1 without kb839643 installed" operator="AND">
       <oval-def:criterion comment="the version of dplayx.dll is less than 5.2.3790.163 on 64-bit edition" test_ref="oval:org.mitre.oval:tst:548" />
-      <oval-def:criterion comment="DirectX 8.1x Installed" test_ref="oval:org.mitre.oval:tst:598" />
+      <oval-def:criterion comment="DirectX 8.1 Installed" test_ref="oval:org.mitre.oval:tst:6805" />
       <oval-def:criterion comment="the patch kb839643 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:597" />
     </oval-def:criteria>
     <oval-def:criteria comment="Windows XP 64-bit with SP1 (or earlier) installed" operator="AND">
-      <oval-def:criteria comment="Windows XP (sp1 or earlier) is installed" operator="AND">
         <oval-def:criterion comment="Windows XP is installed" test_ref="oval:org.mitre.oval:tst:2838" />
         <oval-def:criterion comment="Win2K/XP/2003 service pack 2 (or later) is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2837" />
-      </oval-def:criteria>
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_2516.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_2516.xml
@@ -25,23 +25,23 @@
       <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria comment="Software section" operator="AND">
-    <oval-def:criterion comment="Windows Server 2003 is installed" negate="false" test_ref="oval:org.mitre.oval:tst:2761" />
-    <oval-def:criterion comment="32-Bit version of Windows is installed" negate="false" test_ref="oval:org.mitre.oval:tst:2748" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Windows Server 2003 is installed" test_ref="oval:org.mitre.oval:tst:2761" />
+    <oval-def:criterion comment="32-Bit version of Windows is installed" test_ref="oval:org.mitre.oval:tst:2748" />
     <oval-def:criteria comment="DirectX without KB839643 Installed on Windows Server 2003" operator="OR">
       <oval-def:criteria comment="DirectX 8.2 without DirectX82-KB839643-x86-ENU.EXE Installed" operator="AND">
-        <oval-def:criterion comment="the version of dplayx.dll is less than 5.2.3677.144" negate="false" test_ref="oval:org.mitre.oval:tst:605" />
-        <oval-def:criterion comment="DirectX 8.2 Installed" negate="false" test_ref="oval:org.mitre.oval:tst:604" />
+        <oval-def:criterion comment="the version of dplayx.dll is less than 5.2.3677.144" test_ref="oval:org.mitre.oval:tst:605" />
+        <oval-def:criterion comment="DirectX 8.2 Installed" test_ref="oval:org.mitre.oval:tst:604" />
         <oval-def:criterion comment="Patch DirectX82-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:603" />
       </oval-def:criteria>
       <oval-def:criteria comment="DirectX 9.0 without DirectX9-KB839643-x86-ENU.EXE Installed" operator="AND">
-        <oval-def:criterion comment="the version of dplayx.dll is less than 5.3.0.903" negate="false" test_ref="oval:org.mitre.oval:tst:602" />
-        <oval-def:criterion comment="DirectX 9.0x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:601" />
+        <oval-def:criterion comment="the version of dplayx.dll is less than 5.3.0.903" test_ref="oval:org.mitre.oval:tst:602" />
+        <oval-def:criterion comment="DirectX 9.0x Installed" test_ref="oval:org.mitre.oval:tst:601" />
         <oval-def:criterion comment="Patch DirectX90-KB839643-x86-ENU Installed" negate="true" test_ref="oval:org.mitre.oval:tst:600" />
       </oval-def:criteria>
       <oval-def:criteria comment="DirectX 8.1 without WindowsServer2003-KB839643-x86-ENU.EXE Installed" operator="AND">
-        <oval-def:criterion comment="the version of dplayx.dll is less than 5.2.3790.163" negate="false" test_ref="oval:org.mitre.oval:tst:528" />
-        <oval-def:criterion comment="DirectX 8.1x Installed" negate="false" test_ref="oval:org.mitre.oval:tst:598" />
+        <oval-def:criterion comment="the version of dplayx.dll is less than 5.2.3790.163" test_ref="oval:org.mitre.oval:tst:528" />
+        <oval-def:criterion comment="DirectX 8.1 Installed" test_ref="oval:org.mitre.oval:tst:6805" />
         <oval-def:criterion comment="the patch kb839643 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:597" />
       </oval-def:criteria>
     </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_2705.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_2705.xml
@@ -36,7 +36,7 @@
     <oval-def:criterion comment="64-Bit version of Windows is installed" test_ref="oval:org.mitre.oval:tst:2747" />
     <oval-def:criteria comment="DirectX 8.1 without kb839643 installed" operator="AND">
       <oval-def:criterion comment="the version of dplayx.dll is less than 5.2.3790.163 on 64-bit edition" test_ref="oval:org.mitre.oval:tst:548" />
-      <oval-def:criterion comment="DirectX 8.1x Installed" test_ref="oval:org.mitre.oval:tst:598" />
+      <oval-def:criterion comment="DirectX 8.1 Installed" test_ref="oval:org.mitre.oval:tst:6805" />
       <oval-def:criterion comment="the patch kb839643 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:597" />
     </oval-def:criteria>
   </oval-def:criteria>

--- a/repository/objects/windows/registry_object/44000/oval_org.mitre.oval_obj_44181.xml
+++ b/repository/objects/windows/registry_object/44000/oval_org.mitre.oval_obj_44181.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds DirectX Version" id="oval:org.mitre.oval:obj:44181" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds DirectX Version" id="oval:org.mitre.oval:obj:44181" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\DirectX</key>
   <name>Version</name>

--- a/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_542.xml
+++ b/repository/states/windows/registry_state/0000/oval_org.mitre.oval_ste_542.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:542" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:542" deprecated="true" version="1">
   <value operation="pattern match">^4\.08\.01.*$</value>
 </registry_state>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1001.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1001.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1001" version="2">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1001" deprecated="true" version="2">
   <value operation="pattern match">^4\.[0]*9\..*$</value>
 </registry_state>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1153.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1153.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1153" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1153" deprecated="true" version="1">
   <value operation="pattern match">^4\.09\.00.*</value>
 </registry_state>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1156.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1156.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1156" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1156" deprecated="true" version="1">
   <value operation="pattern match">^4\.08\.02.*</value>
 </registry_state>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1159.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1159.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1159" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1159" deprecated="true" version="1">
   <value operation="pattern match">^4\.08\.01.*</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_598.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_598.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 8.1x Installed" id="oval:org.mitre.oval:tst:598" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 8.1x Installed" id="oval:org.mitre.oval:tst:598" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:499" />
   <state state_ref="oval:org.mitre.oval:ste:542" />
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1120.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1120.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 9.x Installed" id="oval:org.mitre.oval:tst:1120" version="2">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 9.x Installed" id="oval:org.mitre.oval:tst:1120" deprecated="true" version="2">
   <object object_ref="oval:org.mitre.oval:obj:499" />
   <state state_ref="oval:org.mitre.oval:ste:1001" />
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1284.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1284.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 9.0x Installed" id="oval:org.mitre.oval:tst:1284" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 9.0x Installed" id="oval:org.mitre.oval:tst:1284" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:499" />
   <state state_ref="oval:org.mitre.oval:ste:1153" />
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1287.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1287.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 8.2x Installed" id="oval:org.mitre.oval:tst:1287" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 8.2x Installed" id="oval:org.mitre.oval:tst:1287" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:499" />
   <state state_ref="oval:org.mitre.oval:ste:1156" />
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1290.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1290.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 8.1x Installed" id="oval:org.mitre.oval:tst:1290" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="DirectX 8.1x Installed" id="oval:org.mitre.oval:tst:1290" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:499" />
   <state state_ref="oval:org.mitre.oval:ste:1159" />
 </registry_test>

--- a/repository/tests/windows/registry_test/138000/oval_org.mitre.oval_tst_138738.xml
+++ b/repository/tests/windows/registry_test/138000/oval_org.mitre.oval_tst_138738.xml
@@ -1,3 +1,3 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if DirectX is installed" id="oval:org.mitre.oval:tst:138738" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:44181" />
+  <object object_ref="oval:org.mitre.oval:obj:499" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:499](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:499) and [oval:org.mitre.oval:obj:44181](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:44181) are duplicates. [oval:org.mitre.oval:obj:499](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:499) was taken as a basic because it used in larger number of tests.
[oval:org.mitre.oval:tst:601](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:601), [oval:org.mitre.oval:tst:1120](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1120) and [oval:org.mitre.oval:tst:1284](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1284) are duplicates. [oval:org.mitre.oval:tst:601](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:601) was taken as a basic, other should be deprecated.
[oval:org.mitre.oval:tst:604](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:604) and [oval:org.mitre.oval:tst:1287](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1287) are duplicates. [oval:org.mitre.oval:tst:604](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:604) was taken as a basic, [oval:org.mitre.oval:tst:1287](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1287) should be deprecated.
[oval:org.mitre.oval:tst:6805](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:6805), [oval:org.mitre.oval:tst:1290](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1290) and [oval:org.mitre.oval:tst:598](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:598)  are duplicates. [oval:org.mitre.oval:tst:6805](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:6805) was taken as a basic, other should be deprecated.

<contributor organization="ALTX-SOFT">Maria Mikhno</contributor>