### PR TITLE
Kemanik duplicate obj 264

### DIFF
--- a/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_265.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.mitre.oval_obj_265.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:265" version="2">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:265" deprecated="true" version="2">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Active Setup\Installed Components\{78705f0d-e8db-4b2d-8193-982bdda15ecd}</key>
   <name>Version</name>

--- a/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15765.xml
+++ b/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15765.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:15765" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:15765" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>Software\Microsoft\Active Setup\Installed Components\{78705f0d-e8db-4b2d-8193-982bdda15ecd}</key>
   <name>Version</name>

--- a/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_289.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.mitre.oval_tst_289.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Is Service Pack 2 for Microsoft .NET Framework 1.0 installed" id="oval:org.mitre.oval:tst:289" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:265" />
+  <object object_ref="oval:org.mitre.oval:obj:264" />
   <state state_ref="oval:org.mitre.oval:ste:286" />
 </registry_test>

--- a/repository/tests/windows/registry_test/42000/oval_org.mitre.oval_tst_42130.xml
+++ b/repository/tests/windows/registry_test/42000/oval_org.mitre.oval_tst_42130.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Is the Microsoft .NET Framework 1.0 patched to SP3 or greater (XP MCE/Tablet)" id="oval:org.mitre.oval:tst:42130" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15765" />
+  <object object_ref="oval:org.mitre.oval:obj:264" />
   <state state_ref="oval:org.mitre.oval:ste:11841" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:265](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:265), [oval:org.mitre.oval:obj:264](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:264) and [oval:org.mitre.oval:obj:15765](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15765) are duplicates. [oval:org.mitre.oval:obj:264](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:264) was taken as a basic, other should be deprecated.