### PR TITLE
Kemanik mscomctl ocx

### DIFF
--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79815.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79815.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Mscomctl.Ocx version is less than 6.01.98.33" id="oval:org.mitre.oval:tst:79815" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:23554" />
+  <object object_ref="oval:org.mitre.oval:obj:39161" />
   <state state_ref="oval:org.mitre.oval:ste:19532" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80068.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80068.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mscomctl.ocx is less than 6.1.98.34" id="oval:org.mitre.oval:tst:80068" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:23554" />
+  <object object_ref="oval:org.mitre.oval:obj:39161" />
   <state state_ref="oval:org.mitre.oval:ste:19869" />
 </file_test>


### PR DESCRIPTION
The object [oval:org.mitre.oval:obj:23554](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:23554) was replaced with [oval:org.mitre.oval:obj:39161](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:39161) because it is more full.