### PR TITLE
Kemanik obj 12128

### DIFF
--- a/repository/objects/windows/file_object/12000/oval_org.mitre.oval_obj_12128.xml
+++ b/repository/objects/windows/file_object/12000/oval_org.mitre.oval_obj_12128.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:12128" version="2">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:12128" deprecated="true" version="2">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:157" />
   <filename>infopath.exe</filename>
 </file_object>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42866.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42866.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of infopath.exe is less than 15.0.0.0" id="oval:org.mitre.oval:tst:42866" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:12128" />
+  <object object_ref="oval:org.cisecurity:obj:157" />
   <state state_ref="oval:org.mitre.oval:ste:11973" />
 </file_test>

--- a/repository/variables/oval_org.mitre.oval_var_157.xml
+++ b/repository/variables/oval_org.mitre.oval_var_157.xml
@@ -1,4 +1,4 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="InfoPath installation directory" datatype="string" id="oval:org.mitre.oval:var:157" version="2">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="InfoPath installation directory" datatype="string" id="oval:org.mitre.oval:var:157" deprecated="true" version="2">
   <oval-def:regex_capture pattern="^(.*[^\\])\\?$">
     <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:12270" />
   </oval-def:regex_capture>


### PR DESCRIPTION
The object oval:org.mitre.oval:obj:12128 should be replaced with oval:org.cisecurity:obj:157 in the test because the test could return wrong value if more than one Infopath is installed on system.