### PR TITLE
Kemanik oracle fix

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_24927.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_24927.xml
@@ -37,7 +37,7 @@
       <oval-def:criterion comment="Check if Oracle VM VirtualBox version is from 4.0.0 to 4.0.24" test_ref="oval:org.mitre.oval:tst:115646" />
       <oval-def:criterion comment="Check if Oracle VM VirtualBox version is from 4.1.0 to 4.1.32" test_ref="oval:org.mitre.oval:tst:115962" />
       <oval-def:criterion comment="Check if Oracle VM VirtualBox version is from 4.2.0 to 4.2.24" test_ref="oval:org.mitre.oval:tst:116019" />
-      <oval-def:criterion comment="Check if Oracle VM VirtualBox version is from 4.3.0 to 4.3.10" test_ref="oval:org.mitre.oval:tst:115787" />
+      <oval-def:criterion comment="Check if Oracle VM VirtualBox version is from 4.3.0 to 4.3.12" test_ref="oval:org.mitre.oval:tst:115684" />
     </oval-def:criteria>
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/states/windows/file_state/oval_ru.test.win_ste_2
+++ b/repository/states/windows/file_state/oval_ru.test.win_ste_2
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.test.win:ste:2" version="0" comment="State matches if Oracle VM VirtualBox version is less than  or equal 4.3.10">
+      <version datatype="version" operation="less than or equal">4.3.10</version>
+    </file_state>

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115787.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115787.xml
@@ -1,5 +1,5 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="all_exist" comment="Check if Oracle VM VirtualBox version is from 4.3.0 to 4.3.10" id="oval:org.mitre.oval:tst:115787" version="1">
   <object object_ref="oval:org.mitre.oval:obj:39355" />
   <state state_ref="oval:org.mitre.oval:ste:27456" />
-  <state state_ref="oval:org.mitre.oval:ste:31612" />
+  <state state_ref="oval:ru.test.win:ste:2" />
 </file_test>


### PR DESCRIPTION
State was fixed in [oval:org.mitre.oval:tst:115787](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:tst:115787). The version 4.3.12 was replaced with 4.3.10.