### PR TITLE
Kemanik obj 2045

### DIFF
--- a/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2045.xml
+++ b/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2045.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2045" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2045" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>csrsrv.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3645.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3645.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of csrsrv.dll is less than 6.0.5600.20522" id="oval:org.mitre.oval:tst:3645" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:2045" />
+  <object object_ref="oval:org.mitre.oval:obj:12030" />
   <state state_ref="oval:org.mitre.oval:ste:3236" />
 </file_test>

--- a/repository/tests/windows/file_test/4000/oval_org.mitre.oval_tst_4022.xml
+++ b/repository/tests/windows/file_test/4000/oval_org.mitre.oval_tst_4022.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of csrsrv.dll is less than 6.0.6000.16445" id="oval:org.mitre.oval:tst:4022" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:2045" />
+  <object object_ref="oval:org.mitre.oval:obj:12030" />
   <state state_ref="oval:org.mitre.oval:ste:3788" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:12030](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:12030) and [oval:org.mitre.oval:obj:2045](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:2045).[oval:org.mitre.oval:obj:12030](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:12030) was taken as a basic.