### PR TITLE
The definitions oval:org.cisecurity:def:506, 516 and 518 are inventor…

### DIFF
--- a/repository/definitions/inventory/oval_org.cisecurity_def_506.xml
+++ b/repository/definitions/inventory/oval_org.cisecurity_def_506.xml
@@ -1,6 +1,6 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:518" version="1">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.cisecurity:def:506" version="1">
   <metadata>
-    <title>Adobe Flash Player 21 is installed</title>
+    <title>Adobe Flash Player 20 is installed</title>
     <affected family="windows">
       <platform>Microsoft Windows XP</platform>
       <platform>Microsoft Windows Vista</platform>
@@ -14,8 +14,8 @@
       <platform>Microsoft Windows 10</platform>
       <product>Adobe Flash Player</product>
     </affected>
-    <reference ref_id="cpe:/a:adobe:flash_player:21" source="CPE" />
-    <description>Adobe Flash Player 21 is installed on the system</description>
+    <reference ref_id="cpe:/a:adobe:flash_player:20" source="CPE" />
+    <description>Adobe Flash Player 20 is installed on the system</description>
     <oval_repository>
       <dates>
         <submitted date="2016-04-07T22:00:00+08:00">
@@ -27,6 +27,6 @@
     </oval_repository>
   </metadata>
   <criteria comment="Check for the version of Adobe Flash Player">
-    <criterion comment="Adobe Flash Player 21 is installed on the system" test_ref="oval:org.cisecurity:tst:924" />
+    <criterion comment="Adobe Flash Player 20 is installed on the system" test_ref="oval:org.cisecurity:tst:922" />
   </criteria>
 </definition>

--- a/repository/definitions/inventory/oval_org.cisecurity_def_516.xml
+++ b/repository/definitions/inventory/oval_org.cisecurity_def_516.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:516" version="1">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.cisecurity:def:516" version="1">
   <metadata>
     <title>Adobe Flash Player 19 is installed</title>
     <affected family="windows">

--- a/repository/definitions/inventory/oval_org.cisecurity_def_518.xml
+++ b/repository/definitions/inventory/oval_org.cisecurity_def_518.xml
@@ -1,6 +1,6 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:506" version="1">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.cisecurity:def:518" version="1">
   <metadata>
-    <title>Adobe Flash Player 20 is installed</title>
+    <title>Adobe Flash Player 21 is installed</title>
     <affected family="windows">
       <platform>Microsoft Windows XP</platform>
       <platform>Microsoft Windows Vista</platform>
@@ -14,8 +14,8 @@
       <platform>Microsoft Windows 10</platform>
       <product>Adobe Flash Player</product>
     </affected>
-    <reference ref_id="cpe:/a:adobe:flash_player:20" source="CPE" />
-    <description>Adobe Flash Player 20 is installed on the system</description>
+    <reference ref_id="cpe:/a:adobe:flash_player:21" source="CPE" />
+    <description>Adobe Flash Player 21 is installed on the system</description>
     <oval_repository>
       <dates>
         <submitted date="2016-04-07T22:00:00+08:00">
@@ -27,6 +27,6 @@
     </oval_repository>
   </metadata>
   <criteria comment="Check for the version of Adobe Flash Player">
-    <criterion comment="Adobe Flash Player 20 is installed on the system" test_ref="oval:org.cisecurity:tst:922" />
+    <criterion comment="Adobe Flash Player 21 is installed on the system" test_ref="oval:org.cisecurity:tst:924" />
   </criteria>
 </definition>


### PR DESCRIPTION
…y definitions, but they were incorrectly assigned @class="vulnerability"