### PR TITLE
Kemanik infopath

### DIFF
--- a/oval_ru.test.win_var_157.xm
+++ b/oval_ru.test.win_var_157.xm
@@ -1,3 +1,3 @@
 <local_variable id="oval:ru.test.win:var:157" version="1" comment="Variable holds the path to Infopath installation (Office 2003)" datatype="string">
-        <object_component item_field="value" object_ref="oval:org.mitre.oval:obj:11854" />
+        <object_component item_field="value" object_ref="oval:org.mitre.oval:obj:12292" />
     </local_variable>

--- a/oval_ru.test.win_var_157.xm
+++ b/oval_ru.test.win_var_157.xm
@@ -1,0 +1,3 @@
+<local_variable id="oval:ru.test.win:var:157" version="1" comment="Variable holds the path to Infopath installation (Office 2003)" datatype="string">
+        <object_component item_field="value" object_ref="oval:org.mitre.oval:obj:11854" />
+    </local_variable>

--- a/repository/objects/windows/file_object/11000/oval_org.mitre.oval_obj_11908.xml
+++ b/repository/objects/windows/file_object/11000/oval_org.mitre.oval_obj_11908.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:11908" version="2">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:157" />
+  <path var_check="all" var_ref="oval:ru.test.win:var:157" />
   <filename>Infopath.exe</filename>
 </file_object>

--- a/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38728.xml
+++ b/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38728.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:38728" comment="Object holds the details of infopath.exe (Office 2010)" version="1">
+      <path var_ref="oval:ru.altx-soft.win:var:38198" var_check="at least one" />
+      <filename>infopath.exe</filename>
+    </file_object>

--- a/repository/objects/windows/registry_object/11000/oval_org.mitre.oval_obj_11854.xml
+++ b/repository/objects/windows/registry_object/11000/oval_org.mitre.oval_obj_11854.xml
@@ -2,5 +2,5 @@
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Office\12.0\InfoPath\InstallRoot</key>
-  <name xsi:nil="true" />
+  <name>Path</name>
 </registry_object>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27632.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27632.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of infopath.exe is less than 13.0.0.0" id="oval:org.mitre.oval:tst:27632" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:org.mitre.oval:obj:12173" />
   <state state_ref="oval:org.mitre.oval:ste:4287" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27656.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27656.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of infopath.exe is greater than or equal 12.0.0.0" id="oval:org.mitre.oval:tst:27656" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:org.mitre.oval:obj:12173" />
   <state state_ref="oval:org.mitre.oval:ste:4449" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42773.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42773.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of infopath.exe is greater than or equal 14.0.0.0" id="oval:org.mitre.oval:tst:42773" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38728" />
   <state state_ref="oval:org.mitre.oval:ste:11789" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79527.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79527.xml
@@ -1,5 +1,5 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if version of infopath.exe is less than 14.0.6009.1000 and less than 14.0.7015.1000" id="oval:org.mitre.oval:tst:79527" state_operator="AND" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38728" />
   <state state_ref="oval:org.mitre.oval:ste:20063" />
   <state state_ref="oval:org.mitre.oval:ste:21747" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79678.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79678.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6123.5006" id="oval:org.mitre.oval:tst:79678" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38728" />
   <state state_ref="oval:org.mitre.oval:ste:19930" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79873.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79873.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 12.0.6661.5000" id="oval:org.mitre.oval:tst:79873" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:org.mitre.oval:obj:12173" />
   <state state_ref="oval:org.mitre.oval:ste:19490" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80072.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80072.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6120.5000" id="oval:org.mitre.oval:tst:80072" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38728" />
   <state state_ref="oval:org.mitre.oval:ste:19741" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80214.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80214.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 12.0.6662.5004" id="oval:org.mitre.oval:tst:80214" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:org.mitre.oval:obj:12173" />
   <state state_ref="oval:org.mitre.oval:ste:19758" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80688.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80688.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6134.5004" id="oval:org.mitre.oval:tst:80688" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38728" />
   <state state_ref="oval:org.mitre.oval:ste:20146" />
 </file_test>

--- a/repository/tests/windows/file_test/82000/oval_org.mitre.oval_tst_82626.xml
+++ b/repository/tests/windows/file_test/82000/oval_org.mitre.oval_tst_82626.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="infopath.exe version is greater than or equal 14.0.7015.1000" id="oval:org.mitre.oval:tst:82626" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38728" />
   <state state_ref="oval:org.mitre.oval:ste:21301" />
 </file_test>

--- a/repository/variables/oval_ru.altx-soft.win_var_38198.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_38198.xml
@@ -1,0 +1,3 @@
+<local_variable id="oval:ru.altx-soft.win:var:38198" comment="Variable holds the path to Infopath installation (Office 2010)" version="1" datatype="string">
+      <object_component object_ref="oval:org.mitre.oval:obj:15673" item_field="value" />
+    </local_variable>


### PR DESCRIPTION
The objects that check the version of file infopath.exe for Office 2003, 2007 and 2010 should be different. Otherwise when two or more versions of Infopath are installed the results of definitions will be wrong.