### PR TITLE
Update oval_org.cisecurity_ste_976.xml

### DIFF
--- a/repository/states/windows/file_state/0000/oval_org.cisecurity_ste_976.xml
+++ b/repository/states/windows/file_state/0000/oval_org.cisecurity_ste_976.xml
@@ -1,3 +1,3 @@
-<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches Win32k.sys version less than 6.0.6002.19636" id="oval:org.cisecurity:ste:976" version="0">
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.0.6002.19636" id="oval:org.cisecurity:ste:976" version="2">
   <version datatype="version" operation="less than">6.0.6002.19636</version>
 </file_state>


### PR DESCRIPTION
change comment from: "State matches Win32k.sys version less than 6.0.6002.19636" to "State holds if the version is less than 6.0.6002.19636" to make the file state usable to other files.