### PR TITLE
Oval submission for IBM AIX 6.1 and 7.1

### DIFF
--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160101.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160101.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160101" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4844" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4844" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the 2D component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160102.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160102.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160102" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4843" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4843" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the Libraries component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160103.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160103.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160103" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4805" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4805" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the Serialization component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160104.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160104.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160104" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4860" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4860" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the RMI component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160105.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160105.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160105" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4883" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4883" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the RMI component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160106.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160106.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160106" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4835" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4835" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the CORBA component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160107.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160107.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160107" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4810" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4810" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the Deployment component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160108.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160108.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160108" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4806" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4806" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the Libraries component has partial confidentiality impact, partial integrity impact, and no availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160109.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160109.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160109" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4871" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4871" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the Libraries component has partial confidentiality impact, partial integrity impact, and no availability impact</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160110.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160110.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160110" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4902" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4902" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the Deployment component has no confidentiality impact, partial integrity impact, and no availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160111.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160111.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160111" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4872" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4872" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the Security component has no confidentiality impact, partial integrity impact, and no availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160112.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160112.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160112" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4911" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4911" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the JAXP component could allow a remote attacker to cause a denial of service.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160113.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160113.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160113" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4893" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4893" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the JAXP component could allow a remote attacker to cause a denial of service.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160114.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160114.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160114" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4840" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4840" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the 2D component could allow a remote attacker to obtain sensitive information.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160115.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160115.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160115" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4842" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4842" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the JAXP component could allow a remote attacker to obtain sensitive information.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160116.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160116.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160116" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4882" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4882" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the CORBA component could allow a remote attacker to cause a denial of service.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160117.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160117.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160117" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4903" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4903" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the RMI component could allow a remote attacker to obtain sensitive information.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160118.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160118.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160118" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4803" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4803" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the JAXP component could allow a remote attacker to cause a denial of service.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160119.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160119.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160119" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-4734" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4734" source="CVE" />
+    <oval-def:description>An unspecified vulnerability related to the JGSS component could allow a remote attacker to obtain sensitive information.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160120.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160120.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160120" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-5006" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5006" source="CVE" />
+    <oval-def:description>IBM Java Security Components could allow an attacker with physical access to the system to obtain sensitive information from the Kerberos Credential Cache.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java5.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160101" />
+      <oval-def:criterion comment="Java5_64.sdk less than 5.0.0.620" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.510" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.270" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.150" test_ref="oval:com.hp.temp.oval:tst:20160108" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160109" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.70" test_ref="oval:com.hp.temp.oval:tst:20160110" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/objects/aix/fileset_object/20160000/oval_com.hp.temp.oval_obj_20160101.xml
+++ b/repository/objects/aix/fileset_object/20160000/oval_com.hp.temp.oval_obj_20160101.xml
@@ -1,0 +1,3 @@
+<fileset_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:obj:20160101" version="0">
+  <flstinst>Java8.sdk</flstinst>
+</fileset_object>

--- a/repository/objects/aix/fileset_object/20160000/oval_com.hp.temp.oval_obj_20160102.xml
+++ b/repository/objects/aix/fileset_object/20160000/oval_com.hp.temp.oval_obj_20160102.xml
@@ -1,0 +1,3 @@
+<fileset_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:obj:20160102" version="0">
+  <flstinst>Java8_64.sdk</flstinst>
+</fileset_object>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160101.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160101.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160101" version="0">
+  <level datatype="version" operation="less than">5.0.0.620</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160102.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160102.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160102" version="0">
+  <level datatype="version" operation="less than">6.0.0.510</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160103.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160103.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160103" version="0">
+  <level datatype="version" operation="less than">7.0.0.270</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160104.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160104.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160104" version="0">
+  <level datatype="version" operation="less than">7.1.0.150</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160105.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160105.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160105" version="0">
+  <level datatype="version" operation="less than">8.0.0.70</level>
+</fileset_state>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160101.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160101.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java5.sdk less than 5.0.0.620" id="oval:com.hp.temp.oval:tst:20160101" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43579" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160101" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160102.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160102.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java5_64.sdk less than 5.0.0.620" id="oval:com.hp.temp.oval:tst:20160102" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43957" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160101" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160103.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160103.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java6.sdk less than 6.0.0.510" id="oval:com.hp.temp.oval:tst:20160103" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43277" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160102" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160104.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160104.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java6_64.sdk less than 6.0.0.510" id="oval:com.hp.temp.oval:tst:20160104" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43965" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160102" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160105.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160105.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java7.sdk less than 7.0.0.270" id="oval:com.hp.temp.oval:tst:20160105" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43113" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160103" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160106.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160106.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java7_64.sdk less than 7.0.0.270" id="oval:com.hp.temp.oval:tst:20160106" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43946" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160103" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160107.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160107.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java71.sdk less than 7.1.0.150" id="oval:com.hp.temp.oval:tst:20160107" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43787" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160104" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160108.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160108.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java71_64.sdk less than 7.1.0.150" id="oval:com.hp.temp.oval:tst:20160108" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:44036" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160104" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160109.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160109.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java8.sdk less than 8.0.0.70" id="oval:com.hp.temp.oval:tst:20160109" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20160101" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160105" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160110.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160110.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java8_64.sdk less than 8.0.0.70" id="oval:com.hp.temp.oval:tst:20160110" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20160102" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160105" />
+</fileset_test>


### PR DESCRIPTION
Oval submission for IBM AIX 6.1 and 7.1 for multiple 'IBM Java SDK' vulnerabilities