### PR TITLE
SAP ASE vulnerability (CVE-2014-6284)

### DIFF
--- a/repository/definitions/inventory/oval_ru.altx-soft.win_def_35628
+++ b/repository/definitions/inventory/oval_ru.altx-soft.win_def_35628
@@ -1,0 +1,29 @@
+<definition class="inventory" id="oval:ru.altx-soft.win:def:35628" version="0">
+      <metadata>
+        <title>SAP Adaptive Server Enterprise is installed</title>
+        <affected family="windows">
+          <platform>Microsoft Windows 7</platform>
+          <platform>Microsoft Windows 8</platform>
+          <platform>Microsoft Windows 8.1</platform>
+          <platform>Microsoft Windows 10</platform>
+          <platform>Microsoft Windows Server 2008</platform>
+          <platform>Microsoft Windows Server 2008 R2</platform>
+          <platform>Microsoft Windows Server 2012</platform>
+          <platform>Microsoft Windows Server 2012 R2</platform>
+          <product>SAP Adaptive Server Enterprise</product>
+        </affected>
+        <reference ref_id="cpe:/a:sap:adaptive_server_enterprise" source="CPE" />
+        <description>SAP Adaptive Server Enterprise (ASE) is installed</description>
+        <oval_repository>
+          <dates>
+            <submitted date="2016-07-02T12:49:00">
+              <contributor organization="ALTX-SOFT">Sergey Artykhov</contributor>
+            </submitted>
+          </dates>
+        </oval_repository>
+      </metadata>
+      <criteria operator="OR">
+        <criterion comment="Sybase Adaptive Server Enterprise is installed" test_ref="oval:ru.altx-soft.win:tst:44538" />
+        <criterion comment="SAP Adaptive Server Enterprise is installed" test_ref="oval:ru.altx-soft.win:tst:44539" />
+      </criteria>
+    </definition>

--- a/repository/definitions/vulnerability/oval_com.altx-soft.win_def_3562
+++ b/repository/definitions/vulnerability/oval_com.altx-soft.win_def_3562
@@ -1,0 +1,33 @@
+<definition class="vulnerability" id="oval:com.altx-soft.win:def:35629" version="0">
+      <metadata>
+        <title>SAP Adaptive Server Enterprise (ASE) before 15.7 SP132 and 16.0 before 16.0 SP01 allows remote attackers to bypass the challenge and response mechanism and obtain access to the probe account via a crafted response, aka SAP Security Note 2113995.</title>
+        <affected family="windows">
+          <platform>Microsoft Windows 7</platform>
+          <platform>Microsoft Windows 8</platform>
+          <platform>Microsoft Windows 8.1</platform>
+          <platform>Microsoft Windows 10</platform>
+          <platform>Microsoft Windows Server 2008</platform>
+          <platform>Microsoft Windows Server 2008 R2</platform>
+          <platform>Microsoft Windows Server 2012</platform>
+          <platform>Microsoft Windows Server 2012 R2</platform>
+          <product>SAP Adaptive Server Enterprise</product>
+        </affected>
+        <reference ref_id="CVE-2014-6284" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6284" source="CVE" />
+        <reference ref_id="2113995" ref_url="https://support.sap.com/securitynotes" source="SAP" />
+        <description>SAP Adaptive Server Enterprise (ASE) before 15.7 SP132 and 16.0 before 16.0 SP01 allows remote attackers to bypass the challenge and response mechanism and obtain access to the probe account via a crafted response, aka SAP Security Note 2113995.</description>
+        <oval_repository>
+          <dates>
+            <submitted date="2016-07-03T12:49:00">
+              <contributor organization="ALTX-SOFT">Sergey Artykhov</contributor>
+            </submitted>
+          </dates>
+        </oval_repository>
+      </metadata>
+      <criteria>
+        <extend_definition definition_ref="oval:ru.altx-soft.win:def:35628" comment="SAP Adaptive Server Enterprise is installed" />
+        <criteria comment="checking ASE versions" operator="OR">
+          <criterion comment="ASE 15.7 SP132 and previous versions" test_ref="oval:ru.altx-soft.win:tst:44541" />
+          <criterion comment="ASE 16.0 before 16.0 SP01" test_ref="oval:ru.altx-soft.win:tst:44540" />
+        </criteria>
+      </criteria>
+    </definition>

--- a/repository/objects/windows/registry_object/42000/oval_ru.altx-soft.win_obj_42428
+++ b/repository/objects/windows/registry_object/42000/oval_ru.altx-soft.win_obj_42428
@@ -1,0 +1,5 @@
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:42428" comment="HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sybase Adaptive Server Enterprise Suite!DisplayVersion" version="0">
+  <hive>HKEY_LOCAL_MACHINE</hive>
+  <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sybase Adaptive Server Enterprise Suite</key>
+  <name>DisplayVersion</name>
+</registry_object>

