### PR TITLE
Oval definitions for IBM AIX 6.1 and 7.1 for Mar 2016

### DIFF
--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160301.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160301.xml
@@ -1,19 +1,19 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:29329" version="7">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160301" version="0">
   <oval-def:metadata>
     <oval-def:title>Vulnerabilities in OpenSSL affect AIX </oval-def:title>
     <oval-def:affected family="unix">
       <oval-def:platform>IBM AIX 6.1</oval-def:platform>
       <oval-def:platform>IBM AIX 7.1</oval-def:platform>
     </oval-def:affected>
-    <oval-def:reference ref_id="CVE-2015-4000" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4000" source="CVE" />
-    <oval-def:description>A previously published vulnerability in the TLS protocol allows a man-in-the-middle attacker to downgrade vulnerable TLS connections using ephemeral Diffie-Hellman key exchange to 512-bit export-grade cryptography. This vulnerability is known as 'Logjam'. AIX OpenSSL had the Logjam mitigation for TLS clients by rejecting handshakes with DH parameters shorter than 768 bits. This limit has now been increased to 1024 bits.</oval-def:description>
+    <oval-def:reference ref_id="CVE-2015-3197" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3197" source="CVE" />
+    <oval-def:description>A malicious client can negotiate SSLv2 ciphers that have been disabled on the server and complete SSLv2 handshakes even if all SSLv2 ciphers have been disabled, provided that the SSLv2 protocol was not disabled via SSL_OP_NO_SSLv2.</oval-def:description>
     <oval-def:oval_repository>
       <oval-def:dates>
         <oval-def:submitted date="2014-11-05T11:43:28.000-05:00">
           <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
         </oval-def:submitted>
       </oval-def:dates>
-      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria operator="AND">

--- a/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160301.xml
+++ b/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160301.xml
@@ -1,0 +1,3 @@
+<interim_fix_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:obj:20160301" version="0">
+  <vuid>00F850C34C00021103023416</vuid>
+</interim_fix_object>

--- a/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160302.xml
+++ b/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160302.xml
@@ -1,0 +1,3 @@
+<interim_fix_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:obj:20160302" version="0">
+  <vuid>00F850C34C00021103021916</vuid>
+</interim_fix_object>

--- a/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160303.xml
+++ b/repository/objects/aix/interim_fix_object/20160000/oval_com.hp.temp.oval_obj_20160303.xml
@@ -1,0 +1,3 @@
+<interim_fix_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:obj:20160303" version="0">
+  <vuid>00F850C34C00021103024116</vuid>
+</interim_fix_object>

--- a/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160302.xml
+++ b/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160302.xml
@@ -1,0 +1,4 @@
+<interim_fix_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Interim fix IV81287m9a (vuid: 00F850C34C00021103023416) is installed" id="oval:com.hp.temp.oval:tst:20160302" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20160301" />
+  <state state_ref="oval:org.mitre.oval:ste:39185" />
+</interim_fix_test>

--- a/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160305.xml
+++ b/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160305.xml
@@ -1,0 +1,4 @@
+<interim_fix_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Interim fix IV81287m9b (vuid: 00F850C34C00021103021916) is installed" id="oval:com.hp.temp.oval:tst:20160305" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20160302" />
+  <state state_ref="oval:org.mitre.oval:ste:39185" />
+</interim_fix_test>

--- a/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160307.xml
+++ b/repository/tests/aix/interim_fix_test/20160000/oval_com.hp.temp.oval_tst_20160307.xml
@@ -1,0 +1,4 @@
+<interim_fix_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Interim fix IV81287m9c (vuid: 00F850C34C00021103024116) is installed" id="oval:com.hp.temp.oval:tst:20160307" version="0">
+  <object object_ref="oval:com.hp.temp.oval:obj:20160303" />
+  <state state_ref="oval:org.mitre.oval:ste:39185" />
+</interim_fix_test>


### PR DESCRIPTION
Updated oval definition for CVE-2015-4000 and added new definition for CVE-2015-3197