### PR TITLE
Kemanik duplicate obj 23674

### DIFF
--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23674.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23674.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds if Microsoft Office 2007 SP3 is installed" id="oval:org.mitre.oval:obj:23674" version="3">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds if Microsoft Office 2007 SP3 is installed" id="oval:org.mitre.oval:obj:23674" deprecated="true" version="3">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="pattern match">^SOFTWARE\\Microsoft\\Office\\12\.0\\Registration\\\{[0-9a-zA-Z]{2}12[0-9]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[01]000-0000000FF1CE\}$</key>

--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23755.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23755.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds if Office 2007 SP2 is installed" id="oval:org.mitre.oval:obj:23755" version="3">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry holds if Office 2007 SP is installed" id="oval:org.mitre.oval:obj:23755" version="3">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="pattern match">^SOFTWARE\\Microsoft\\Office\\12\.0\\Registration\\\{[0-9a-zA-Z]{2}12[0-9]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[01]000-0000000FF1CE\}$</key>

--- a/repository/tests/windows/registry_test/79000/oval_org.mitre.oval_tst_79673.xml
+++ b/repository/tests/windows/registry_test/79000/oval_org.mitre.oval_tst_79673.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Microsoft Office products 2007 SP3 is installed" id="oval:org.mitre.oval:tst:79673" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:23674" />
+  <object object_ref="oval:org.mitre.oval:obj:23755" />
   <state state_ref="oval:org.mitre.oval:ste:19903" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:23674](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23674) and [oval:org.mitre.oval:obj:23755](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23755) are duplicates. [oval:org.mitre.oval:obj:23755](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23755) was taken as a basic.
The comment was changed in [oval:org.mitre.oval:obj:23755](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23755) because the object is universal.