### PR TITLE
Kemanik obj 15851

### DIFF
--- a/repository/objects/windows/file_object/15000/oval_org.mitre.oval_obj_15851.xml
+++ b/repository/objects/windows/file_object/15000/oval_org.mitre.oval_obj_15851.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:15851" version="1">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:15851" deprecated="true" version="2">
   <path var_check="all" var_ref="oval:org.mitre.oval:var:994" />
   <filename>xlsrv.dll</filename>
 </file_object>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43943.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43943.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="xlsrv.dll version is less than 14.0.6106.5005" id="oval:org.mitre.oval:tst:43943" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15851" />
+  <object object_ref="oval:org.mitre.oval:obj:26571" />
   <state state_ref="oval:org.mitre.oval:ste:12912" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:26571](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:26571) is more correct than [oval:org.mitre.oval:obj:15851](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15851). the object [oval:org.mitre.oval:obj:15851](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15851) should be deprecated