### PR TITLE
Kemanik duplicate obj 6945

### DIFF
--- a/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6089.xml
+++ b/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6089.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6089" version="3">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6089" comment="Full path to xlview.exe" version="3">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:107" />
   <filename>XLVIEW.EXE</filename>
 </file_object>

--- a/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6945.xml
+++ b/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6945.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Full path to xlview.exe" id="oval:org.mitre.oval:obj:6945" version="3">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Full path to xlview.exe" id="oval:org.mitre.oval:obj:6945" version="3" deprecated="true">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:107" />
   <filename>xlview.exe</filename>
 </file_object>

--- a/repository/tests/windows/file_test/44000/oval_org.mitre.oval_tst_44309.xml
+++ b/repository/tests/windows/file_test/44000/oval_org.mitre.oval_tst_44309.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of xlview.exe is less than 11.0.8202.0" id="oval:org.mitre.oval:tst:44309" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:6945" />
+  <object object_ref="oval:org.mitre.oval:obj:6089" />
   <state state_ref="oval:org.mitre.oval:ste:3191" />
 </file_test>

--- a/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9880.xml
+++ b/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9880.xml
@@ -1,3 +1,3 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="%ProgramFile%\Microsoft Office\OFFICE11\xlview.exe exists" id="oval:org.mitre.oval:tst:9880" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:6945" />
+  <object object_ref="oval:org.mitre.oval:obj:6089" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:6945](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6945) and [oval:org.mitre.oval:obj:6089](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6089) are duplicates. The object [oval:org.mitre.oval:obj:6089](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6089) was taken as a basic because it used in larger number of tests. The second object should be deprecated.