### PR TITLE
Kemanik duplicate tst 2890

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_141.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_141.xml
@@ -71,7 +71,7 @@
       </oval-def:criteria>
       <oval-def:criterion comment="File %windir%\system32\shdocvw.dll version is less than 5.0.3214.2000" test_ref="oval:org.mitre.oval:tst:2892" />
       <oval-def:criterion comment="the patch q290108 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2891" />
-      <oval-def:criterion comment="the patch q295106 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:2890" />
+      <oval-def:criterion comment="Patch Q295106 Installed" negate="true" test_ref="oval:org.mitre.oval:tst:1461" />
       <oval-def:criterion comment="Win2K/XP/2003/Vista/2008 Service Pack 2 is installed" negate="true" test_ref="oval:org.mitre.oval:tst:3019" />
     </oval-def:criteria>
     <oval-def:criteria comment="Configuration section" operator="AND">

--- a/repository/objects/windows/registry_object/1000/oval_org.mitre.oval_obj_1657.xml
+++ b/repository/objects/windows/registry_object/1000/oval_org.mitre.oval_obj_1657.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1657" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1657" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Active Setup\Installed Components\{754D29C1-0C97-405F-98D0-21B212CA7FF1}</key>
   <name>IsInstalled</name>

--- a/repository/states/windows/registry_state/2000/oval_org.mitre.oval_ste_2706.xml
+++ b/repository/states/windows/registry_state/2000/oval_org.mitre.oval_ste_2706.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:2706" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:2706" deprecated="true" version="1">
   <value datatype="int">1</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/2000/oval_org.mitre.oval_tst_2890.xml
+++ b/repository/tests/windows/registry_test/2000/oval_org.mitre.oval_tst_2890.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the patch q295106 is installed" id="oval:org.mitre.oval:tst:2890" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the patch q295106 is installed" id="oval:org.mitre.oval:tst:2890" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:1657" />
   <state state_ref="oval:org.mitre.oval:ste:2706" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:tst:2890](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2890) and [oval:org.mitre.oval:tst:1461](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1461) are duplicates. [oval:org.mitre.oval:tst:1461](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1461) was taken as a basic.