### PR TITLE
Update oval_org.mitre.oval_obj_7290.xml

### DIFF
--- a/repository/objects/windows/registry_object/7000/oval_org.mitre.oval_obj_7290.xml
+++ b/repository/objects/windows/registry_object/7000/oval_org.mitre.oval_obj_7290.xml
@@ -1,11 +1,6 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Registry that holds the versions of all Flash Player instances" id="oval:org.mitre.oval:obj:7290" version="4">
-  <oval-def:set>
     <oval-def:set>
       <oval-def:object_reference>oval:org.mitre.oval:obj:27479</oval-def:object_reference>
       <oval-def:object_reference>oval:org.mitre.oval:obj:27174</oval-def:object_reference>
     </oval-def:set>
-    <oval-def:set>
-      <oval-def:object_reference>oval:org.mitre.oval:obj:27426</oval-def:object_reference>
-    </oval-def:set>
-  </oval-def:set>
 </registry_object>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:27426](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:27426) was removed because there is standalone criterion for activeX component [oval:org.mitre.oval:obj:41861](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:41861) and version in registry could contain wrong old plugin version