### PR TITLE
Kemanik duplicate obj 558

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_558.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_558.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:558" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:558" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>wmpui.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_711.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_711.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of wmpui.dll is less than 8.0.0.4496" id="oval:org.mitre.oval:tst:711" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:558" />
+  <object object_ref="oval:org.mitre.oval:obj:639" />
   <state state_ref="oval:org.mitre.oval:ste:637" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.mitre.oval_tst_1065.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.mitre.oval_tst_1065.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of wmpui.dll is less than 7.10.0.3076" id="oval:org.mitre.oval:tst:1065" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:558" />
+  <object object_ref="oval:org.mitre.oval:obj:639" />
   <state state_ref="oval:org.mitre.oval:ste:951" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:558](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:558) and [oval:org.mitre.oval:obj:639](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:639) are duplicates. The object [oval:org.mitre.oval:obj:639](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:639) was taken as basic. [oval:org.mitre.oval:obj:558](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:558) should be deprecated.