### PR TITLE
Kemanik obj 30227

### DIFF
--- a/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100090.xml
+++ b/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100090.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Msoserver.Dll is less than 15.0.4551.1507" id="oval:org.mitre.oval:tst:100090" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:30227" />
+  <object object_ref="oval:org.mitre.oval:obj:30360" />
   <state state_ref="oval:org.mitre.oval:ste:27285" />
 </file_test>

--- a/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100103.xml
+++ b/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100103.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Msoserver.Dll is less than 15.0.4551.1007" id="oval:org.mitre.oval:tst:100103" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:30227" />
+  <object object_ref="oval:org.mitre.oval:obj:30360" />
   <state state_ref="oval:org.mitre.oval:ste:27906" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113807.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113807.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 15.0.4605.1000" id="oval:org.mitre.oval:tst:113807" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:30227" />
+  <object object_ref="oval:org.mitre.oval:obj:30360" />
   <state state_ref="oval:org.mitre.oval:ste:30197" />
 </file_test>

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114430.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114430.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msoserver.dll is less than 15.0.4615.1000" id="oval:org.mitre.oval:tst:114430" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:30227" />
+  <object object_ref="oval:org.mitre.oval:obj:30360" />
   <state state_ref="oval:org.mitre.oval:ste:31346" />
 </file_test>


### PR DESCRIPTION
The object  [oval:org.mitre.oval:obj:30227](http://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:30227) checks Office14 (Office 2010) but it should check Office Web Apps 2013. That's why the object was replaced with [oval:org.mitre.oval:obj:30360](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:30360)