### PR TITLE
Update oval_org.mitre.oval_obj_292.xml

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_292.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_292.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:292" version="3">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:292" version="3" comment="grpconv.exe (syswow64)">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:202" />
-  <filename>shell32.dll</filename>
+  <filename>grpconv.exe</filename>
 </file_object>


### PR DESCRIPTION
Filename was changed from shell32.dll to grpconv.exe because [oval:org.mitre.oval:obj:292](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:292) is used in tests that are checking the version of grpconv.exe file.