### PR TITLE
kemanik-dpkg-duplicates-3

### DIFF
--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_128.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_128.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="ppp is earlier than 0:2.4.5-5.1+deb7u2" id="oval:org.cisecurity:tst:128" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:43060" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="ppp is earlier than 0:2.4.5-5.1+deb7u2" id="oval:org.cisecurity:tst:128" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:43278" />
   <state state_ref="oval:org.cisecurity:ste:275" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_128.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_128.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="ppp is earlier than 0:2.4.5-5.1+deb7u2" id="oval:org.cisecurity:tst:128" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="ppp is earlier than 0:2.4.5-5.1+deb7u2" id="oval:org.cisecurity:tst:128" version="1">
   <object object_ref="oval:org.mitre.oval:obj:43278" />
   <state state_ref="oval:org.cisecurity:ste:275" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_139.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_139.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u4" id="oval:org.cisecurity:tst:139" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23514" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u4" id="oval:org.cisecurity:tst:139" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:140" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_139.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_139.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u4" id="oval:org.cisecurity:tst:139" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u4" id="oval:org.cisecurity:tst:139" version="1">
   <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:140" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_153.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_153.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="vlc is earlier than 0:2.0.3-5+deb7u2" id="oval:org.cisecurity:tst:153" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="vlc is earlier than 0:2.0.3-5+deb7u2" id="oval:org.cisecurity:tst:153" version="1">
   <object object_ref="oval:org.mitre.oval:obj:10387" />
   <state state_ref="oval:org.cisecurity:ste:107" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_153.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_153.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="vlc is earlier than 0:2.0.3-5+deb7u2" id="oval:org.cisecurity:tst:153" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:11141" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="vlc is earlier than 0:2.0.3-5+deb7u2" id="oval:org.cisecurity:tst:153" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:10387" />
   <state state_ref="oval:org.cisecurity:ste:107" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_159.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_159.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u8" id="oval:org.cisecurity:tst:159" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23514" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u8" id="oval:org.cisecurity:tst:159" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:185" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_159.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_159.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u8" id="oval:org.cisecurity:tst:159" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u8" id="oval:org.cisecurity:tst:159" version="1">
   <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:185" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_207.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_207.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="nbd is earlier than 1:3.8-4+deb8u1" id="oval:org.cisecurity:tst:207" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="nbd is earlier than 1:3.8-4+deb8u1" id="oval:org.cisecurity:tst:207" version="1">
   <object object_ref="oval:org.mitre.oval:obj:28493" />
   <state state_ref="oval:org.cisecurity:ste:340" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_207.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_207.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="nbd is earlier than 1:3.8-4+deb8u1" id="oval:org.cisecurity:tst:207" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15706" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="nbd is earlier than 1:3.8-4+deb8u1" id="oval:org.cisecurity:tst:207" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:28493" />
   <state state_ref="oval:org.cisecurity:ste:340" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_229.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_229.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u6" id="oval:org.cisecurity:tst:229" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23514" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u6" id="oval:org.cisecurity:tst:229" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:64" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_229.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_229.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u6" id="oval:org.cisecurity:tst:229" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u6" id="oval:org.cisecurity:tst:229" version="1">
   <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:64" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_238.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_238.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="nbd is earlier than 1:3.2-4~deb7u5" id="oval:org.cisecurity:tst:238" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="nbd is earlier than 1:3.2-4~deb7u5" id="oval:org.cisecurity:tst:238" version="1">
   <object object_ref="oval:org.mitre.oval:obj:28493" />
   <state state_ref="oval:org.cisecurity:ste:337" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_238.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_238.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="nbd is earlier than 1:3.2-4~deb7u5" id="oval:org.cisecurity:tst:238" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15706" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="nbd is earlier than 1:3.2-4~deb7u5" id="oval:org.cisecurity:tst:238" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:28493" />
   <state state_ref="oval:org.cisecurity:ste:337" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_24.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_24.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="sympa is earlier than 0:6.1.11~dfsg-5+deb7u2" id="oval:org.cisecurity:tst:24" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:11203" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="sympa is earlier than 0:6.1.11~dfsg-5+deb7u2" id="oval:org.cisecurity:tst:24" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:25859" />
   <state state_ref="oval:org.cisecurity:ste:169" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_24.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_24.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="sympa is earlier than 0:6.1.11~dfsg-5+deb7u2" id="oval:org.cisecurity:tst:24" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="sympa is earlier than 0:6.1.11~dfsg-5+deb7u2" id="oval:org.cisecurity:tst:24" version="1">
   <object object_ref="oval:org.mitre.oval:obj:25859" />
   <state state_ref="oval:org.cisecurity:ste:169" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_241.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_241.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="libtasn1-3 is earlier than 0:2.13-2+deb7u2" id="oval:org.cisecurity:tst:241" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="libtasn1-3 is earlier than 0:2.13-2+deb7u2" id="oval:org.cisecurity:tst:241" version="1">
   <object object_ref="oval:org.mitre.oval:obj:25399" />
   <state state_ref="oval:org.cisecurity:ste:315" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_241.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_241.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="libtasn1-3 is earlier than 0:2.13-2+deb7u2" id="oval:org.cisecurity:tst:241" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23348" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="libtasn1-3 is earlier than 0:2.13-2+deb7u2" id="oval:org.cisecurity:tst:241" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:25399" />
   <state state_ref="oval:org.cisecurity:ste:315" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_253.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_253.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.4.1-9+deb8u1" id="oval:org.cisecurity:tst:253" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.4.1-9+deb8u1" id="oval:org.cisecurity:tst:253" version="1">
   <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:308" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_253.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_253.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.4.1-9+deb8u1" id="oval:org.cisecurity:tst:253" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23514" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.4.1-9+deb8u1" id="oval:org.cisecurity:tst:253" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:308" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_259.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_259.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="cups-filters is earlier than 0:1.0.18-2.1+deb7u2" id="oval:org.cisecurity:tst:259" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:38716" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="cups-filters is earlier than 0:1.0.18-2.1+deb7u2" id="oval:org.cisecurity:tst:259" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:38610" />
   <state state_ref="oval:org.cisecurity:ste:138" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_259.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_259.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="cups-filters is earlier than 0:1.0.18-2.1+deb7u2" id="oval:org.cisecurity:tst:259" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="cups-filters is earlier than 0:1.0.18-2.1+deb7u2" id="oval:org.cisecurity:tst:259" version="1">
   <object object_ref="oval:org.mitre.oval:obj:38610" />
   <state state_ref="oval:org.cisecurity:ste:138" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_266.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_266.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="unzip is earlier than 0:6.0-8+deb7u2" id="oval:org.cisecurity:tst:266" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="unzip is earlier than 0:6.0-8+deb7u2" id="oval:org.cisecurity:tst:266" version="1">
   <object object_ref="oval:org.mitre.oval:obj:24661" />
   <state state_ref="oval:org.cisecurity:ste:66" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_266.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_266.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="unzip is earlier than 0:6.0-8+deb7u2" id="oval:org.cisecurity:tst:266" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:11519" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="unzip is earlier than 0:6.0-8+deb7u2" id="oval:org.cisecurity:tst:266" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:24661" />
   <state state_ref="oval:org.cisecurity:ste:66" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_284.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_284.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="cups-filters is earlier than 0:1.0.61-5+deb8u1" id="oval:org.cisecurity:tst:284" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:38716" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="cups-filters is earlier than 0:1.0.61-5+deb8u1" id="oval:org.cisecurity:tst:284" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:38610" />
   <state state_ref="oval:org.cisecurity:ste:246" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_284.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_284.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="cups-filters is earlier than 0:1.0.61-5+deb8u1" id="oval:org.cisecurity:tst:284" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="cups-filters is earlier than 0:1.0.61-5+deb8u1" id="oval:org.cisecurity:tst:284" version="1">
   <object object_ref="oval:org.mitre.oval:obj:38610" />
   <state state_ref="oval:org.cisecurity:ste:246" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_304.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_304.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="krb5 is earlier than 0:1.10.1+dfsg-5+deb7u3" id="oval:org.cisecurity:tst:304" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="krb5 is earlier than 0:1.10.1+dfsg-5+deb7u3" id="oval:org.cisecurity:tst:304" version="1">
   <object object_ref="oval:org.mitre.oval:obj:26382" />
   <state state_ref="oval:org.cisecurity:ste:227" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_304.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_304.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="krb5 is earlier than 0:1.10.1+dfsg-5+deb7u3" id="oval:org.cisecurity:tst:304" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23470" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="krb5 is earlier than 0:1.10.1+dfsg-5+deb7u3" id="oval:org.cisecurity:tst:304" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:26382" />
   <state state_ref="oval:org.cisecurity:ste:227" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_330.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_330.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="vlc is earlier than 0:2.2.0~rc2-2+deb8u1" id="oval:org.cisecurity:tst:330" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:11141" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="vlc is earlier than 0:2.2.0~rc2-2+deb8u1" id="oval:org.cisecurity:tst:330" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:10387" />
   <state state_ref="oval:org.cisecurity:ste:44" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_330.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_330.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="vlc is earlier than 0:2.2.0~rc2-2+deb8u1" id="oval:org.cisecurity:tst:330" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="vlc is earlier than 0:2.2.0~rc2-2+deb8u1" id="oval:org.cisecurity:tst:330" version="1">
   <object object_ref="oval:org.mitre.oval:obj:10387" />
   <state state_ref="oval:org.cisecurity:ste:44" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_334.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_334.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="pdns-recursor is earlier than 0:3.6.2-2+deb8u2" id="oval:org.cisecurity:tst:334" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="pdns-recursor is earlier than 0:3.6.2-2+deb8u2" id="oval:org.cisecurity:tst:334" version="1">
   <object object_ref="oval:org.mitre.oval:obj:10433" />
   <state state_ref="oval:org.cisecurity:ste:174" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_334.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_334.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="pdns-recursor is earlier than 0:3.6.2-2+deb8u2" id="oval:org.cisecurity:tst:334" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:10384" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="pdns-recursor is earlier than 0:3.6.2-2+deb8u2" id="oval:org.cisecurity:tst:334" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:10433" />
   <state state_ref="oval:org.cisecurity:ste:174" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_343.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_343.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u5" id="oval:org.cisecurity:tst:343" version="2">
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u5" id="oval:org.cisecurity:tst:343" version="1">
   <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:269" />
 </dpkginfo_test>

--- a/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_343.xml
+++ b/repository/tests/linux/dpkginfo_test/0000/oval_org.cisecurity_tst_343.xml
@@ -1,4 +1,4 @@
-<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u5" id="oval:org.cisecurity:tst:343" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:23514" />
+<dpkginfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="xen is earlier than 0:4.1.4-3+deb7u5" id="oval:org.cisecurity:tst:343" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:28114" />
   <state state_ref="oval:org.cisecurity:ste:269" />
 </dpkginfo_test>


### PR DESCRIPTION
The last portion of dpkginfo_test duplicates. The objects were deprecated but were not replaced in some tests. Now all deprecated objects are not used.