### PR TITLE
Kemanik sles 11

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_17270.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_17270.xml
@@ -25,6 +25,6 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria>
-    <oval-def:criterion comment="SUSE Linux Enterprise Server 11.x is installed" test_ref="oval:org.mitre.oval:tst:81116" />
+    <oval-def:criterion comment="SUSE Linux Enterprise Server 11.x is installed" test_ref="oval:ru.test.nix:tst:1" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/objects/independent/textfilecontent54_object/oval_ru.test.nix_obj_1.xml
+++ b/repository/objects/independent/textfilecontent54_object/oval_ru.test.nix_obj_1.xml
@@ -1,0 +1,6 @@
+<textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:ru.test.nix:obj:1" version="0" comment="Object holds SLES version">
+      <path>/etc</path>
+      <filename>SuSE-release</filename>
+      <pattern operation="pattern match">^SUSE Linux Enterprise Server (\d+).*$</pattern>
+      <instance datatype="int">1</instance>
+    </textfilecontent54_object>

--- a/repository/states/independent/textfilecontent54_state/oval_ru.test.nix_ste_1.xml
+++ b/repository/states/independent/textfilecontent54_state/oval_ru.test.nix_ste_1.xml
@@ -1,0 +1,3 @@
+<textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:ru.test.nix:ste:1" version="0" comment="version is equal to 11">
+      <subexpression>11</subexpression>
+    </textfilecontent54_state>

--- a/repository/tests/independent/textfilecontent54_test/oval_ru.test.nix_tst_1.xml
+++ b/repository/tests/independent/textfilecontent54_test/oval_ru.test.nix_tst_1.xml
@@ -1,0 +1,4 @@
+<textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:ru.test.nix:tst:1" version="0" comment="SUSE Linux Enterprise Server 11.x is installed" check_existence="at_least_one_exists" check="all">
+      <object object_ref="oval:ru.test.nix:obj:1" />
+      <state state_ref="oval:ru.test.nix:ste:1" />
+    </textfilecontent54_test>


### PR DESCRIPTION
Criteria in inventory on SLES 11 was changed. After installation VMware vCenter Server on SLES 11 the package _sles-release_ is replaced with _sles-for-vmware-release_ that's why it is more correct to check the file _/etc/suse-release_ which presents in all cases.