### PR TITLE
Kemanik obj 38396

### DIFF
--- a/repository/objects/windows/file_object/38000/oval_org.mitre.oval_obj_38396.xml
+++ b/repository/objects/windows/file_object/38000/oval_org.mitre.oval_obj_38396.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the file Msgr3en.dll (Office 2013)" id="oval:org.mitre.oval:obj:38396" version="3">
-  <path var_check="at least one" var_ref="oval:org.mitre.oval:var:1092" />
+  <path var_check="at least one" var_ref="oval:ru.test.win:var:1092" />
   <filename>Msgr3en.dll</filename>
 </file_object>

--- a/repository/variables/oval_ru.test.win_var_1092.xml
+++ b/repository/variables/oval_ru.test.win_var_1092.xml
@@ -1,0 +1,6 @@
+<local_variable id="oval:ru.test.win:var:1092" version="1" comment="Variable holds the path to Msgr3en.dll (Office 2013)" datatype="string">
+      <concat>
+        <object_component object_ref="oval:org.mitre.oval:obj:39280" item_field="value" />
+        <literal_component>\Microsoft Office\Office15\PROOF\2052</literal_component>
+      </concat>
+    </local_variable>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:38396](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:38396) and [oval:ru.altx-soft.win:obj:39068](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:ru.altx-soft.win:obj:39068) use the same variable which add "\Microsoft Office\Office14\PROOF\1033" to the path. It is wrong because the objects are check Office 2010 and Office 2013.