### PR TITLE
Kemanik duplicate obj 633

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_633.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_633.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:633" version="2">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:633" deprecated="true" version="2">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>Ntkrnlpa.exe</filename>
 </file_object>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_839.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_839.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Ntkrnlpa.exe is less than 5.0.2195.7071" id="oval:org.mitre.oval:tst:839" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:633" />
+  <object object_ref="oval:org.mitre.oval:obj:6635" />
   <state state_ref="oval:org.mitre.oval:ste:752" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:633](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:633) and [oval:org.mitre.oval:obj:6635](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6635) are duplicates. [oval:org.mitre.oval:obj:6635](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6635) was taken as a basic. [oval:org.mitre.oval:obj:633](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:633) should be deprecated.