### PR TITLE
Kemanik duplicate obj 527

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_527.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_527.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:527" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:527" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>wmp.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_658.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_658.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of wmp.dll is less than 10.0.0.3704" id="oval:org.mitre.oval:tst:658" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:527" />
+  <object object_ref="oval:org.mitre.oval:obj:592" />
   <state state_ref="oval:org.mitre.oval:ste:590" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_706.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_706.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of wmp.dll is less than 9.0.0.3349" id="oval:org.mitre.oval:tst:706" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:527" />
+  <object object_ref="oval:org.mitre.oval:obj:592" />
   <state state_ref="oval:org.mitre.oval:ste:633" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_754.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_754.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of wmp.dll is less than 10.0.0.4036" id="oval:org.mitre.oval:tst:754" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:527" />
+  <object object_ref="oval:org.mitre.oval:obj:592" />
   <state state_ref="oval:org.mitre.oval:ste:679" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.mitre.oval_tst_1003.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.mitre.oval_tst_1003.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of wmp.dll is les than 9.0.0.3250" id="oval:org.mitre.oval:tst:1003" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:527" />
+  <object object_ref="oval:org.mitre.oval:obj:592" />
   <state state_ref="oval:org.mitre.oval:ste:894" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:527](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:527) and [oval:org.mitre.oval:obj:592](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:592) are duplicates. The object [oval:org.mitre.oval:obj:592](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:592) was taken as basic. [oval:org.mitre.oval:obj:527](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:527)  should be deprecated.