### PR TITLE
Kemanik visio

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_12659.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_12659.xml
@@ -30,11 +30,11 @@
   <oval-def:criteria operator="OR">
     <oval-def:criteria comment="Microsoft Office Visio 2003" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2003 is installed" definition_ref="oval:org.mitre.oval:def:1450" />
-      <oval-def:criterion comment="Check if the version of Visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
+      <oval-def:criterion comment="Check if the version of visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
     </oval-def:criteria>
     <oval-def:criteria comment="Microsoft Visio 2007" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2007 is installed" definition_ref="oval:org.mitre.oval:def:5261" />
-      <oval-def:criterion comment="Check if the version of Visio.exe is less than 12.0.6556.5000" test_ref="oval:org.mitre.oval:tst:43654" />
+      <oval-def:criterion comment="Check if the version of visio.exe is less than 12.0.6556.5000" test_ref="oval:org.mitre.oval:tst:43654" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_12659.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_12659.xml
@@ -30,11 +30,11 @@
   <oval-def:criteria operator="OR">
     <oval-def:criteria comment="Microsoft Office Visio 2003" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2003 is installed" definition_ref="oval:org.mitre.oval:def:1450" />
-      <oval-def:criterion comment="Uml.dll version is less than 11.0.8338.0" test_ref="oval:org.mitre.oval:tst:43205" />
+      <oval-def:criterion comment="Check if the version of Visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
     </oval-def:criteria>
     <oval-def:criteria comment="Microsoft Visio 2007" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2007 is installed" definition_ref="oval:org.mitre.oval:def:5261" />
-      <oval-def:criterion comment="Visio.exe version is less than 12.0.6556.5000" test_ref="oval:org.mitre.oval:tst:43654" />
+      <oval-def:criterion comment="Check if the version of Visio.exe is less than 12.0.6556.5000" test_ref="oval:org.mitre.oval:tst:43654" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_12852.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_12852.xml
@@ -31,15 +31,15 @@
   <oval-def:criteria operator="OR">
     <oval-def:criteria comment="Microsoft Office Visio 2003" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2003 is installed" definition_ref="oval:org.mitre.oval:def:1450" />
-      <oval-def:criterion comment="Check if the version of Visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
+      <oval-def:criterion comment="Check if the version of visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
     </oval-def:criteria>
     <oval-def:criteria comment="Microsoft Visio 2007" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2007 is installed" definition_ref="oval:org.mitre.oval:def:5261" />
-      <oval-def:criterion comment="Check if the version of Visio.exe is less than 12.0.6556.5000" test_ref="oval:org.mitre.oval:tst:43654" />
+      <oval-def:criterion comment="Check if the version of visio.exe is less than 12.0.6556.5000" test_ref="oval:org.mitre.oval:tst:43654" />
     </oval-def:criteria>
     <oval-def:criteria comment="Microsoft Visio 2010" operator="AND">
       <oval-def:extend_definition comment="Microsoft Visio 2010 is installed" definition_ref="oval:org.mitre.oval:def:12930" />
-      <oval-def:criterion comment="Check if the version of Visio.exe is less than 14.0.6106.5000" test_ref="oval:org.mitre.oval:tst:43597" />
+      <oval-def:criterion comment="Check if the version of visio.exe is less than 14.0.6106.5000" test_ref="oval:org.mitre.oval:tst:43597" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_12852.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_12852.xml
@@ -31,7 +31,7 @@
   <oval-def:criteria operator="OR">
     <oval-def:criteria comment="Microsoft Office Visio 2003" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2003 is installed" definition_ref="oval:org.mitre.oval:def:1450" />
-      <oval-def:criterion comment="Uml.dll version is less than 11.0.8338.0" test_ref="oval:org.mitre.oval:tst:43205" />
+      <oval-def:criterion comment="Check if the version of Visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
     </oval-def:criteria>
     <oval-def:criteria comment="Microsoft Visio 2007" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2007 is installed" definition_ref="oval:org.mitre.oval:def:5261" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_12852.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_12852.xml
@@ -35,11 +35,11 @@
     </oval-def:criteria>
     <oval-def:criteria comment="Microsoft Visio 2007" operator="AND">
       <oval-def:extend_definition comment="Microsoft Office Visio 2007 is installed" definition_ref="oval:org.mitre.oval:def:5261" />
