### PR TITLE
Kemanik obj 7087

### DIFF
--- a/repository/objects/windows/file_object/7000/oval_org.mitre.oval_obj_7087.xml
+++ b/repository/objects/windows/file_object/7000/oval_org.mitre.oval_obj_7087.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:7087" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:7087" deprecated="true" version="1">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:200" />
   <filename>strmdll.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/10000/oval_org.mitre.oval_tst_10752.xml
+++ b/repository/tests/windows/file_test/10000/oval_org.mitre.oval_tst_10752.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of strmdll.dll is less than 4.1.0.3938" id="oval:org.mitre.oval:tst:10752" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:7087" />
+  <object object_ref="oval:org.mitre.oval:obj:7277" />
   <state state_ref="oval:org.mitre.oval:ste:5414" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:7087](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7087) and [oval:org.mitre.oval:obj:7277](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7277) are dublicates.  [oval:org.mitre.oval:obj:7277](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:7277) was taken as a basic.