### PR TITLE
Kemanik duplicate obj 454

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_454.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_454.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:454" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:454" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>Sp3res.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_533.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_533.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Sp3res.dll is less than 5.0.2195.6928" id="oval:org.mitre.oval:tst:533" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:454" />
+  <object object_ref="oval:org.mitre.oval:obj:1494" />
   <state state_ref="oval:org.mitre.oval:ste:485" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:454](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:454) and [oval:org.mitre.oval:obj:1494](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:1494) are duplicates. The object [oval:org.mitre.oval:obj:1494](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:1494) was taken as a basic. [oval:org.mitre.oval:obj:454](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:454) should be deprecated.