### PR TITLE
Escape non-regex .'s in oval:org.mitre.var:306

### DIFF
--- a/repository/variables/oval_org.mitre.oval_var_306.xml
+++ b/repository/variables/oval_org.mitre.oval_var_306.xml
@@ -1,9 +1,9 @@
-<local_variable xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="WinHttp directory" datatype="string" id="oval:org.mitre.oval:var:306" version="12">
+<local_variable xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="WinHttp directory" datatype="string" id="oval:org.mitre.oval:var:306" version="13">
   <concat>
     <literal_component>^</literal_component>
     <escape_regex>
       <object_component item_field="value" object_ref="oval:org.mitre.oval:obj:219" />
     </escape_regex>
-    <literal_component>\\WinSxS\\x86_Microsoft.Windows.WinHTTP_.+$</literal_component>
+    <literal_component>\\WinSxS\\x86_Microsoft\.Windows\.WinHTTP_.+$</literal_component>
   </concat>
 </local_variable>


### PR DESCRIPTION
This fix improves scan time by ~100sec.