-      <oval-def:criterion comment="Visio.exe version is less than 12.0.6556.5000" test_ref="oval:org.mitre.oval:tst:43654" />
+      <oval-def:criterion comment="Check if the version of Visio.exe is less than 12.0.6556.5000" test_ref="oval:org.mitre.oval:tst:43654" />
     </oval-def:criteria>
     <oval-def:criteria comment="Microsoft Visio 2010" operator="AND">
       <oval-def:extend_definition comment="Microsoft Visio 2010 is installed" definition_ref="oval:org.mitre.oval:def:12930" />
-      <oval-def:criterion comment="Visio.exe version is less than 14.0.6106.5000" test_ref="oval:org.mitre.oval:tst:43597" />
+      <oval-def:criterion comment="Check if the version of Visio.exe is less than 14.0.6106.5000" test_ref="oval:org.mitre.oval:tst:43597" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16750.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16750.xml
@@ -29,18 +29,18 @@
       <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="OR">
-    <oval-def:criteria comment="visio 2003/version" operator="AND">
-      <oval-def:criterion comment="Check if the version of Visbrgr.dll is less than 11.0.8402.0" test_ref="oval:org.mitre.oval:tst:80845" />
-      <oval-def:extend_definition comment="Microsoft Office Visio 2003 Service Pack 3 is installed" definition_ref="oval:org.mitre.oval:def:16562" />
-    </oval-def:criteria>
-    <oval-def:criteria comment="visio 2007/version" operator="AND">
-      <oval-def:criterion comment="Check if the version of vislib.dll is less than 12.0.6676.5000" test_ref="oval:org.mitre.oval:tst:81020" />
-      <oval-def:extend_definition comment="Microsoft Office Visio 2007 Service Pack 3 is installed" definition_ref="oval:org.mitre.oval:def:16197" />
-    </oval-def:criteria>
-    <oval-def:criteria comment="visio 2010/version" operator="AND">
-      <oval-def:criterion comment="Check if the version of vislib.dll is less than 14.0.7100.5000" test_ref="oval:org.mitre.oval:tst:80468" />
-      <oval-def:extend_definition comment="Microsoft Visio 2010 SP1 is installed" definition_ref="oval:org.mitre.oval:def:15564" />
-    </oval-def:criteria>
-  </oval-def:criteria>
+  <criteria operator="OR">
+        <criteria operator="AND" comment="visio 2003/version">
+          <criterion comment="Check if the version of Visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
+          <extend_definition comment="Microsoft Office Visio 2003 Service Pack 3 is installed" definition_ref="oval:org.mitre.oval:def:16562" />
+        </criteria>
+        <criteria operator="AND" comment="visio 2007/version">
+          <criterion comment="Check if the version of Visio.exe is less than 12.0.6676.5000" test_ref="oval:org.mitre.oval:tst:81020" />
+          <extend_definition comment="Microsoft Office Visio 2007 Service Pack 3 is installed" definition_ref="oval:org.mitre.oval:def:16197" />
+        </criteria>
+        <criteria operator="AND" comment="visio 2010/version">
+          <criterion comment="Check if the version of Visio.exe is less than 14.0.7100.5000" test_ref="oval:org.mitre.oval:tst:80468" />
+          <extend_definition comment="Microsoft Visio 2010 SP1 is installed" definition_ref="oval:org.mitre.oval:def:15564" />
+        </criteria>
+      </criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16750.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16750.xml
@@ -31,15 +31,15 @@
   </oval-def:metadata>
   <criteria operator="OR">
         <criteria operator="AND" comment="visio 2003/version">
-          <criterion comment="Check if the version of Visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
+          <criterion comment="Check if the version of visio.exe is less than 11.0.8207.0" test_ref="oval:org.mitre.oval:tst:43205" />
           <extend_definition comment="Microsoft Office Visio 2003 Service Pack 3 is installed" definition_ref="oval:org.mitre.oval:def:16562" />
         </criteria>
         <criteria operator="AND" comment="visio 2007/version">
