### PR TITLE
Kemanik obj 1382

### DIFF
--- a/repository/objects/windows/file_object/1000/oval_org.mitre.oval_obj_1382.xml
+++ b/repository/objects/windows/file_object/1000/oval_org.mitre.oval_obj_1382.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1382" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:1382" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>winsrv.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/2000/oval_org.mitre.oval_tst_2428.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.mitre.oval_tst_2428.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of winsrv.dll is less than 4.0.1381.7202" id="oval:org.mitre.oval:tst:2428" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:2275" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3229.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3229.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="The version of winsrv.dll is less than 5.2.3790.2902." id="oval:org.mitre.oval:tst:3229" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:3200" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3288.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3288.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="The version of winsrv.dll is less than 5.2.3790.658." id="oval:org.mitre.oval:tst:3288" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:3536" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3303.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3303.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of winsrv.dll is less than 6.0.5600.20522" id="oval:org.mitre.oval:tst:3303" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:3000" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3701.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3701.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="The version of winsrv.dll is less than 6.0.6000.16445." id="oval:org.mitre.oval:tst:3701" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:3852" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3935.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3935.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="The version of winsrv.dll is less than 5.0.2195.7135." id="oval:org.mitre.oval:tst:3935" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:3501" />
 </file_test>

--- a/repository/tests/windows/file_test/4000/oval_org.mitre.oval_tst_4046.xml
+++ b/repository/tests/windows/file_test/4000/oval_org.mitre.oval_tst_4046.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of winsrv.dll is less than 6.0.6000.16445" id="oval:org.mitre.oval:tst:4046" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:3124" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42142.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42142.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="The version of winsrv.dll is less than 5.1.2600.3103." id="oval:org.mitre.oval:tst:42142" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:12381" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79826.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79826.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of winsrv.dll is less than 6.0.6000.20544" id="oval:org.mitre.oval:tst:79826" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:19508" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80223.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80223.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of winsrv.dll is greater than or equal 6.0.6000.20000" id="oval:org.mitre.oval:tst:80223" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:19788" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80250.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80250.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="The version of winsrv.dll is less than 5.2.3790.4043." id="oval:org.mitre.oval:tst:80250" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:1382" />
+  <object object_ref="oval:org.mitre.oval:obj:6560" />
   <state state_ref="oval:org.mitre.oval:ste:19849" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:6560](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6560) and [oval:org.mitre.oval:obj:1382](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:1382) are duplicates. [oval:org.mitre.oval:obj:6560](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:6560)  was taken as a basic.