### PR TITLE
Oval submission for IBM AIX 6.1 and 7.1 (for January 2016)

### DIFF
--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160101.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160101.xml
@@ -1,0 +1,32 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160101" version="0">
+  <oval-def:metadata>
+    <oval-def:title>AIX Logjam Vulnerability</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-3194" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3194" source="CVE" />
+    <oval-def:description>OpenSSL allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via an RSA PSS ASN.1 signature that lacks a mask generation function parameter.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2014-11-05T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="filesets" operator="OR">
+      <oval-def:criteria comment="File Version Exists" operator="AND">
+        <oval-def:criterion comment="openssl.base greater than or equal 1.0.1.500" test_ref="oval:org.mitre.oval:tst:126498" />
+        <oval-def:criterion comment="openssl.base less than or equal 1.0.1.515" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+        <oval-def:criterion comment="Interim fix 101_ifix.151218 (vuid: 00F850C34C00121802123315) is installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160102.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160102.xml
@@ -1,0 +1,42 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160102" version="0">
+  <oval-def:metadata>
+    <oval-def:title>AIX Logjam Vulnerability</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-3195" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3195" source="CVE" />
+    <oval-def:description>The ASN1_TFLG_COMBINE implementation in OpenSSL mishandles errors caused by malformed X509_ATTRIBUTE data, which allows remote attackers to obtain sensitive information from process memory by triggering a decoding failure in a PKCS#7 or CMS application.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2014-11-05T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="filesets" operator="OR">
+      <oval-def:criteria comment="File Version Exists" operator="AND">
+        <oval-def:criterion comment="openssl.base greater than or equal 1.0.1.500" test_ref="oval:org.mitre.oval:tst:126498" />
+        <oval-def:criterion comment="openssl.base less than or equal 1.0.1.515" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+        <oval-def:criterion comment="Interim fix 101_ifix.151218 (vuid: 00F850C34C00121802123315) is installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="File Version Exists" operator="AND">
+        <oval-def:criterion comment="openssl.base greater than or equal 0.9.8.401" test_ref="oval:org.mitre.oval:tst:126501" />
+        <oval-def:criterion comment="openssl.base less than or equal 0.9.8.2506" test_ref="oval:com.hp.temp.oval:tst:20160104" />
+        <oval-def:criterion comment="Interim fix 098_ifix.151218 (vuid: 00F850C34C00121803122115) is installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20160105" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="File Version Exists" operator="AND">
+        <oval-def:criterion comment="openssl.base greater than or equal 12.9.8.1100" test_ref="oval:org.mitre.oval:tst:126325" />
+        <oval-def:criterion comment="openssl.base less than or equal 12.9.8.2506" test_ref="oval:com.hp.temp.oval:tst:20160106" />
+        <oval-def:criterion comment="Interim fix 1298_ifix.151218 (vuid: 00F850C34C00121803125215) is installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20160107" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160103.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160103.xml
@@ -1,0 +1,32 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160103" version="0">
+  <oval-def:metadata>
+    <oval-def:title>AIX Logjam Vulnerability</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-3196" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3196" source="CVE" />
+    <oval-def:description>OpenSSL when used for a multi-threaded client, writes the PSK identity hint to an incorrect data structure, which allows remote servers to cause a denial of service (race condition and double free) via a crafted ServerKeyExchange message.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2014-11-05T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="filesets" operator="OR">
+      <oval-def:criteria comment="File Version Exists" operator="AND">
+        <oval-def:criterion comment="openssl.base greater than or equal 1.0.1.500" test_ref="oval:org.mitre.oval:tst:126498" />
+        <oval-def:criterion comment="openssl.base less than or equal 1.0.1.515" test_ref="oval:com.hp.temp.oval:tst:20160103" />
+        <oval-def:criterion comment="Interim fix 101_ifix.151218 (vuid: 00F850C34C00121802123315) is installed" negate="true" test_ref="oval:com.hp.temp.oval:tst:20160102" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160101.xml
+++ b/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160101.xml
@@ -1,0 +1,3 @@
+<interim_fix_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:obj:20160101" version="0">
+  <vuid>00F850C34C00121803122115</vuid>
+</interim_fix_object>

--- a/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160102.xml
+++ b/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160102.xml
@@ -1,0 +1,3 @@
+<interim_fix_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:obj:20160102" version="0">
+  <vuid>00F850C34C00121802123315</vuid>
+</interim_fix_object>

--- a/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160103.xml
+++ b/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160103.xml
@@ -1,0 +1,3 @@
+<interim_fix_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:obj:20160103" version="0">
+  <vuid>00F850C34C00121803125215</vuid>
+</interim_fix_object>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160101.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160101.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160101" version="0">
+  <level datatype="version" operation="less than or equal">1.0.1.515</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160102.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160102.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160102" version="0">
+  <level datatype="version" operation="less than or equal">0.9.8.2506</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160103.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160103.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160103" version="0">
+  <level datatype="version" operation="less than or equal">12.9.8.2506</level>
+</fileset_state>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160103.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160103.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="openssl.base less than or equal 1.0.1.515" id="oval:com.hp.temp.oval:tst:20160103" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:42746" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160101" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160104.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160104.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="openssl.base less than or equal 0.9.8.2506" id="oval:com.hp.temp.oval:tst:20160104" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:42746" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160102" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160106.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160106.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="openssl.base less than or equal 12.9.8.2506" id="oval:com.hp.temp.oval:tst:20160106" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:42746" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160103" />
+</fileset_test>

--- a/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160102.xml
+++ b/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160102.xml
@@ -1,0 +1,4 @@
+<interim_fix_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Interim fix 101_ifix.151218 (vuid: 00F850C34C00121802123315) is installed" id="oval:com.hp.temp.oval:tst:20160102" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20160102" />
+  <state state_ref="oval:org.mitre.oval:ste:39185" />
+</interim_fix_test>

--- a/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160105.xml
+++ b/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160105.xml
@@ -1,0 +1,4 @@
+<interim_fix_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Interim fix 098_ifix.151218 (vuid: 00F850C34C00121803122115) is installed" id="oval:com.hp.temp.oval:tst:20160105" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20160101" />
+  <state state_ref="oval:org.mitre.oval:ste:39185" />
+</interim_fix_test>

--- a/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160107.xml
+++ b/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160107.xml
@@ -1,0 +1,4 @@
+<interim_fix_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Interim fix 1298_ifix.151218 (vuid: 00F850C34C00121803125215) is installed" id="oval:com.hp.temp.oval:tst:20160107" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20160103" />
+  <state state_ref="oval:org.mitre.oval:ste:39185" />
+</interim_fix_test>


### PR DESCRIPTION
Oval definitions added for CVE-2015-3194, CVE-2015-3195 and CVE-2015-3196