-          <criterion comment="Check if the version of Visio.exe is less than 12.0.6676.5000" test_ref="oval:org.mitre.oval:tst:81020" />
+          <criterion comment="Check if the version of visio.exe is less than 12.0.6676.5000" test_ref="oval:org.mitre.oval:tst:81020" />
           <extend_definition comment="Microsoft Office Visio 2007 Service Pack 3 is installed" definition_ref="oval:org.mitre.oval:def:16197" />
         </criteria>
         <criteria operator="AND" comment="visio 2010/version">
-          <criterion comment="Check if the version of Visio.exe is less than 14.0.7100.5000" test_ref="oval:org.mitre.oval:tst:80468" />
+          <criterion comment="Check if the version of visio.exe is less than 14.0.7100.5000" test_ref="oval:org.mitre.oval:tst:80468" />
           <extend_definition comment="Microsoft Visio 2010 SP1 is installed" definition_ref="oval:org.mitre.oval:def:15564" />
         </criteria>
       </criteria>

--- a/repository/objects/windows/file_object/15000/oval_org.mitre.oval_obj_15670.xml
+++ b/repository/objects/windows/file_object/15000/oval_org.mitre.oval_obj_15670.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:15670" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:15670" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:338" />
   <filename>Visio.exe</filename>
 </file_object>

--- a/repository/objects/windows/file_object/16000/oval_org.mitre.oval_obj_16159.xml
+++ b/repository/objects/windows/file_object/16000/oval_org.mitre.oval_obj_16159.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:16159" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:16159" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:338" />
   <filename>uml.dll</filename>
 </file_object>

--- a/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2089.xml
+++ b/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2089.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2089" version="1">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:338" />
-  <filename>vislib.dll</filename>
-</file_object>
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2089" comment="Object holds the details of visio.exe (Office 2007)" version="1">
+      <path var_ref="oval:ru.test.win:var:3381" var_check="all" />
+      <filename>Visio.exe</filename>
+    </file_object>

--- a/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2089.xml
+++ b/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2089.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2089" comment="Object holds the details of visio.exe (Office 2007)" version="1">
-      <path var_ref="oval:ru.test.win:var:3381" var_check="all" />
+      <path var_ref="oval:org.mitre.oval:var:338" var_check="all" />
       <filename>Visio.exe</filename>
     </file_object>

--- a/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23864.xml
+++ b/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23864.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the path to Visbrgr.dll" id="oval:org.mitre.oval:obj:23864" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the path to Visbrgr.dll" id="oval:org.mitre.oval:obj:23864" deprecated="true" version="1">
   <path var_ref="oval:org.mitre.oval:var:338" />
   <filename>Visbrgr.dll</filename>
 </file_object>

--- a/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38442.xml
+++ b/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38442.xml
@@ -1,0 +1,4 @@
+ <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:38442" comment="Object holds the details of visio.exe (Office 2010)" version="2">
+      <path var_ref="oval:ru.altx-soft.win:var:38128" var_check="at least one" />
+      <filename>visio.exe</filename>
+    </file_object>

--- a/repository/objects/windows/registry_object/2000/oval_org.mitre.oval_obj_2440.xml
+++ b/repository/objects/windows/registry_object/2000/oval_org.mitre.oval_obj_2440.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2440" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2440" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\visio.exe</key>
   <name>Path</name>

--- a/repository/objects/windows/registry_object/43000/oval_org.mitre.oval_obj_43819.xml
+++ b/repository/objects/windows/registry_object/43000/oval_org.mitre.oval_obj_43819.xml
@@ -1,5 +1,5 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" comment="Microsoft Office Visio Standard 2003" id="oval:org.mitre.oval:obj:43819" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>Software\Microsoft\Windows\CurrentVersion\Uninstall\{90530409-6000-11D3-8CFE-0150048383C9}</key>
-  <name xsi:nil="true" />
+  <name>DisplayVersion</name>
 </registry_object>

--- a/repository/objects/windows/registry_object/44000/oval_org.mitre.oval_obj_44208.xml
+++ b/repository/objects/windows/registry_object/44000/oval_org.mitre.oval_obj_44208.xml
@@ -1,5 +1,5 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" comment="Microsoft Office Visio Professional 2003" id="oval:org.mitre.oval:obj:44208" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>Software\Microsoft\Windows\CurrentVersion\Uninstall\{90510409-6000-11D3-8CFE-0150048383C9}</key>
-  <name xsi:nil="true" />
+  <name>DisplayVersion</name>
 </registry_object>

