### PR TITLE
Update oval_org.mitre.oval_var_1887.xml

### DIFF
--- a/repository/variables/oval_org.mitre.oval_var_1887.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1887.xml
@@ -4,6 +4,6 @@
     <oval-def:escape_regex>
       <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:219" />
     </oval-def:escape_regex>
-    <oval-def:literal_component>\\winsxs\\(x86|amd64)_microsoft\.windows\.gdiplus_6595b64144ccf1df_.+$|\\WinSxS\\(x86|amd64)_Microsoft\.Windows\.GdiPlus_6595b64144ccf1df_.+$</oval-def:literal_component>
+    <oval-def:literal_component>\\winsxs\\(x86|amd64)_microsoft\.windows\.gdiplus_6595b64144ccf1df_.+$</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
Pattern expression has been simplified. The string after alternation symbol was excess.