### PR TITLE
kemanik-MS13-009

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16126.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16126.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16126" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16126" version="9">
   <oval-def:metadata>
     <oval-def:title>Internet Explorer pasteHTML use after free vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -56,8 +56,10 @@
         </oval-def:criteria>
         <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
           <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
             <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
           </oval-def:criteria>
           <oval-def:criteria comment="Check for vulnerable version" operator="OR">
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -65,16 +67,10 @@
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
             </oval-def:criteria>
-          </oval-def:criteria>
-        </oval-def:criteria>
-        <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-          <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-          </oval-def:criteria>
-          <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            <oval-def:criteria comment="Check for GDR range" operator="AND">
+              <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+              <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            </oval-def:criteria>
             <oval-def:criteria comment="Check for LDR range" operator="AND">
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16245.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16245.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16245" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16245" version="9">
   <oval-def:metadata>
     <oval-def:title>Internet Explorer CHTML use after free vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -113,8 +113,10 @@
         </oval-def:criteria>
         <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
           <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
             <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
           </oval-def:criteria>
           <oval-def:criteria comment="Check for vulnerable version" operator="OR">
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -122,16 +124,10 @@
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
             </oval-def:criteria>
-          </oval-def:criteria>
-        </oval-def:criteria>
-        <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-          <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-          </oval-def:criteria>
-          <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            <oval-def:criteria comment="Check for GDR range" operator="AND">
+              <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+              <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            </oval-def:criteria>
             <oval-def:criteria comment="Check for LDR range" operator="AND">
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16249.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16249.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16249" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16249" version="9">
   <oval-def:metadata>
     <oval-def:title>Internet Explorer CObjectElement use after free vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -113,8 +113,10 @@
         </oval-def:criteria>
         <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
           <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
             <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
           </oval-def:criteria>
           <oval-def:criteria comment="Check for vulnerable version" operator="OR">
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -122,16 +124,10 @@
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
             </oval-def:criteria>
-          </oval-def:criteria>
-        </oval-def:criteria>
-        <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-          <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-          </oval-def:criteria>
-          <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            <oval-def:criteria comment="Check for GDR range" operator="AND">
+              <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+              <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            </oval-def:criteria>
             <oval-def:criteria comment="Check for LDR range" operator="AND">
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16294.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16294.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16294" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16294" version="9">
   <oval-def:metadata>
     <oval-def:title>Internet Explorer SLayoutRun use after free vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -54,8 +54,10 @@
       </oval-def:criteria>
       <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
         <oval-def:criteria comment="Win 7 / R2" operator="OR">
-          <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+          <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+          <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
           <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+          <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
         </oval-def:criteria>
         <oval-def:criteria comment="Check for vulnerable version" operator="OR">
           <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -63,16 +65,10 @@
             <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
           </oval-def:criteria>
-        </oval-def:criteria>
-      </oval-def:criteria>
-      <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-        <oval-def:criteria comment="Win 7 / R2" operator="OR">
-          <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-          <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-          <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-        </oval-def:criteria>
-        <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-          <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+          <oval-def:criteria comment="Check for GDR range" operator="AND">
+            <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+          </oval-def:criteria>
           <oval-def:criteria comment="Check for LDR range" operator="AND">
             <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16360.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16360.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16360" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16360" version="9">
   <oval-def:metadata>
     <oval-def:title>Internet Explorer CPasteCommand use after free vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -116,8 +116,10 @@
         </oval-def:criteria>
         <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
           <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
             <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
           </oval-def:criteria>
           <oval-def:criteria comment="Check for vulnerable version" operator="OR">
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -125,16 +127,10 @@
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
             </oval-def:criteria>
-          </oval-def:criteria>
-        </oval-def:criteria>
-        <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-          <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-          </oval-def:criteria>
-          <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            <oval-def:criteria comment="Check for GDR range" operator="AND">
+              <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+              <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            </oval-def:criteria>
             <oval-def:criteria comment="Check for LDR range" operator="AND">
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16371.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16371.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16371" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16371" version="9">
   <oval-def:metadata>
     <oval-def:title>Shift JIS character encoding vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -113,8 +113,10 @@
         </oval-def:criteria>
         <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
           <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
             <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
           </oval-def:criteria>
           <oval-def:criteria comment="Check for vulnerable version" operator="OR">
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -122,16 +124,10 @@
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
             </oval-def:criteria>