--- a/repository/states/windows/file_state/12000/oval_org.mitre.oval_ste_12888.xml
+++ b/repository/states/windows/file_state/12000/oval_org.mitre.oval_ste_12888.xml
@@ -1,3 +1,3 @@
-<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:12888" version="1">
-  <version datatype="version" operation="less than">11.0.8338.0</version>
-</file_state>
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:12888" version="2">
+      <value datatype="version" operation="less than">11.0.8207.0</value>
+    </registry_state>

--- a/repository/states/windows/file_state/20000/oval_org.mitre.oval_ste_20682.xml
+++ b/repository/states/windows/file_state/20000/oval_org.mitre.oval_ste_20682.xml
@@ -1,3 +1,3 @@
-<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if the version is greater than or equal to 11.0.8161.0" id="oval:org.mitre.oval:ste:20682" version="1">
-  <version datatype="version" operation="greater than or equal">11.0.8161.0</version>
-</file_state>
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:ste:20682" version="1" comment="State matches if the version is greater than or equal to 11.0.8161.0">
+      <value datatype="version" operation="greater than or equal">11.0.8161.0</value>
+    </registry_state>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43205.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43205.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Uml.dll version is less than 11.0.8338.0" id="oval:org.mitre.oval:tst:43205" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:16159" />
-  <state state_ref="oval:org.mitre.oval:ste:12888" />
-</file_test>
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 11.0.8207.0" id="oval:org.mitre.oval:tst:43205" version="2">
+      <object object_ref="oval:org.mitre.oval:obj:387" />
+      <state state_ref="oval:org.mitre.oval:ste:12888" />
+    </registry_test>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43205.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43205.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 11.0.8207.0" id="oval:org.mitre.oval:tst:43205" version="2">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 11.0.8207.0" id="oval:org.mitre.oval:tst:43205" version="2">
       <object object_ref="oval:org.mitre.oval:obj:387" />
       <state state_ref="oval:org.mitre.oval:ste:12888" />
     </registry_test>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43597.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43597.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 14.0.6106.5000" id="oval:org.mitre.oval:tst:43597" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 14.0.6106.5000" id="oval:org.mitre.oval:tst:43597" version="1">
   <object object_ref="oval:ru.altx-soft.win:obj:38442" />
   <state state_ref="oval:org.mitre.oval:ste:12737" />
 </file_test>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43597.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43597.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Visio.exe version is less than 14.0.6106.5000" id="oval:org.mitre.oval:tst:43597" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15670" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38442" />
   <state state_ref="oval:org.mitre.oval:ste:12737" />
 </file_test>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43597.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43597.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Visio.exe version is less than 14.0.6106.5000" id="oval:org.mitre.oval:tst:43597" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 14.0.6106.5000" id="oval:org.mitre.oval:tst:43597" version="1">
   <object object_ref="oval:ru.altx-soft.win:obj:38442" />
   <state state_ref="oval:org.mitre.oval:ste:12737" />
 </file_test>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43654.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43654.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Visio.exe version is less than 12.0.6556.5000" id="oval:org.mitre.oval:tst:43654" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15670" />
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 12.0.6556.5000" id="oval:org.mitre.oval:tst:43654" version="1">
+  <object object_ref="oval:org.mitre.oval:obj:2089" />
   <state state_ref="oval:org.mitre.oval:ste:12860" />
 </file_test>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43654.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43654.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 12.0.6556.5000" id="oval:org.mitre.oval:tst:43654" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 12.0.6556.5000" id="oval:org.mitre.oval:tst:43654" version="1">
   <object object_ref="oval:org.mitre.oval:obj:2089" />
   <state state_ref="oval:org.mitre.oval:ste:12860" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80468.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80468.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 14.0.7100.5000" id="oval:org.mitre.oval:tst:80468" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 14.0.7100.5000" id="oval:org.mitre.oval:tst:80468" version="1">
   <object object_ref="oval:ru.altx-soft.win:obj:38442" />
   <state state_ref="oval:org.mitre.oval:ste:20274" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80468.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80468.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of vislib.dll is less than 14.0.7100.5000" id="oval:org.mitre.oval:tst:80468" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:2089" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38442" />
   <state state_ref="oval:org.mitre.oval:ste:20274" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80468.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80468.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of vislib.dll is less than 14.0.7100.5000" id="oval:org.mitre.oval:tst:80468" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 14.0.7100.5000" id="oval:org.mitre.oval:tst:80468" version="1">
   <object object_ref="oval:ru.altx-soft.win:obj:38442" />
   <state state_ref="oval:org.mitre.oval:ste:20274" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80845.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80845.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visbrgr.dll is less than 11.0.8402.0" id="oval:org.mitre.oval:tst:80845" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visbrgr.dll is less than 11.0.8402.0" id="oval:org.mitre.oval:tst:80845" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23864" />
   <state state_ref="oval:org.mitre.oval:ste:20557" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81020.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81020.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 12.0.6676.5000" id="oval:org.mitre.oval:tst:81020" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 12.0.6676.5000" id="oval:org.mitre.oval:tst:81020" version="1">
   <object object_ref="oval:org.mitre.oval:obj:2089" />
   <state state_ref="oval:org.mitre.oval:ste:20355" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81020.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81020.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of vislib.dll is less than 12.0.6676.5000" id="oval:org.mitre.oval:tst:81020" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Visio.exe is less than 12.0.6676.5000" id="oval:org.mitre.oval:tst:81020" version="1">
   <object object_ref="oval:org.mitre.oval:obj:2089" />
   <state state_ref="oval:org.mitre.oval:ste:20355" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81154.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81154.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is greater than or equal to 11.0.8161.0" id="oval:org.mitre.oval:tst:81154" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15670" />
