### PR TITLE
Kemanik obj 23541

### DIFF
--- a/repository/objects/windows/registry_object/22000/oval_org.mitre.oval_obj_22598.xml
+++ b/repository/objects/windows/registry_object/22000/oval_org.mitre.oval_obj_22598.xml
@@ -1,6 +1,6 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Registry key specifying Service Pack for Microsoft Visual Studio 2010 (32bit view)" id="oval:org.mitre.oval:obj:22598" version="1">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
-  <key>SOFTWARE\Microsoft\DevDiv\VS\Servicing\10.0\vstscore</key>
+  <key>SOFTWARE\Microsoft\DevDiv\VS\Servicing\10.0</key>
   <name>SP</name>
 </registry_object>

--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23529.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23529.xml
@@ -1,5 +1,5 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Registry key specifying Service Pack for Microsoft Visual Studio 2010" id="oval:org.mitre.oval:obj:23529" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
-  <key>SOFTWARE\Microsoft\DevDiv\VS\Servicing\10.0\vstscore</key>
+  <key>SOFTWARE\Microsoft\DevDiv\VS\Servicing\10.0</key>
   <name>SP</name>
 </registry_object>

--- a/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23541.xml
+++ b/repository/objects/windows/registry_object/23000/oval_org.mitre.oval_obj_23541.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Visual Studio 2008 SP1 Registry" id="oval:org.mitre.oval:obj:23541" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Visual Studio 2010 SP Registry" id="oval:org.mitre.oval:obj:23541" version="1">
   <oval-def:set>
     <oval-def:object_reference>oval:org.mitre.oval:obj:22598</oval-def:object_reference>
     <oval-def:object_reference>oval:org.mitre.oval:obj:23529</oval-def:object_reference>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:23541](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23541) was changed. Registry path HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\VS\Servicing\10.0\vstscore!SP does not exist unlike HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\VS\Servicing\10.0!SP.