### PR TITLE
Update oval_org.mitre.oval_tst_114919.xml

### DIFF
--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114919.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114919.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Mozilla Firefox ESR is greater than or equal to 24.0" id="oval:org.mitre.oval:tst:114919" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:30278" />
+  <object object_ref="oval:org.mitre.oval:obj:30347" />
   <state state_ref="oval:org.mitre.oval:ste:31042" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:30278](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:30278) was replaced with [oval:org.mitre.oval:obj:30347](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:30347) because it checked thunderbird.exe instead firefox.exe