### PR TITLE
Kemanik excel

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_662.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_662.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:662" version="2">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:231" />
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:662" comment="Excel 2013 Excel.exe" version="2">
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:231" />
   <filename>excel.exe</filename>
 </file_object>

--- a/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23971.xml
+++ b/repository/objects/windows/file_object/23000/oval_org.mitre.oval_obj_23971.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Excel 2010 Excel.exe" id="oval:org.mitre.oval:obj:23971" version="1">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:1610" />
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1610" />
   <filename>excel.exe</filename>
 </file_object>

--- a/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6362.xml
+++ b/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6362.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6362" version="2">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6362" comment="Excel 2007 Excel.exe" version="2">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:1793" />
   <filename>EXCEL.EXE</filename>
 </file_object>

--- a/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6435.xml
+++ b/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6435.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6435" version="2">
-  <path var_check="all" var_ref="oval:org.mitre.oval:var:1024" />
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6435" comment="Excel 2003 Excel.exe" version="2">
+  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1024" />
   <filename>EXCEL.EXE</filename>
 </file_object>

--- a/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6435.xml
+++ b/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6435.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6435" comment="Excel 2003 Excel.exe" version="2">
-  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1024" />
+  <path var_check="all" var_ref="oval:org.mitre.oval:var:1024" />
   <filename>EXCEL.EXE</filename>
 </file_object>

--- a/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6509.xml
+++ b/repository/objects/windows/file_object/6000/oval_org.mitre.oval_obj_6509.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6509" version="3">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:6509" comment="Excel 2000 Excel.exe" version="3">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:826" />
   <filename>EXCEL.EXE</filename>
 </file_object>

--- a/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
+++ b/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
@@ -1,4 +1,1 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:38200" comment="Object holds the file Onenote.Exe" version="1">
-      <path var_ref="oval:ru.altx-soft.win:var:38054" var_check="all" />
-      <filename>Onenote.exe</filename>
-    </file_object>
+

--- a/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
+++ b/repository/objects/windows/file_object/oval_ru.altx-soft.win_obj_38200.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:38200" comment="Object holds the file Onenote.Exe" version="1">
+      <path var_ref="oval:ru.altx-soft.win:var:38054" var_check="all" />
+      <filename>Onenote.exe</filename>
+    </file_object>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137990.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137990.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7143.5000" id="oval:org.mitre.oval:tst:137990" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:662" />
+  <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.mitre.oval:ste:38286" />
 </file_test>

--- a/repository/variables/oval_org.mitre.oval_var_231.xml
+++ b/repository/variables/oval_org.mitre.oval_var_231.xml
@@ -1,3 +1,3 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Excel installation directory" datatype="string" id="oval:org.mitre.oval:var:231" version="1">
-  <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:663" />
+  <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23980" />
 </oval-def:local_variable>

--- a/repository/variables/oval_ru.altx-soft.win_var_38054.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_38054.xml
@@ -1,3 +1,1 @@
-<local_variable id="oval:ru.altx-soft.win:var:38054" comment="File path to office14" version="1" datatype="string">
-      <object_component object_ref="oval:org.mitre.oval:obj:23452" item_field="value" />
-    </local_variable>
+

--- a/repository/variables/oval_ru.altx-soft.win_var_38054.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_38054.xml
@@ -1,0 +1,3 @@
+<local_variable id="oval:ru.altx-soft.win:var:38054" comment="File path to office14" version="1" datatype="string">
+      <object_component object_ref="oval:org.mitre.oval:obj:23452" item_field="value" />
+    </local_variable>


### PR DESCRIPTION
The objects that check the version of file excel.exe for Office 2003, 2007, 2010 and 2013 should be different. Otherwise when two or more versions of Excel are installed the results of definitions will be wrong.