### PR TITLE
Kemanik obj 15473

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_29391.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_29391.xml
@@ -20,11 +20,11 @@
       <min_schema_version>5.4</min_schema_version>
     </oval_repository>
   </metadata>
-  <criteria operator="AND">
+  <criteria>
     <criteria comment="8.1 /  2k12 (x64 bit)" operator="OR">
       <extend_definition comment="Microsoft Windows 8.1 (x64) is installed" definition_ref="oval:org.mitre.oval:def:20956" />
       <extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
     </criteria>
-    <criterion comment="Check if the version of storvsp.sys is less than 6.3.9600.17723" test_ref="oval:org.mitre.oval:tst:141050" />
+    <criterion comment="the version of Storvsp.sys is less than 6.3.9600.17723" test_ref="oval:org.mitre.oval:tst:141050" />
   </criteria>
 </definition>

--- a/repository/objects/windows/file_object/44000/oval_org.mitre.oval_obj_44256.xml
+++ b/repository/objects/windows/file_object/44000/oval_org.mitre.oval_obj_44256.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the information of storvsp.sys" id="oval:org.mitre.oval:obj:44256" version="8">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the information of storvsp.sys" id="oval:org.mitre.oval:obj:44256" deprecated="true" version="8">
   <path var_check="at least one" var_ref="oval:org.mitre.oval:var:201" />
   <filename>storvsp.sys</filename>
 </file_object>

--- a/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141050.xml
+++ b/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141050.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of storvsp.sys is less than 6.3.9600.17723" id="oval:org.mitre.oval:tst:141050" version="8">
-  <object object_ref="oval:org.mitre.oval:obj:44256" />
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Storvsp.sys is less than 6.3.9600.17723" id="oval:org.mitre.oval:tst:141050" version="8">
+  <object object_ref="oval:org.mitre.oval:obj:15473" />
   <state state_ref="oval:org.mitre.oval:ste:39440" />
 </file_test>


### PR DESCRIPTION
[oval:org.mitre.oval:obj:15473](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15473) and [oval:org.mitre.oval:obj:44256](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:44256) are duplicates. [oval:org.mitre.oval:obj:15473](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:15473) was taken as a basic because it used in greater quantity of tests.