### PR TITLE
Kemanik onenote

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_16539.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_16539.xml
@@ -32,8 +32,8 @@
       <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Check if the version of Onenote.Exe is less than 14.0.6134.5000" test_ref="oval:org.mitre.oval:tst:80902" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Check if the version of onenote.exe is less than 14.0.6134.5000" test_ref="oval:org.mitre.oval:tst:80902" />
     <oval-def:extend_definition comment="Microsoft OneNote 2010 Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:16535" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_26089.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_26089.xml
@@ -30,8 +30,8 @@
       <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Check if the version of Onmain.dll is less than 12.0.6703.5000" test_ref="oval:org.mitre.oval:tst:121444" />
+  <oval-def:criteria>
+    <oval-def:criterion comment="Check if the version of onenote.exe is less than 12.0.6703.5000" test_ref="oval:org.mitre.oval:tst:121444" />
     <oval-def:extend_definition comment="Microsoft Office OneNote 2007 is installed" definition_ref="oval:org.mitre.oval:def:15926" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_5970.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_5970.xml
@@ -58,7 +58,7 @@
     </oval-def:criteria>
     <oval-def:criteria operator="AND">
       <oval-def:criterion comment="OneNote 2007 is installed" test_ref="oval:org.mitre.oval:tst:8374" />
-      <oval-def:criterion comment="Onenote.exe version is less than 12.0.6316.5000" test_ref="oval:org.mitre.oval:tst:8591" />
+      <oval-def:criterion comment="Check if the version of onenote.exe is less than 12.0.6316.5000" test_ref="oval:org.mitre.oval:tst:8591" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
+++ b/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:38200" comment="Object holds the file Onenote.Exe" version="1">
+      <path var_ref="oval:ru.altx-soft.win:var:38054" var_check="all" />
+      <filename>Onenote.exe</filename>
+    </file_object>

--- a/repository/objects/windows/registry_object/6000/oval_org.mitre.oval_obj_6456.xml
+++ b/repository/objects/windows/registry_object/6000/oval_org.mitre.oval_obj_6456.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6456" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6456" deprecated="true" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\OneNote.exe</key>
   <name>Path</name>

--- a/repository/objects/windows/registry_object/6000/oval_org.mitre.oval_obj_6456.xml
+++ b/repository/objects/windows/registry_object/6000/oval_org.mitre.oval_obj_6456.xml
@@ -1,5 +1,6 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6456" version="1">
-  <hive>HKEY_LOCAL_MACHINE</hive>
-  <key>SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\OneNote.exe</key>
-  <name>Path</name>
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6456" version="1" comment="OneNote 2007 InstallRoot">
+ <behaviors windows_view="32_bit" />
+      <hive>HKEY_LOCAL_MACHINE</hive>
+      <key>SOFTWARE\Microsoft\Office\12.0\OneNote\InstallRoot</key>
+      <name>Path</name>
 </registry_object>

--- a/repository/objects/windows/registry_object/6000/oval_org.mitre.oval_obj_6456.xml
+++ b/repository/objects/windows/registry_object/6000/oval_org.mitre.oval_obj_6456.xml
@@ -1,4 +1,4 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6456" deprecated="true" version="1">
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6456" version="1">
   <hive>HKEY_LOCAL_MACHINE</hive>
   <key>SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\OneNote.exe</key>
   <name>Path</name>

--- a/repository/tests/windows/file_test/121000/oval_org.mitre.oval_tst_121444.xml
+++ b/repository/tests/windows/file_test/121000/oval_org.mitre.oval_tst_121444.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Onmain.dll is less than 12.0.6703.5000" id="oval:org.mitre.oval:tst:121444" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:41961" />
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of onenote.exe is less than 12.0.6703.5000" id="oval:org.mitre.oval:tst:121444" version="1">
+  <object object_ref="oval:org.mitre.oval:obj:6606" />
   <state state_ref="oval:org.mitre.oval:ste:33547" />
 </file_test>

--- a/repository/tests/windows/file_test/8000/oval_org.mitre.oval_tst_8591.xml
+++ b/repository/tests/windows/file_test/8000/oval_org.mitre.oval_tst_8591.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Onenote.exe version is less than 12.0.6316.5000" id="oval:org.mitre.oval:tst:8591" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of onenote.exe is less than 12.0.6316.5000" id="oval:org.mitre.oval:tst:8591" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6606" />
   <state state_ref="oval:org.mitre.oval:ste:4302" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80902.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80902.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Onenote.Exe is less than 14.0.6134.5000" id="oval:org.mitre.oval:tst:80902" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:6606" />
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of onenote.Exe is less than 14.0.6134.5000" id="oval:org.mitre.oval:tst:80902" version="2">
+  <object object_ref="oval:ru.altx-soft.win:obj:38200" />
   <state state_ref="oval:org.mitre.oval:ste:19698" />
 </file_test>

--- a/repository/variables/oval_org.mitre.oval_var_338.xml
+++ b/repository/variables/oval_org.mitre.oval_var_338.xml
@@ -1,3 +1,3 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Install directory of Visio" datatype="string" id="oval:org.mitre.oval:var:338" version="1">
-  <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:2440" />
-</oval-def:local_variable>
+<local_variable id="oval:org.mitre.oval:var:338" version="1" comment="Variable holds the path to visio.exe (Office 2007)" datatype="string">
+      <object_component object_ref="oval:org.mitre.oval:obj:24203" item_field="value" />
+    </local_variable>

--- a/repository/variables/oval_org.mitre.oval_var_44.xml
+++ b/repository/variables/oval_org.mitre.oval_var_44.xml
@@ -1,5 +1,3 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="OneNote Installation directory" datatype="string" id="oval:org.mitre.oval:var:44" version="2">
-  <oval-def:regex_capture pattern="^(.*[^\\])\\?$">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="OneNote 2007 Installation directory" datatype="string" id="oval:org.mitre.oval:var:44" version="2">
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:6456" />
-  </oval-def:regex_capture>
 </oval-def:local_variable>

--- a/repository/variables/oval_ru.altx-soft.win_var_38054.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_38054.xml
@@ -1,0 +1,3 @@
+<local_variable id="oval:ru.altx-soft.win:var:38054" comment="File path to office14" version="1" datatype="string">
+      <object_component object_ref="oval:org.mitre.oval:obj:23452" item_field="value" />
+    </local_variable>


### PR DESCRIPTION
The objects that check the version of file onenote.exe for Office 2007 and 2010 should be different. Otherwise when two or more versions of OneNote are installed the results of definitions will be wrong.