### PR TITLE
New Oval definitions for IBM AIX 6.1 and 7.1 for Mar 2016

### DIFF
--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160301.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160301.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160301" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-8472" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8472" source="CVE" />
+    <oval-def:description>libpng is vulnerable to a buffer overflow, caused by improper bounds checking by the png_get_PLTE() and png_set_PLTE() functions. By persuading a victim to open a specially crafted PNG image, a remote attacker could overflow a buffer and execute arbitrary code on the system or cause the application to crash.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160302.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160302.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160302" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-0475" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0475" source="CVE" />
+    <oval-def:description>An unspecified vulnerability in Oracle Java SE Java SE Embedded and Jrockit related to the Libraries component has partial confidentiality impact, partial integrity impact, and no availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160303.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160303.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160303" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-0466" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0466" source="CVE" />
+    <oval-def:description>An unspecified vulnerability in Oracle Java SE Java SE Embedded and Jrockit related to the JAXP component could allow a remote attacker to cause a denial of service resulting in a partial availability impact using unknown attack vectors.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160304.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160304.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160304" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-0402" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0402" source="CVE" />
+    <oval-def:description>An unspecified vulnerability in Oracle Java SE and Java SE Embedded related to the Networking component has no confidentiality impact, partial integrity impact, and no availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160305.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160305.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160305" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-0448" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0448" source="CVE" />
+    <oval-def:description>An unspecified vulnerability in Oracle Java SE and Java SE Embedded related to the JMX component could allow a remote attacker to obtain sensitive information resulting in a partial confidentiality impact using unknown attack vectors.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160306.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160306.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160306" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-0494" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0494" source="CVE" />
+    <oval-def:description>An unspecified vulnerability in Oracle Java SE and Java SE Embedded related to the 2D component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160307.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160307.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160307" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-0483" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0483" source="CVE" />
+    <oval-def:description>An unspecified vulnerability in Oracle Java SE Java SE Embedded and Jrockit related to the AWT component has complete confidentiality impact, complete integrity impact, and complete availability impact.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160308.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160308.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160308" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-5041" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5041" source="CVE" />
+    <oval-def:description>A flaw in the IBM J9 JVM allows code to invoke non-public interface methods under these circumstances. Untrusted code could potentially exploit this. This could lead to sensitive data being exposed to an attacker, or the attacker being able to inject bad data.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160309.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160309.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160309" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-7981" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7981" source="CVE" />
+    <oval-def:description>libpng could allow a remote attacker to obtain sensitive information, caused by an out-of-bounds read in the png_convert_to_rfc1123 function. An attacker could exploit this vulnerability to obtain sensitive information.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160310.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160310.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160310" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-8126" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8126" source="CVE" />
+    <oval-def:description>libpng is vulnerable to a buffer overflow, caused by improper bounds checking by the png_set_PLTE() and png_get_PLTE() functions. By persuading a victim to open a specially-crafted PNG file, a remote attacker could overflow a buffer and execute arbitrary code on the system..</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160311.xml
+++ b/repository/definitions/vulnerability/oval_com.hp.temp.oval_def_20160311.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.hp.temp.oval:def:20160311" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in IBM SDK Java affects AIX</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>IBM AIX 6.1</oval-def:platform>
+      <oval-def:platform>IBM AIX 7.1</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-8540" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8540" source="CVE" />
+    <oval-def:description>libpng is vulnerable to a buffer overflow, caused by a read underflow in png_check_keyword in pngwutil.c. By sending an overly long argument, a remote attacker could overflow a buffer and execute arbitrary code on the system or cause the application to crash.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-02-25T11:43:28.000-05:00">
+          <oval-def:contributor organization="Hewlett-Packard">Jaikumar</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="AND">
+    <oval-def:criteria comment="platforms" operator="OR">
+      <oval-def:extend_definition comment="IBM AIX 6.1 is installed" definition_ref="oval:org.mitre.oval:def:5267" />
+      <oval-def:extend_definition comment="IBM AIX 7.1 is installed" definition_ref="oval:org.mitre.oval:def:18828" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File Version Exists" operator="OR">
+      <oval-def:criterion comment="Java6.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160301" />
+      <oval-def:criterion comment="Java6_64.sdk less than 6.0.0.535" test_ref="oval:com.hp.temp.oval:tst:20160302" />
+      <oval-def:criterion comment="Java7.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160303" />
+      <oval-def:criterion comment="Java7_64.sdk less than 7.0.0.320" test_ref="oval:com.hp.temp.oval:tst:20160304" />
+      <oval-def:criterion comment="Java71.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160305" />
+      <oval-def:criterion comment="Java71_64.sdk less than 7.1.0.200" test_ref="oval:com.hp.temp.oval:tst:20160306" />
+      <oval-def:criterion comment="Java8.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160307" />
+      <oval-def:criterion comment="Java8_64.sdk less than 8.0.0.120" test_ref="oval:com.hp.temp.oval:tst:20160308" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160301.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160301.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160301" version="0">
+  <level datatype="version" operation="less than">6.0.0.535</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160302.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160302.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160302" version="0">
+  <level datatype="version" operation="less than">7.0.0.320</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160303.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160303.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160303" version="0">
+  <level datatype="version" operation="less than">7.1.0.200</level>
+</fileset_state>

--- a/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160304.xml
+++ b/repository/states/aix/fileset_state/20160000/oval_com.hp.temp.oval_ste_20160304.xml
@@ -1,0 +1,3 @@
+<fileset_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" id="oval:com.hp.temp.oval:ste:20160304" version="0">
+  <level datatype="version" operation="less than">8.0.0.120</level>
+</fileset_state>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160301.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160301.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java6.sdk less than 6.0.0.535" id="oval:com.hp.temp.oval:tst:20160301" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43277" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160301" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160302.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160302.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java6_64.sdk less than 6.0.0.535" id="oval:com.hp.temp.oval:tst:20160302" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43965" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160301" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160303.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160303.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java7.sdk less than 7.0.0.320" id="oval:com.hp.temp.oval:tst:20160303" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43113" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160302" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160304.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160304.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java7_64.sdk less than 7.0.0.320" id="oval:com.hp.temp.oval:tst:20160304" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43946" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160302" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160305.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160305.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java71.sdk less than 7.1.0.200" id="oval:com.hp.temp.oval:tst:20160305" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:43787" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160303" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160306.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160306.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java71_64.sdk less than 7.1.0.200" id="oval:com.hp.temp.oval:tst:20160306" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:44036" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160303" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160307.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160307.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java8.sdk less than 8.0.0.120" id="oval:com.hp.temp.oval:tst:20160307" version="0">
+  <object object_ref="oval:org.cisecurity:obj:112" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160304" />
+</fileset_test>

--- a/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160308.xml
+++ b/repository/tests/aix/fileset_test/20160000/oval_com.hp.temp.oval_tst_20160308.xml
@@ -1,0 +1,4 @@
+<fileset_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix" check="at least one" check_existence="at_least_one_exists" comment="Java8_64.sdk less than 8.0.0.120" id="oval:com.hp.temp.oval:tst:20160308" version="0">
+  <object object_ref="oval:org.cisecurity:obj:113" />
+  <state state_ref="oval:com.hp.temp.oval:ste:20160304" />
+</fileset_test>


### PR DESCRIPTION
Oval definitions for following CVEs - CVE-2015-8472 CVE-2016-0475 CVE-2016-0466 CVE-2016-0402 
    CVE-2016-0448 CVE-2016-0494 CVE-2016-0483 CVE-2015-5041 CVE-2015-7981
    CVE-2015-8126 CVE-2015-8540
