### PR TITLE
Kemanik duplicate obj 1599

### DIFF
--- a/repository/objects/windows/file_object/1000/oval_org.mitre.oval_obj_1599.xml
+++ b/repository/objects/windows/file_object/1000/oval_org.mitre.oval_obj_1599.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1599" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1599" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>quartz.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/2000/oval_org.mitre.oval_tst_2788.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.mitre.oval_tst_2788.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of quartz.dll is less than 6.1.5.132" id="oval:org.mitre.oval:tst:2788" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1599" />
+  <object object_ref="oval:org.mitre.oval:obj:704" />
   <state state_ref="oval:org.mitre.oval:ste:2609" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:1599](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:1599) and [oval:org.mitre.oval:obj:704](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:704)  are duplicates. The object [oval:org.mitre.oval:obj:704](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:704) was taken as basic. [oval:org.mitre.oval:obj:1599](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:1599) should be deprecated.