### PR TITLE
Kemanik tst 87282

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_18488.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_18488.xml
@@ -125,7 +125,7 @@
         <oval-def:extend_definition comment="Microsoft Windows 8.1 is installed" definition_ref="oval:org.mitre.oval:def:18863" />
         <oval-def:extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
       </oval-def:criteria>
-      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9431.224" test_ref="oval:org.mitre.oval:tst:87282" />
+      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.16438" test_ref="oval:org.mitre.oval:tst:87282" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_18893.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_18893.xml
@@ -78,7 +78,7 @@
         <oval-def:extend_definition comment="Microsoft Windows 8.1 is installed" definition_ref="oval:org.mitre.oval:def:18863" />
         <oval-def:extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
       </oval-def:criteria>
-      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9431.224" test_ref="oval:org.mitre.oval:tst:87282" />
+      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.16438" test_ref="oval:org.mitre.oval:tst:87282" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_19138.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_19138.xml
@@ -176,7 +176,7 @@
         <oval-def:extend_definition comment="Microsoft Windows 8.1 is installed" definition_ref="oval:org.mitre.oval:def:18863" />
         <oval-def:extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
       </oval-def:criteria>
-      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9431.224" test_ref="oval:org.mitre.oval:tst:87282" />
+      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.16438" test_ref="oval:org.mitre.oval:tst:87282" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_19182.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_19182.xml
@@ -125,7 +125,7 @@
         <oval-def:extend_definition comment="Microsoft Windows 8.1 is installed" definition_ref="oval:org.mitre.oval:def:18863" />
         <oval-def:extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
       </oval-def:criteria>
-      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9431.224" test_ref="oval:org.mitre.oval:tst:87282" />
+      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.16438" test_ref="oval:org.mitre.oval:tst:87282" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_19243.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_19243.xml
@@ -176,7 +176,7 @@
         <oval-def:extend_definition comment="Microsoft Windows 8.1 is installed" definition_ref="oval:org.mitre.oval:def:18863" />
         <oval-def:extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
       </oval-def:criteria>
-      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9431.224" test_ref="oval:org.mitre.oval:tst:87282" />
+      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.16438" test_ref="oval:org.mitre.oval:tst:87282" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/states/windows/file_state/24000/oval_org.mitre.oval_ste_24182.xml
+++ b/repository/states/windows/file_state/24000/oval_org.mitre.oval_ste_24182.xml
@@ -1,3 +1,3 @@
-<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 11.0.9431.224" id="oval:org.mitre.oval:ste:24182" version="1">
-  <version datatype="version" operation="less than">11.0.9431.224</version>
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 11.0.9600.16438" id="oval:org.mitre.oval:ste:24182" version="1">
+  <version datatype="version" operation="less than">11.0.9600.16438</version>
 </file_state>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87282.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87282.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mshtml.dll is less than 11.0.9431.224" id="oval:org.mitre.oval:tst:87282" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mshtml.dll is less than 11.0.9600.16438" id="oval:org.mitre.oval:tst:87282" version="1">
   <object object_ref="oval:org.mitre.oval:obj:222" />
   <state state_ref="oval:org.mitre.oval:ste:24182" />
 </file_test>


### PR DESCRIPTION
The state [oval:org.mitre.oval:ste:24182](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:ste:24182) was changed on the right one according [KB2888505](https://support.microsoft.com/ru-ru/kb/2888505). The version 11.0.9431.224 was replaced with 11.0.9600.16438.