### PR TITLE
Kemanik tst 122660

### DIFF
--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23760.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23760.xml
@@ -1,6 +1,6 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Registry key for HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\.*!DisplayName (windows_view='32_bit')" id="oval:org.mitre.oval:obj:23760" version="2">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Registry key for HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\.*!DisplayName (windows_view='32_bit')" id="oval:org.mitre.oval:obj:23760" version="3">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
-  <key operation="pattern match">^SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\.*$</key>
-  <name>DisplayName</name>
+  <key operation="pattern match">^SOFTWARE\\Google\\(Google )?SketchUp( \d+)?\\InstallLocation$</key>
+  <name />
 </registry_object>

--- a/repository/objects/windows/registry_object/41000/oval_org.mitre.oval_obj_41329.xml
+++ b/repository/objects/windows/registry_object/41000/oval_org.mitre.oval_obj_41329.xml
@@ -1,6 +1,6 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:41329" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:41329" version="2">
   <behaviors windows_view="32_bit" />
       <hive>HKEY_LOCAL_MACHINE</hive>
-      <key operation="pattern match">^SOFTWARE\\Google\\(Google )?SketchUp( \d+)?\\InstallLocation$</key>
-      <name />
+      <key operation="pattern match">^Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\.*$</key>
+      <name>DisplayName</name>
 </registry_object>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:23760](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23760) should be changed instead [oval:org.mitre.oval:obj:41329](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:41329) because [oval:org.mitre.oval:obj:23760](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23760) is used in [oval:org.mitre.oval:tst:122660](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:122660)