### PR TITLE
Kemanik tst 122660

### DIFF
--- a/repository/objects/windows/registry_object/41000/oval_org.mitre.oval_obj_41329.xml
+++ b/repository/objects/windows/registry_object/41000/oval_org.mitre.oval_obj_41329.xml
@@ -1,6 +1,6 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:41329" version="1">
   <behaviors windows_view="32_bit" />
-  <hive>HKEY_LOCAL_MACHINE</hive>
-  <key operation="pattern match">^Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\.*$</key>
-  <name>DisplayName</name>
+      <hive>HKEY_LOCAL_MACHINE</hive>
+      <key operation="pattern match">^SOFTWARE\\Google\\(Google )?SketchUp( \d+)?\\InstallLocation$</key>
+      <name />
 </registry_object>

--- a/repository/states/windows/registry_state/33000/oval_org.mitre.oval_ste_33846.xml
+++ b/repository/states/windows/registry_state/33000/oval_org.mitre.oval_ste_33846.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Google SketchUp is installed" id="oval:org.mitre.oval:ste:33846" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Google SketchUp is installed" id="oval:org.mitre.oval:ste:33846" deprecated="true" version="1">
   <value operation="pattern match">^(Google )?SketchUp.*$</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122660.xml
+++ b/repository/tests/windows/registry_test/122000/oval_org.mitre.oval_tst_122660.xml
@@ -1,4 +1,3 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Google SketchUp is installed" id="oval:org.mitre.oval:tst:122660" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23760" />
-  <state state_ref="oval:org.mitre.oval:ste:33846" />
 </registry_test>


### PR DESCRIPTION
The check in [oval:org.mitre.oval:tst:122660](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:122660) was changed on the easier one, without Uninstall branch checking. Now the branch ^HKEY_LOCAL_MACHINE\\SOFTWARE\\Google\\(Google )?SketchUp( \d+)?\\InstallLocation$ is checked in [oval:org.mitre.oval:obj:41329](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:41329). The state [oval:org.mitre.oval:ste:33846](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:33846) is not needed within the new checking.