### PR TITLE
Kemanik obj 2184

### DIFF
--- a/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2184.xml
+++ b/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2184.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2184" version="3">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2184" deprecated="true" version="3">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:929" />
   <filename>excelcnv.exe</filename>
 </file_object>

--- a/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135691.xml
+++ b/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135691.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excelcnv.exe is less than 12.0.6713.5000" id="oval:org.mitre.oval:tst:135691" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:2184" />
+  <object object_ref="oval:org.mitre.oval:obj:5316" />
   <state state_ref="oval:org.mitre.oval:ste:37576" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138030.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138030.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excelcnv.exe is less than 12.0.6717.5000" id="oval:org.mitre.oval:tst:138030" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:2184" />
+  <object object_ref="oval:org.mitre.oval:obj:5316" />
   <state state_ref="oval:org.mitre.oval:ste:38349" />
 </file_test>

--- a/repository/tests/windows/file_test/140000/oval_org.mitre.oval_tst_140850.xml
+++ b/repository/tests/windows/file_test/140000/oval_org.mitre.oval_tst_140850.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excelcnv.exe is less than 12.0.6723.5000" id="oval:org.mitre.oval:tst:140850" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:2184" />
+  <object object_ref="oval:org.mitre.oval:obj:5316" />
   <state state_ref="oval:org.mitre.oval:ste:39472" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3531.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3531.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="excelcnv.exe is installed with a version less than 12.00.6014.5000" id="oval:org.mitre.oval:tst:3531" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:2184" />
+  <object object_ref="oval:org.mitre.oval:obj:5316" />
   <state state_ref="oval:org.mitre.oval:ste:3303" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3911.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3911.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of excelcnv.exe is less than 12.00.6024.5000" id="oval:org.mitre.oval:tst:3911" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:2184" />
+  <object object_ref="oval:org.mitre.oval:obj:5316" />
   <state state_ref="oval:org.mitre.oval:ste:3611" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86335.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86335.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excelcnv.exe is less than 12.0.6679.5000" id="oval:org.mitre.oval:tst:86335" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:2184" />
+  <object object_ref="oval:org.mitre.oval:obj:5316" />
   <state state_ref="oval:org.mitre.oval:ste:20522" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87032.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87032.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excelcnv.exe is less than 12.0.6683.5002" id="oval:org.mitre.oval:tst:87032" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:2184" />
+  <object object_ref="oval:org.mitre.oval:obj:5316" />
   <state state_ref="oval:org.mitre.oval:ste:23635" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:2184](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:2184) and [oval:org.mitre.oval:obj:5316](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:5316) are duplicates.[oval:org.mitre.oval:obj:5316](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:5316) was taken as a basic. [oval:org.mitre.oval:obj:2184](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:2184) should be deprecated