### PR TITLE
kemanik-duplicate-tst-3121-tst-3120

### DIFF
--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_991.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_991.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:991" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:991" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="equals">Software\Microsoft\Active Setup\Installed Components\{2D5974C5-5185-4f5b-80B6-28015ACDD74C}</key>
   <name operation="equals">IsInstalled</name>

--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_992.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_992.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:992" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:992" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="equals">Software\Microsoft\Active Setup\Installed Components\{E81659DF-28E1-4C60-B4B9-00A4BC5FA76D}</key>
   <name operation="equals">IsInstalled</name>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1315.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1315.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1315" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1315" deprecated="true" version="1">
   <value datatype="int" operation="equals">1</value>
 </registry_state>

--- a/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1316.xml
+++ b/repository/states/windows/registry_state/1000/oval_org.mitre.oval_ste_1316.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1316" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:1316" deprecated="true" version="1">
   <value datatype="int" operation="equals">1</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1457.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1457.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch Q319282 Installed" id="oval:org.mitre.oval:tst:1457" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch Q319282 Installed" id="oval:org.mitre.oval:tst:1457" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:991" />
   <state state_ref="oval:org.mitre.oval:ste:1315" />
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1458.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1458.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch Q316059.exe Installed" id="oval:org.mitre.oval:tst:1458" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Patch Q316059.exe Installed" id="oval:org.mitre.oval:tst:1458" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:992" />
   <state state_ref="oval:org.mitre.oval:ste:1316" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:tst:1458](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1458) and [oval:org.mitre.oval:tst:1457](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1457) should be deprecated.