### PR TITLE
Kemanik duplicate obj 23760

### DIFF
--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23760.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23760.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Registry key for HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\.*!DisplayName (windows_view='32_bit')" id="oval:org.mitre.oval:obj:23760" version="2">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Registry key for HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\.*!DisplayName (windows_view='32_bit')" id="oval:org.mitre.oval:obj:23760" deprecated="true" version="2">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="pattern match">^SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\.*$</key>

--- a/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122130.xml
+++ b/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122130.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Audition is installed" id="oval:org.mitre.oval:tst:122130" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23760" />
+  <object object_ref="oval:org.mitre.oval:obj:41329" />
   <state state_ref="oval:org.mitre.oval:ste:33319" />
 </registry_test>

--- a/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122590.xml
+++ b/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122590.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Illustrator is installed" id="oval:org.mitre.oval:tst:122590" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23760" />
+  <object object_ref="oval:org.mitre.oval:obj:41329" />
   <state state_ref="oval:org.mitre.oval:ste:33446" />
 </registry_test>

--- a/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122660.xml
+++ b/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122660.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Google SketchUp is installed" id="oval:org.mitre.oval:tst:122660" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23760" />
+  <object object_ref="oval:org.mitre.oval:obj:41329" />
   <state state_ref="oval:org.mitre.oval:ste:33846" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:23760](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23760) and [oval:org.mitre.oval:obj:41329](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:41329) are duplicates. [oval:org.mitre.oval:obj:41329](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:41329) was taken as a basic.