### PR TITLE
Kemanik duplicate obj 42829

### DIFF
--- a/repository/objects/windows/registry_object/38000/oval_org.mitre.oval_obj_38406.xml
+++ b/repository/objects/windows/registry_object/38000/oval_org.mitre.oval_obj_38406.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry key holds the path to Python" id="oval:org.mitre.oval:obj:38406" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry key holds the path to Python" id="oval:org.mitre.oval:obj:38406" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="pattern match">^SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\.*$</key>
   <name>DisplayName</name>

--- a/repository/objects/windows/registry_object/42000/oval_org.mitre.oval_obj_42775.xml
+++ b/repository/objects/windows/registry_object/42000/oval_org.mitre.oval_obj_42775.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry key holds the path to Python 32_bit" id="oval:org.mitre.oval:obj:42775" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry key holds the path to Python 32_bit" id="oval:org.mitre.oval:obj:42775" deprecated="true" version="1">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="pattern match">^SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\.*$</key>

--- a/repository/objects/windows/registry_object/42000/oval_org.mitre.oval_obj_42829.xml
+++ b/repository/objects/windows/registry_object/42000/oval_org.mitre.oval_obj_42829.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Set of Python objects" id="oval:org.mitre.oval:obj:42829" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Set of Python objects" id="oval:org.mitre.oval:obj:42829" deprecated="true" version="1">
   <oval-def:set>
     <oval-def:object_reference>oval:org.mitre.oval:obj:38406</oval-def:object_reference>
     <oval-def:object_reference>oval:org.mitre.oval:obj:42775</oval-def:object_reference>

--- a/repository/tests/windows/registry_test/135000/oval_org.mitre.oval_tst_135282.xml
+++ b/repository/tests/windows/registry_test/135000/oval_org.mitre.oval_tst_135282.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Python is installed" id="oval:org.mitre.oval:tst:135282" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:42829" />
+  <object object_ref="oval:org.mitre.oval:obj:911" />
   <state state_ref="oval:org.mitre.oval:ste:31049" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:42829](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:42829) and [oval:org.mitre.oval:obj:911](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:911) are duplicates. [oval:org.mitre.oval:obj:911](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:911) was taken as a basic.