### PR TITLE
Kemanik duplicate obj 453

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_453.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_453.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:453" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:453" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>Umandlg.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_532.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_532.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Umandlg.dll is less than 1.0.0.5" id="oval:org.mitre.oval:tst:532" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:453" />
+  <object object_ref="oval:org.mitre.oval:obj:870" />
   <state state_ref="oval:org.mitre.oval:ste:484" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:453](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:453) and [oval:org.mitre.oval:obj:870](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:870) are duplicates. The object [oval:org.mitre.oval:obj:870](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:870) was taken as a basic. [oval:org.mitre.oval:obj:453](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:453)  should be deprecated.