-          </oval-def:criteria>
-        </oval-def:criteria>
-        <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-          <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-          </oval-def:criteria>
-          <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            <oval-def:criteria comment="Check for GDR range" operator="AND">
+              <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+              <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            </oval-def:criteria>
             <oval-def:criteria comment="Check for LDR range" operator="AND">
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16438.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16438.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16438" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16438" version="9">
   <oval-def:metadata>
     <oval-def:title>Internet Explorer SetCapture use after free vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -113,8 +113,10 @@
         </oval-def:criteria>
         <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
           <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
             <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
           </oval-def:criteria>
           <oval-def:criteria comment="Check for vulnerable version" operator="OR">
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -122,16 +124,10 @@
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
             </oval-def:criteria>
-          </oval-def:criteria>
-        </oval-def:criteria>
-        <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-          <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-          </oval-def:criteria>
-          <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            <oval-def:criteria comment="Check for GDR range" operator="AND">
+              <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+              <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            </oval-def:criteria>
             <oval-def:criteria comment="Check for LDR range" operator="AND">
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16465.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16465.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16465" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16465" version="9">
   <oval-def:metadata>
     <oval-def:title>Internet Explorer COmWindowProxy use after free vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -97,8 +97,10 @@
         </oval-def:criteria>
         <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
           <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
             <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
           </oval-def:criteria>
           <oval-def:criteria comment="Check for vulnerable version" operator="OR">
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -106,16 +108,10 @@
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
             </oval-def:criteria>
-          </oval-def:criteria>
-        </oval-def:criteria>
-        <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-          <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-          </oval-def:criteria>
-          <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            <oval-def:criteria comment="Check for GDR range" operator="AND">
+              <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+              <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            </oval-def:criteria>
             <oval-def:criteria comment="Check for LDR range" operator="AND">
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16483.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16483.xml
@@ -1,4 +1,4 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16483" version="5">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:16483" version="9">
   <oval-def:metadata>
     <oval-def:title>Internet Explorer vtable use after free vulnerability - MS13-009</oval-def:title>
     <oval-def:affected family="windows">
@@ -116,8 +116,10 @@
         </oval-def:criteria>
         <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
           <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
             <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
           </oval-def:criteria>
           <oval-def:criteria comment="Check for vulnerable version" operator="OR">
             <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.17209" test_ref="oval:org.mitre.oval:tst:80045" />
@@ -125,16 +127,10 @@
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7600.20000" test_ref="oval:org.mitre.oval:tst:10804" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7600.21419" test_ref="oval:org.mitre.oval:tst:80804" />
             </oval-def:criteria>
-          </oval-def:criteria>
-        </oval-def:criteria>
-        <oval-def:criteria comment="Win 7 / R2 and vulnerable IE 8 version" operator="AND">
-          <oval-def:criteria comment="Win 7 / R2" operator="OR">
-            <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
-            <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
-            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
-          </oval-def:criteria>
-          <oval-def:criteria comment="Check for vulnerable version" operator="OR">
-            <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            <oval-def:criteria comment="Check for GDR range" operator="AND">
+              <oval-def:criterion comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" test_ref="oval:ru.test.win:tst:1" />
+              <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.18035" test_ref="oval:org.mitre.oval:tst:80702" />
+            </oval-def:criteria>
             <oval-def:criteria comment="Check for LDR range" operator="AND">
               <oval-def:criterion comment="Mshtml.dll version is greater than or equal to 8.0.7601.21000" test_ref="oval:org.mitre.oval:tst:80043" />
               <oval-def:criterion comment="Check if the version of mshtml.dll is less than 8.0.7601.22199" test_ref="oval:org.mitre.oval:tst:80711" />

--- a/repository/states/windows/file_state/0000/oval_ru.test.win_ste_1.xml
+++ b/repository/states/windows/file_state/0000/oval_ru.test.win_ste_1.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if the version is less than or equal 8.0.7601.17000" id="oval:ru.test.win:ste:1" version="1">
+  <version datatype="version" operation="greater than or equal">8.0.7601.17000</version>
+</file_state>

--- a/repository/tests/windows/file_test/0000/oval_ru.test.win_tst_1.xml
+++ b/repository/tests/windows/file_test/0000/oval_ru.test.win_tst_1.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Mshtml.dll version is greater than or equal 8.0.7601.17000" id="oval:ru.test.win:tst:1" version="1">
+  <object object_ref="oval:org.mitre.oval:obj:222" />
+  <state state_ref="oval:ru.test.win:ste:1" />
+</file_test>


### PR DESCRIPTION
Two criteria "Win 7 / R2 and vulnerable IE 8 version" were combined and the test "Mshtml.dll version is greater than or equal 8.0.7601.17000" was added.