### PR TITLE
Kemanik duplicate obj 6360

### DIFF
--- a/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6360.xml
+++ b/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6360.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6360" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6360" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>Win32k.sys</filename>
 </file_object>

--- a/repository/tests/windows/file_test/8000/oval_org.mitre.oval_tst_8907.xml
+++ b/repository/tests/windows/file_test/8000/oval_org.mitre.oval_tst_8907.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="The version of Win32k.sys is less than 5.1.2600.2622" id="oval:org.mitre.oval:tst:8907" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:6360" />
+  <object object_ref="oval:org.mitre.oval:obj:570" />
   <state state_ref="oval:org.mitre.oval:ste:2559" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:6360](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6360) and [oval:org.mitre.oval:obj:570](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:570) are duplicates. The object [oval:org.mitre.oval:obj:570](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:570) was taken as basic. [oval:org.mitre.oval:obj:6360](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6360) should be deprecated.