### PR TITLE
Update oval_org.mitre.oval_var_1912.xml

### DIFF
--- a/repository/variables/oval_org.mitre.oval_var_1912.xml
+++ b/repository/variables/oval_org.mitre.oval_var_1912.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The Microsoft Visual Studio 2010 (32/64bit) ...Common7\IDE\ShellExtensions\Platform subdirectory" datatype="string" id="oval:org.mitre.oval:var:1912" version="1">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23379" />
-    <oval-def:literal_component>Common7\IDE\ShellExtensions\Platform</oval-def:literal_component>
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:7336" />
+    <oval-def:literal_component>ShellExtensions\Platform</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:23379](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23379) was replaced with [oval:org.mitre.oval:obj:7336](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7336) and literal_component "Common7\IDE\ShellExtensions\Platform
" was changed on "ShellExtensions\Platform" because this variable is not get path to AppenvStub.dll