### PR TITLE
Kemanik ms13 080

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_18665.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_18665.xml
@@ -2,12 +2,16 @@
   <oval-def:metadata>
     <oval-def:title>Internet Explorer Memory Corruption Vulnerability (CVE-2013-3893) - MS13-080</oval-def:title>
     <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
       <oval-def:platform>Microsoft Windows 7</oval-def:platform>
       <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
       <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
       <oval-def:platform>Microsoft Windows XP</oval-def:platform>
       <oval-def:product>Microsoft Internet Explorer 6</oval-def:product>
@@ -15,6 +19,7 @@
       <oval-def:product>Microsoft Internet Explorer 8</oval-def:product>
       <oval-def:product>Microsoft Internet Explorer 9</oval-def:product>
       <oval-def:product>Microsoft Internet Explorer 10</oval-def:product>
+      <oval-def:product>Microsoft Internet Explorer 11</oval-def:product>
     </oval-def:affected>
     <oval-def:reference ref_id="CVE-2013-3893" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-3893" source="CVE" />
     <oval-def:description>Use-after-free vulnerability in the SetMouseCapture implementation in mshtml.dll in Microsoft Internet Explorer 6 through 11 allows remote attackers to execute arbitrary code via crafted JavaScript strings, as demonstrated by use of an ms-help: URL that triggers loading of hxds.dll.</oval-def:description>
@@ -168,5 +173,14 @@
         </oval-def:criteria>
       </oval-def:criteria>
     </oval-def:criteria>
+    <criteria comment="IE 11 and vulnerable file version" operator="AND">
+          <extend_definition comment="Microsoft Internet Explorer 11 is installed" definition_ref="oval:org.mitre.oval:def:18343" />
+          <criteria operator="OR" comment="Win 8.1 / 2k12 R2 and vulnerable file version">
+            <extend_definition comment="Microsoft Windows 8.1 is installed" definition_ref="oval:org.mitre.oval:def:18863" />
+            <extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
+          </criteria>
+          <criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.16412" test_ref="oval:ru.test.win:tst:1" />
+        </criteria>
+      </criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_18989.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_18989.xml
@@ -2,12 +2,16 @@
   <oval-def:metadata>
     <oval-def:title>Internet Explorer Memory Corruption Vulnerability (CVE-2013-3897) - MS13-080</oval-def:title>
     <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
       <oval-def:platform>Microsoft Windows 7</oval-def:platform>
       <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
       <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
       <oval-def:platform>Microsoft Windows XP</oval-def:platform>
       <oval-def:product>Microsoft Internet Explorer 6</oval-def:product>
@@ -15,6 +19,7 @@
       <oval-def:product>Microsoft Internet Explorer 8</oval-def:product>
       <oval-def:product>Microsoft Internet Explorer 9</oval-def:product>
       <oval-def:product>Microsoft Internet Explorer 10</oval-def:product>
+      <oval-def:product>Microsoft Internet Explorer 11</oval-def:product>
     </oval-def:affected>
     <oval-def:reference ref_id="CVE-2013-3897" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-3897" source="CVE" />
     <oval-def:description>Use-after-free vulnerability in the CDisplayPointer class in mshtml.dll in Microsoft Internet Explorer 6 through 11 allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via crafted JavaScript code that uses the onpropertychange event handler, as exploited in the wild in September and October 2013, aka "Internet Explorer Memory Corruption Vulnerability."</oval-def:description>
@@ -167,5 +172,14 @@
         </oval-def:criteria>
       </oval-def:criteria>
     </oval-def:criteria>
+    <criteria comment="IE 11 and vulnerable file version" operator="AND">
+          <extend_definition comment="Microsoft Internet Explorer 11 is installed" definition_ref="oval:org.mitre.oval:def:18343" />
+          <criteria operator="OR" comment="Win 8.1 / 2k12 R2 and vulnerable file version">
+            <extend_definition comment="Microsoft Windows 8.1 is installed" definition_ref="oval:org.mitre.oval:def:18863" />
+            <extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
+          </criteria>
+          <criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.16412" test_ref="oval:ru.test.win:tst:1" />
+        </criteria>
+      </criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/states/windows/file_state/oval_ru.test.win_ste_1.xml
+++ b/repository/states/windows/file_state/oval_ru.test.win_ste_1.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.test.win:ste:1" version="1" comment="State holds if the version is less than 11.0.9600.16412">
+      <version datatype="version" operation="less than">11.0.9600.16412</version>
+    </file_state>

--- a/repository/tests/windows/file_test/oval_ru.test.win_tst_1.xml
+++ b/repository/tests/windows/file_test/oval_ru.test.win_tst_1.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mshtml.dll is less than 11.0.9600.16412" id="oval:ru.test.win:tst:1" version="1">
+      <object object_ref="oval:org.mitre.oval:obj:222" />
+      <state state_ref="oval:ru.test.win:ste:1" />
+    </file_test>


### PR DESCRIPTION
The criteria "IE 11 and vulnerable file version" was added in vulnerability definitions from [ms13-080](https://technet.microsoft.com/library/security/ms13-080)