### PR TITLE
fixed oval:org.cisecurity:def:448

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_448.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_448.xml
@@ -106,7 +106,7 @@
           <criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.18161" test_ref="oval:org.cisecurity:tst:690" />
         </criteria>
         <criteria comment="Win 10 + vulnerable file version" operator="AND">
-          <extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
+          <extend_definition comment="Microsoft Windows 10 is installed" definition_ref="oval:org.mitre.oval:def:28545" />
           <criterion comment="Check if the version of mshtml.dll is less than 11.0.10240.16603" test_ref="oval:org.cisecurity:tst:695" />
         </criteria>
         <criteria comment="Win 10 version 1511 + vulnerable file version" operator="AND">


### PR DESCRIPTION
a criteria which should check windows 10 wrongly checked windows 7 x64