### PR TITLE
Update oval_org.mitre.oval_def_12267.xml

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_12267.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_12267.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:12267" version="3">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:12267" deprecated="true" version="3">
   <oval-def:metadata>
     <oval-def:title>Adobe ColdFusion is installed</oval-def:title>
     <oval-def:affected family="windows">


### PR DESCRIPTION
[oval:org.mitre.oval:def:12267](https://ovaldb.altx-soft.ru/Definition.aspx?id=oval:org.mitre.oval:def:12267) and [oval:org.mitre.oval:def:25976](https://ovaldb.altx-soft.ru/Definition.aspx?id=oval:org.mitre.oval:def:25976) are duplicates.[oval:org.mitre.oval:def:12267](https://ovaldb.altx-soft.ru/Definition.aspx?id=oval:org.mitre.oval:def:12267) should be deprecated because it does not check 32-bit branch.

<contributor organization="ALTX-SOFT">Maria Mikhno</contributor>