### PR TITLE
Kemanik tst 1456

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1014.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1014.xml
@@ -64,7 +64,7 @@
     </criteria>
     <criteria comment="Configuration section" operator="AND">
       <criteria comment="File Downloads Not Disabled" operator="AND">
-        <criterion comment="Use Machine Settings" negate="false" test_ref="oval:org.mitre.oval:tst:1456" />
+        <criterion comment="use machine settings rather than individual user settings" negate="false" test_ref="oval:org.mitre.oval:tst:2951" />
         <criterion comment="File Downloads Allowed In At Least One Zone" negate="false" test_ref="oval:org.mitre.oval:tst:1455" />
       </criteria>
     </criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_921.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_921.xml
@@ -60,7 +60,7 @@
     <criterion comment="the patch q828750 is installed (Installed Components key)" negate="true" test_ref="oval:org.mitre.oval:tst:3111" />
     <criterion comment="the patch q824145 is installed (Installed Components key)" negate="true" test_ref="oval:org.mitre.oval:tst:3110" />
     <criterion comment="the patch q832894 is installed (Installed Components key)" negate="true" test_ref="oval:org.mitre.oval:tst:2588" />
-    <criterion comment="Use Machine Settings" test_ref="oval:org.mitre.oval:tst:1456" />
+    <criterion comment="use machine settings rather than individual user settings" test_ref="oval:org.mitre.oval:tst:2951 />
     <criterion comment="File Downloads Allowed In At Least One Zone" test_ref="oval:org.mitre.oval:tst:1455" />
   </criteria>
 </definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_925.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_925.xml
@@ -58,7 +58,7 @@
     <criterion comment="the patch q828750 is installed (Installed Components key)" negate="true" test_ref="oval:org.mitre.oval:tst:3111" />
     <criterion comment="the patch q824145 is installed (Installed Components key)" negate="true" test_ref="oval:org.mitre.oval:tst:3110" />
     <criterion comment="the patch q832894 is installed (Installed Components key)" negate="true" test_ref="oval:org.mitre.oval:tst:2588" />
-    <criterion comment="Use Machine Settings" test_ref="oval:org.mitre.oval:tst:1456" />
+    <criterion comment="use machine settings rather than individual user settings" test_ref="oval:org.mitre.oval:tst:2951" />
     <criterion comment="Run ActiveX Controls and Plugins Allowed In At Least One Zone" test_ref="oval:org.mitre.oval:tst:1450" />
   </criteria>
 </definition>

--- a/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1456.xml
+++ b/repository/tests/windows/registry_test/1000/oval_org.mitre.oval_tst_1456.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Use Machine Settings" id="oval:org.mitre.oval:tst:1456" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Use Machine Settings" id="oval:org.mitre.oval:tst:1456" deprecated="true" version="1">
   <object object_ref="oval:org.mitre.oval:obj:990" />
   <state state_ref="oval:org.mitre.oval:ste:1314" />
 </registry_test>


### PR DESCRIPTION
[oval:org.mitre.oval:tst:1456](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:1456) and [oval:org.mitre.oval:tst:2951](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2951) are duplicates.  [oval:org.mitre.oval:tst:2951](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:2951) was taken as a basic because it used in greater quantity of definitions.