### PR TITLE
Kemanik def 5875

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_5875.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_5875.xml
@@ -24,18 +24,7 @@
       <oval-def:min_schema_version>5.4</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criteria operator="OR">
-      <oval-def:extend_definition comment="Microsoft Windows 2000 is installed" definition_ref="oval:org.mitre.oval:def:85" />
-      <oval-def:extend_definition comment="Microsoft Windows XP (x86) SP2 is installed" definition_ref="oval:org.mitre.oval:def:754" />
-      <oval-def:extend_definition comment="Microsoft Windows XP (x86) SP3 is installed" definition_ref="oval:org.mitre.oval:def:5631" />
-      <oval-def:extend_definition comment="Microsoft Windows Server 2003 SP1 (x86) is installed" definition_ref="oval:org.mitre.oval:def:565" />
-      <oval-def:extend_definition comment="Microsoft Windows Server 2003 SP2 (x86) is installed" definition_ref="oval:org.mitre.oval:def:1935" />
-      <oval-def:extend_definition comment="Microsoft Windows Vista (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:1282" />
-      <oval-def:extend_definition comment="Microsoft Windows Vista (32-bit) Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:4873" />
-      <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-      <oval-def:extend_definition comment="Microsoft Windows Server 2008 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:4870" />
-    </oval-def:criteria>
+  <oval-def:criteria>
     <oval-def:criterion comment="Rhino Software Serv-U is installed" test_ref="oval:org.mitre.oval:tst:11147" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11147.xml
+++ b/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11147.xml
@@ -1,3 +1,3 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Rhino Software Serv-U is installed" id="oval:org.mitre.oval:tst:11147" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:7251" />
+  <object object_ref="oval:org.mitre.oval:obj:7188" />
 </registry_test>


### PR DESCRIPTION
oval:org.mitre.oval:obj:7251 was replased with oval:org.mitre.oval:obj:7188 in oval:org.mitre.oval:tst:11147 because obj:7251 returned true after removing the application. Extended_definitions were removed from def:5875.