### PR TITLE
Kemanik ste 18616

### DIFF
--- a/repository/states/windows/registry_state/12000/oval_org.mitre.oval_ste_12347.xml
+++ b/repository/states/windows/registry_state/12000/oval_org.mitre.oval_ste_12347.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:12347" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:12347" deprecated="true" version="1">
   <value datatype="version" operation="less than">10.50.1600.1</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/141000/oval_org.mitre.oval_tst_141117.xml
+++ b/repository/tests/windows/registry_test/141000/oval_org.mitre.oval_tst_141117.xml
@@ -1,4 +1,5 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if SQL Server 2008 SP4 is installed" id="oval:org.mitre.oval:tst:141117" version="1">
   <object object_ref="oval:org.mitre.oval:obj:11792" />
   <state state_ref="oval:org.mitre.oval:ste:39053" />
+  <state state_ref="oval:org.mitre.oval:ste:18616" />
 </registry_test>

--- a/repository/tests/windows/registry_test/42000/oval_org.mitre.oval_tst_42511.xml
+++ b/repository/tests/windows/registry_test/42000/oval_org.mitre.oval_tst_42511.xml
@@ -1,4 +1,4 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\100\DTS\Setup\\Version is less than 10.50.1600.1" id="oval:org.mitre.oval:tst:42511" version="1">
   <object object_ref="oval:org.mitre.oval:obj:15992" />
-  <state state_ref="oval:org.mitre.oval:ste:12347" />
+  <state state_ref="oval:org.mitre.oval:ste:18616" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:ste:18616](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:18616) and [oval:org.mitre.oval:ste:12347](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:12347) are duplicates. [oval:org.mitre.oval:ste:12347](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:12347) should be deprecated. [oval:org.mitre.oval:ste:18616](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:18616) was added into [oval:org.mitre.oval:tst:141117](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:141117) to avoid false positives when several versions of SQL Server are installed.