### PR TITLE
Kemanik duplicate obj 23700

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_15395.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_15395.xml
@@ -49,7 +49,7 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria>
-    <oval-def:criterion comment="SQL Reporting Services exist" test_ref="oval:org.mitre.oval:tst:113660" />
+    <oval-def:criterion comment="Check if HKLM\SOFTWARE\Microsoft\Microsoft SQL Server\.*\Setup!SQLPath exists" test_ref="oval:org.mitre.oval:tst:138262" />
     <oval-def:criteria comment="Check for vulnerable SQL" operator="OR">
       <oval-def:criteria comment="Check for vulnerable SQL 2000 Reporting Services" operator="AND">
         <oval-def:extend_definition comment="Microsoft SQL Server 2000 Reporting Services SP2 is installed" definition_ref="oval:org.mitre.oval:def:15635" />

--- a/repository/objects/windows/file_object/15000/oval_org.mitre.oval_obj_15928.xml
+++ b/repository/objects/windows/file_object/15000/oval_org.mitre.oval_obj_15928.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="SQL Server 2008 - sqlservr.exe" id="oval:org.mitre.oval:obj:15928" version="3">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="SQL Server 2008 - sqlservr.exe" id="oval:org.mitre.oval:obj:15928" deprecated="true" version="3">
   <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1317" />
   <filename>sqlservr.exe</filename>
 </file_object>

--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23700.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23700.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds registry key for SQL Reporting Services" id="oval:org.mitre.oval:obj:23700" version="2">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds registry key for SQL Reporting Services" id="oval:org.mitre.oval:obj:23700" deprecated="true" version="2">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key operation="pattern match">^SOFTWARE\\Microsoft\\Microsoft SQL Server\\.*\\Setup$</key>
   <name>SQLPath</name>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42279.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42279.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Sqlservr.exe is less than 2009.100.1617.0" id="oval:org.mitre.oval:tst:42279" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:15928" />
+  <object object_ref="oval:org.mitre.oval:obj:12081" />
   <state state_ref="oval:org.mitre.oval:ste:12567" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42606.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42606.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Sqlservr.exe is greater than or equal to 2007.100.4300.0" id="oval:org.mitre.oval:tst:42606" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:15928" />
+  <object object_ref="oval:org.mitre.oval:obj:12081" />
   <state state_ref="oval:org.mitre.oval:ste:12731" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42788.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42788.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Sqlservr.exe is less than 2007.100.4311.0" id="oval:org.mitre.oval:tst:42788" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:15928" />
+  <object object_ref="oval:org.mitre.oval:obj:12081" />
   <state state_ref="oval:org.mitre.oval:ste:12790" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42843.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42843.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Sqlservr.exe is less than 2007.100.2573.0" id="oval:org.mitre.oval:tst:42843" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:15928" />
+  <object object_ref="oval:org.mitre.oval:obj:12081" />
   <state state_ref="oval:org.mitre.oval:ste:12068" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42847.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42847.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Sqlservr.exe is less than 2007.100.4064.0" id="oval:org.mitre.oval:tst:42847" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:15928" />
+  <object object_ref="oval:org.mitre.oval:obj:12081" />
   <state state_ref="oval:org.mitre.oval:ste:12796" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42890.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42890.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Sqlservr.exe is less than 2007.100.2841.0" id="oval:org.mitre.oval:tst:42890" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:15928" />
+  <object object_ref="oval:org.mitre.oval:obj:12081" />
   <state state_ref="oval:org.mitre.oval:ste:12305" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42904.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42904.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Sqlservr.exe is greater than or equal to 2007.100.2800.0" id="oval:org.mitre.oval:tst:42904" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:15928" />
+  <object object_ref="oval:org.mitre.oval:obj:12081" />
   <state state_ref="oval:org.mitre.oval:ste:12311" />
 </file_test>

--- a/repository/tests/windows/file_test/99000/oval_org.mitre.oval_tst_99706.xml
+++ b/repository/tests/windows/file_test/99000/oval_org.mitre.oval_tst_99706.xml
@@ -1,5 +1,5 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Sqlservr.exe is greater than or equal to 2009.100.1700.0 and less than 2009.100.1790.0" id="oval:org.mitre.oval:tst:99706" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15928" />
+  <object object_ref="oval:org.mitre.oval:obj:12081" />
   <state state_ref="oval:org.mitre.oval:ste:12500" />
   <state state_ref="oval:org.mitre.oval:ste:12173" />
 </file_test>

--- a/repository/tests/windows/registry_test/113000/oval_org.mitre.oval_tst_113660.xml
+++ b/repository/tests/windows/registry_test/113000/oval_org.mitre.oval_tst_113660.xml
@@ -1,3 +1,3 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="SQL Reporting Services exist" id="oval:org.mitre.oval:tst:113660" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="SQL Reporting Services exist" id="oval:org.mitre.oval:tst:113660" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23700" />
 </registry_test>

--- a/repository/variables/oval_org.mitre.oval_var_1317.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1317.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="MS SQL Server 2008 instance directories" datatype="string" id="oval:org.mitre.oval:var:1317" version="2">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="MS SQL Server 2008 instance directories" datatype="string" id="oval:org.mitre.oval:var:1317" deprecated="true" version="2">
   <oval-def:concat>
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:12103" />
     <oval-def:literal_component>\Binn</oval-def:literal_component>

--- a/repository/variables/oval_org.mitre.oval_var_1508.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1508.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Var holds SQL Report Server directory path" datatype="string" id="oval:org.mitre.oval:var:1508" version="2">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23700" />
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:12103" />
     <oval-def:literal_component>ReportServer\Bin</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>

--- a/repository/variables/oval_org.mitre.oval_var_678.xml
+++ b/repository/variables/oval_org.mitre.oval_var_678.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="MS SQL Server 2005 instance directories" datatype="string" id="oval:org.mitre.oval:var:678" version="2">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="MS SQL Server instance directories" datatype="string" id="oval:org.mitre.oval:var:678" version="2">
   <oval-def:concat>
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:12103" />
     <oval-def:literal_component>\Binn</oval-def:literal_component>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:23700](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23700) and [oval:org.mitre.oval:obj:12103](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:12103) are duplicates. [oval:org.mitre.oval:obj:12103](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:12103) was taken as a basic.
[oval:org.mitre.oval:tst:113660](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:113660) and [oval:org.mitre.oval:tst:138262](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:138262) are duplicates. [oval:org.mitre.oval:tst:138262](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:138262) was taken as a basic.
[oval:org.mitre.oval:obj:15928](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15928) and [oval:org.mitre.oval:obj:12081](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:12081) are duplicates. [oval:org.mitre.oval:obj:12081](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:12081) was taken as a basic.
The comment in [oval:org.mitre.oval:var:678](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:var:678) was changed because the variable is universal