### PR TITLE
Kemanik .net framework 4

### DIFF
--- a/repository/states/windows/registry_state/7000/oval_org.mitre.oval_ste_7243.xml
+++ b/repository/states/windows/registry_state/7000/oval_org.mitre.oval_ste_7243.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:7243" version="1">
-  <value datatype="int">1</value>
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:7243" comment="The version is greater than or equal 4.0.30319" version="1">
+  <value datatype="version" operation="greater than or equal">4.0.30319</value>
 </registry_state>

--- a/repository/states/windows/registry_state/oval_ru.test.win_ste_1.xml
+++ b/repository/states/windows/registry_state/oval_ru.test.win_ste_1.xml
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.test.win:ste:1" comment="The version is less than 4.5" version="1">
+      <value datatype="version" operation="less than">4.5</value>
+    </registry_state>

--- a/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11277.xml
+++ b/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11277.xml
@@ -1,4 +1,5 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment=".NET Framework 4.0 Full version is installed" id="oval:org.mitre.oval:tst:11277" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7694" />
   <state state_ref="oval:org.mitre.oval:ste:7243" />
+  <state state_ref="oval:ru.test.win:ste:1" />
 </registry_test>

--- a/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11277.xml
+++ b/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11277.xml
@@ -1,5 +1,5 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment=".NET Framework 4.0 Full version is installed" id="oval:org.mitre.oval:tst:11277" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:7694" />
+  <object object_ref="oval:org.mitre.oval:obj:23715" />
   <state state_ref="oval:org.mitre.oval:ste:7243" />
   <state state_ref="oval:ru.test.win:ste:1" />
 </registry_test>

--- a/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11340.xml
+++ b/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11340.xml
@@ -1,4 +1,5 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment=".NET Framework 4.0 Client version is installed" id="oval:org.mitre.oval:tst:11340" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7614" />
   <state state_ref="oval:org.mitre.oval:ste:7243" />
+  <state state_ref="oval:ru.test.win:ste:1" />
 </registry_test>

--- a/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11340.xml
+++ b/repository/tests/windows/registry_test/11000/oval_org.mitre.oval_tst_11340.xml
@@ -1,5 +1,5 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment=".NET Framework 4.0 Client version is installed" id="oval:org.mitre.oval:tst:11340" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:7614" />
+  <object object_ref="oval:org.mitre.oval:obj:23764" />
   <state state_ref="oval:org.mitre.oval:ste:7243" />
   <state state_ref="oval:ru.test.win:ste:1" />
 </registry_test>


### PR DESCRIPTION
The parameter Version was checked Instead of the parameter Install to avoid the cases when inventories on .Net Framework 4.0 return true if .Net Framework 4.5 or greater is installed.
["The .NET Framework 4.5 and its point releases are built incrementally on the .NET Framework 4. When you install the .NET Framework 4.5, 4.5.1, 4.5.2, 4.6, or 4.6.1 on a system that has the .NET Framework 4 installed, the version 4 assemblies are replaced with newer versions."](https://msdn.microsoft.com/en-us/library/ee942965(v=vs.110).aspx)