--- a/repository/objects/windows/registry_object/42000/oval_ru.altx-soft.win_obj_42429
+++ b/repository/objects/windows/registry_object/42000/oval_ru.altx-soft.win_obj_42429
@@ -1,0 +1,5 @@
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.altx-soft.win:obj:42429" comment="HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\SAP Adaptive Server Enterprise Suite!DisplayVersion" version="0">
+  <hive>HKEY_LOCAL_MACHINE</hive>
+  <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\SAP Adaptive Server Enterprise</key>
+  <name>DisplayVersion</name>
+</registry_object>

--- a/repository/states/windows/registry_state/2000/oval_ru.altx-soft.win_ste_2885
+++ b/repository/states/windows/registry_state/2000/oval_ru.altx-soft.win_ste_2885
@@ -1,0 +1,3 @@
+    <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" version="0" id="oval:ru.altx-soft.win:ste:2885" comment="version more than or equal 15.7.0.0">
+      <value operation="greater than or equal" datatype="version">15.7.0.0</value>
+    </registry_state>

--- a/repository/states/windows/registry_state/2000/oval_ru.altx-soft.win_ste_2886
+++ b/repository/states/windows/registry_state/2000/oval_ru.altx-soft.win_ste_2886
@@ -1,0 +1,3 @@
+    <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" version="0" id="oval:ru.altx-soft.win:ste:2886" comment="version less than 15.7 SP132">
+      <value operation="less than or equal" datatype="version">15.7.0.132000</value>
+    </registry_state>

--- a/repository/states/windows/registry_state/2000/oval_ru.altx-soft.win_ste_2887
+++ b/repository/states/windows/registry_state/2000/oval_ru.altx-soft.win_ste_2887
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" version="0" id="oval:ru.altx-soft.win:ste:2887" comment="version more than or equal 16.0.0.0">
+  <value operation="greater than or equal" datatype="version">16.0.0.0</value>
+</registry_state>

--- a/repository/states/windows/registry_state/2000/oval_ru.altx-soft.win_ste_2888
+++ b/repository/states/windows/registry_state/2000/oval_ru.altx-soft.win_ste_2888
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" version="0" id="oval:ru.altx-soft.win:ste:2888" comment="version less than 16.0 SP01">
+  <value operation="less than or equal" datatype="version">16.0.01.00</value>
+</registry_state>

--- a/repository/tests/windows/registry_test/44000/oval_ru.altx-soft.win_tst_44538
+++ b/repository/tests/windows/registry_test/44000/oval_ru.altx-soft.win_tst_44538
@@ -1,0 +1,3 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Sybase Adaptive Server Enterprise is installed" id="oval:ru.altx-soft.win:tst:44538" version="0">
+      <object object_ref="oval:ru.altx-soft.win:obj:42428" />
+</registry_test>

--- a/repository/tests/windows/registry_test/44000/oval_ru.altx-soft.win_tst_44539
+++ b/repository/tests/windows/registry_test/44000/oval_ru.altx-soft.win_tst_44539
@@ -1,0 +1,3 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="SAP Adaptive Server Enterprise is installed" id="oval:ru.altx-soft.win:tst:44539" version="0">
+      <object object_ref="oval:ru.altx-soft.win:obj:42429" />
+</registry_test>

--- a/repository/tests/windows/registry_test/44000/oval_ru.altx-soft.win_tst_4454
+++ b/repository/tests/windows/registry_test/44000/oval_ru.altx-soft.win_tst_4454
@@ -1,0 +1,5 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="ASE 16.0 before 16.0 SP01" id="oval:ru.altx-soft.win:tst:44540" version="0">
+  <object object_ref="oval:ru.altx-soft.win:obj:42429" />
+  <state state_ref="oval:ru.altx-soft.win:ste:2888" />
+  <state state_ref="oval:ru.altx-soft.win:ste:2887" />
+</registry_test>

--- a/repository/tests/windows/registry_test/44000/oval_ru.altx-soft.win_tst_44541
+++ b/repository/tests/windows/registry_test/44000/oval_ru.altx-soft.win_tst_44541
@@ -1,0 +1,5 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="ASE 15.7 SP132 and previous versions" id="oval:ru.altx-soft.win:tst:44541" version="0">
+  <object object_ref="oval:ru.altx-soft.win:obj:42428" />
+  <state state_ref="oval:ru.altx-soft.win:ste:2886" />
+  <state state_ref="oval:ru.altx-soft.win:ste:2885" />
+</registry_test>


### PR DESCRIPTION
SAP Adaptive Server Enterprise (ASE) before 15.7 SP132 and 16.0 before 16.0 SP01 allows remote attackers to bypass the challenge and response mechanism and obtain access to the probe account via a crafted response, aka SAP Security Note 2113995.

Source: https://ovaldb.altx-soft.ru/Definition.aspx?id=oval:com.altx-soft.win:def:35629