### PR TITLE
Update oval_org.mitre.oval_var_88.xml

### DIFF
--- a/repository/variables/oval_org.mitre.oval_var_88.xml
+++ b/repository/variables/oval_org.mitre.oval_var_88.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Fullpath to psql.exe" datatype="string" id="oval:org.mitre.oval:var:88" version="1">
   <oval-def:concat>
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:7422" />
-    <oval-def:literal_component>bin</oval-def:literal_component>
+    <oval-def:literal_component>\bin</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
"\" was added because the file path was wrong ("C:\Program Files\PostgreSQL\9.1bin")