### PR TITLE
Update oval_org.mitre.oval_tst_122170.xml

### DIFF
--- a/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122170.xml
+++ b/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122170.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe ColdFusion is installed" id="oval:org.mitre.oval:tst:122170" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:42057" />
+  <object object_ref="oval:org.mitre.oval:obj:911" />
   <state state_ref="oval:org.mitre.oval:ste:33761" />
 </registry_test>


### PR DESCRIPTION
The object [oval:org.mitre.oval:obj:42057](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:42057) was replased with [oval:org.mitre.oval:obj:911](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:911) because the directory HKEY_LOCAL_MACHINE\ Software\Microsoft\Windows\CurrentVersion\Uninstall\Uninstall Adobe ColdFusion does not match the old object's pattern.