### PR TITLE
Kemanik duplicate obj 24170

### DIFF
--- a/repository/objects/windows/registry_object/24000/oval_org.mitre.oval_obj_24170.xml
+++ b/repository/objects/windows/registry_object/24000/oval_org.mitre.oval_obj_24170.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Object holds Uninstall!DisplayName registry key" id="oval:org.mitre.oval:obj:24170" version="2">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Object holds Uninstall!DisplayName registry key" id="oval:org.mitre.oval:obj:24170" deprecated="true" version="2">
   <oval-def:set>
     <oval-def:object_reference>oval:org.mitre.oval:obj:1436</oval-def:object_reference>
     <oval-def:object_reference>oval:org.mitre.oval:obj:23760</oval-def:object_reference>

--- a/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122534.xml
+++ b/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122534.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Adobe Flash Professional is installed" id="oval:org.mitre.oval:tst:122534" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:24170" />
+  <object object_ref="oval:org.mitre.oval:obj:911" />
   <state state_ref="oval:org.mitre.oval:ste:33794" />
 </registry_test>

--- a/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122564.xml
+++ b/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122564.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Inkscape is installed" id="oval:org.mitre.oval:tst:122564" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:24170" />
+  <object object_ref="oval:org.mitre.oval:obj:911" />
   <state state_ref="oval:org.mitre.oval:ste:33939" />
 </registry_test>

--- a/repository/tests/windows/registry_test/81000/oval_org.mitre.oval_tst_81276.xml
+++ b/repository/tests/windows/registry_test/81000/oval_org.mitre.oval_tst_81276.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="VMware View is installed" id="oval:org.mitre.oval:tst:81276" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:24170" />
+  <object object_ref="oval:org.mitre.oval:obj:911" />
   <state state_ref="oval:org.mitre.oval:ste:20962" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:24170](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:24170) and [oval:org.mitre.oval:obj:911](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:911) are duplicates. [oval:org.mitre.oval:obj:911](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:911) was taken as a basic.