### PR TITLE
Kemanik duplicate obj 23698

### DIFF
--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23698.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23698.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Microsoft Commerce Server 2002 Registry" id="oval:org.mitre.oval:obj:23698" version="2">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Microsoft Commerce Server 2002 Registry" id="oval:org.mitre.oval:obj:23698" deprecated="true" version="2">
   <oval-def:set>
     <oval-def:object_reference>oval:org.mitre.oval:obj:23760</oval-def:object_reference>
     <oval-def:object_reference>oval:org.mitre.oval:obj:1436</oval-def:object_reference>

--- a/repository/tests/windows/registry_test/79000/oval_org.mitre.oval_tst_79403.xml
+++ b/repository/tests/windows/registry_test/79000/oval_org.mitre.oval_tst_79403.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Microsoft Commerce Server 2007 is installed" id="oval:org.mitre.oval:tst:79403" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:23698" />
+  <object object_ref="oval:org.mitre.oval:obj:911" />
   <state state_ref="oval:org.mitre.oval:ste:19207" />
 </registry_test>

--- a/repository/tests/windows/registry_test/79000/oval_org.mitre.oval_tst_79858.xml
+++ b/repository/tests/windows/registry_test/79000/oval_org.mitre.oval_tst_79858.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Microsoft Commerce Server 2002 is installed" id="oval:org.mitre.oval:tst:79858" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:23698" />
+  <object object_ref="oval:org.mitre.oval:obj:911" />
   <state state_ref="oval:org.mitre.oval:ste:19188" />
 </registry_test>

--- a/repository/tests/windows/registry_test/79000/oval_org.mitre.oval_tst_79901.xml
+++ b/repository/tests/windows/registry_test/79000/oval_org.mitre.oval_tst_79901.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Microsoft Commerce Server 2009 is installed" id="oval:org.mitre.oval:tst:79901" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:23698" />
+  <object object_ref="oval:org.mitre.oval:obj:911" />
   <state state_ref="oval:org.mitre.oval:ste:19248" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:23698](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23698) and [oval:org.mitre.oval:obj:911](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:911) are duplicates.[oval:org.mitre.oval:obj:911](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:911) was taken as a basic.