### PR TITLE
Kemanik winword

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_492.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_492.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:492" version="2">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:492" commentT="Word 2013 winword.exe" version="2">
   <path var_check="at least one" var_ref="oval:org.mitre.oval:var:221" />
   <filename>winword.exe</filename>
 </file_object>

--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_492.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_492.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:492" version="2">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:221" />
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:221" />
   <filename>winword.exe</filename>
 </file_object>

--- a/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23900.xml
+++ b/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23900.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Word 2010 winword.exe" id="oval:org.mitre.oval:obj:23900" version="1">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:1266" />
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1266" />
   <filename>WINWORD.EXE</filename>
 </file_object>

--- a/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
+++ b/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
@@ -1,4 +1,1 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:38200" comment="Object holds the file Onenote.Exe" version="1">
-      <path var_ref="oval:ru.altx-soft.win:var:38054" var_check="all" />
-      <filename>Onenote.exe</filename>
-    </file_object>
+

--- a/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
+++ b/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:38200" comment="Object holds the file Onenote.Exe" version="1">
+      <path var_ref="oval:ru.altx-soft.win:var:38054" var_check="all" />
+      <filename>Onenote.exe</filename>
+    </file_object>

--- a/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100107.xml
+++ b/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100107.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7113.5001" id="oval:org.mitre.oval:tst:100107" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:492" />
+  <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:27634" />
 </file_test>

--- a/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100175.xml
+++ b/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100175.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 11.0.8409" id="oval:org.mitre.oval:tst:100175" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:492" />
+  <object object_ref="oval:org.mitre.oval:obj:6394" />
   <state state_ref="oval:org.mitre.oval:ste:27890" />
 </file_test>

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114871.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114871.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 12.0.6700.5000" id="oval:org.mitre.oval:tst:114871" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:492" />
+  <object object_ref="oval:org.mitre.oval:obj:23914" />
   <state state_ref="oval:org.mitre.oval:ste:30903" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138611.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138611.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138611" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:492" />
+  <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:38731" />
 </file_test>

--- a/repository/tests/windows/file_test/99000/oval_org.mitre.oval_tst_99795.xml
+++ b/repository/tests/windows/file_test/99000/oval_org.mitre.oval_tst_99795.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 12.0.6690.5000" id="oval:org.mitre.oval:tst:99795" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:492" />
+  <object object_ref="oval:org.mitre.oval:obj:23914" />
   <state state_ref="oval:org.mitre.oval:ste:27878" />
 </file_test>

--- a/repository/variables/oval_org.mitre.oval_var_221.xml
+++ b/repository/variables/oval_org.mitre.oval_var_221.xml
@@ -1,5 +1,3 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Word install directory" datatype="string" id="oval:org.mitre.oval:var:221" version="2">
-  <oval-def:regex_capture pattern="^(.*[^\\])\\?$">
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:493" />
-  </oval-def:regex_capture>
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment=""Path to winword.exe for Word 2013" datatype="string" id="oval:org.mitre.oval:var:221" version="2">
+    <oval-def:object_component item_field="value" object_ref=oval:org.mitre.oval:obj:23844" />
 </oval-def:local_variable>

--- a/repository/variables/oval_ru.altx-soft.win_var_38054.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_38054.xml
@@ -1,3 +1,1 @@
-<local_variable id="oval:ru.altx-soft.win:var:38054" comment="File path to office14" version="1" datatype="string">
-      <object_component object_ref="oval:org.mitre.oval:obj:23452" item_field="value" />
-    </local_variable>
+

--- a/repository/variables/oval_ru.altx-soft.win_var_38054.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_38054.xml
@@ -1,0 +1,3 @@
+<local_variable id="oval:ru.altx-soft.win:var:38054" comment="File path to office14" version="1" datatype="string">
+      <object_component object_ref="oval:org.mitre.oval:obj:23452" item_field="value" />
+    </local_variable>


### PR DESCRIPTION
The objects that check the version of file winword.exe for Office 2003, 2007, 2010 and 2013 should be different. Otherwise when two or more versions of Word are installed the results of definitions will be wrong.