### PR TITLE
Update oval_org.mitre.oval_tst_138931.xml

### DIFF
--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138931.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138931.xml
@@ -1,5 +1,5 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows Movie Maker 2.1 is installed" id="oval:org.mitre.oval:tst:138931" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:11734" />
+  <object object_ref="oval:org.mitre.oval:obj:11944" />
   <state state_ref="oval:org.mitre.oval:ste:38952" />
   <state state_ref="oval:org.mitre.oval:ste:38461" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:11734](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:11734) was replaced with [oval:org.mitre.oval:obj:11944](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:11944) because moviemk.dll does not exist in Windows XP.