-  <state state_ref="oval:org.mitre.oval:ste:20682" />
-</file_test>
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:tst:81154" version="1" comment="Check if the version of visio.exe is greater than or equal to 11.0.8161.0" check_existence="at_least_one_exists" check="all">
+      <object object_ref="oval:org.mitre.oval:obj:387" />
+      <state state_ref="oval:org.mitre.oval:ste:20682" />
+    </registry_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81183.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81183.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is greater than or equal to 12.0.6606.1000" id="oval:org.mitre.oval:tst:81183" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15670" />
+  <object object_ref="oval:org.mitre.oval:obj:2089" />
   <state state_ref="oval:org.mitre.oval:ste:20588" />
 </file_test>

--- a/repository/tests/windows/registry_test/0000/oval_org.cisecurity_tst_3.xml
+++ b/repository/tests/windows/registry_test/0000/oval_org.cisecurity_tst_3.xml
@@ -1,4 +1,3 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Microsoft Visio 2013 is installed" id="oval:org.cisecurity:tst:3" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:2440" />
-  <state state_ref="oval:org.cisecurity:ste:2" />
+  <object object_ref="oval:ru.altx-soft.win:obj:38449" />
 </registry_test>

--- a/repository/variables/oval_ru.altx-soft.win_var_38128.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_38128.xml
@@ -1,0 +1,3 @@
+<local_variable id="oval:ru.altx-soft.win:var:38128" comment="Variable holds the path to visio.exe (Office 2010)" version="1" datatype="string">
+      <object_component object_ref="oval:org.mitre.oval:obj:23935" item_field="value" />
+    </local_variable>

--- a/repository/variables/oval_ru.test.win_var_3381.xml
+++ b/repository/variables/oval_ru.test.win_var_3381.xml
@@ -1,0 +1,3 @@
+<local_variable id="oval:ru.test.win:var:3381" version="1" comment="Variable holds the path to visio.exe (Office 2007)" datatype="string">
+      <object_component object_ref="oval:org.mitre.oval:obj:24203" item_field="value" />
+    </local_variable>

--- a/repository/variables/oval_ru.test.win_var_3381.xml
+++ b/repository/variables/oval_ru.test.win_var_3381.xml
@@ -1,3 +1,1 @@
-<local_variable id="oval:ru.test.win:var:3381" version="1" comment="Variable holds the path to visio.exe (Office 2007)" datatype="string">
-      <object_component object_ref="oval:org.mitre.oval:obj:24203" item_field="value" />
-    </local_variable>
+


### PR DESCRIPTION
The objects that check the version of file visio.exe for Office 2003, 2007 and 2010 should be different. Otherwise when two or more versions of Visio are installed the results of definitions will be wrong. And also it is more correct for uniformity to check the visio.exe version instead other file in Visio vulnerability definitions.