### PR TITLE
Kemanik lotus notes

### DIFF
--- a/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15861.xml
+++ b/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15861.xml
@@ -1,5 +1,6 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds if IBM Lotus Notes is installed" id="oval:org.mitre.oval:obj:15861" version="1">
-  <hive>HKEY_LOCAL_MACHINE</hive>
-  <key>SOFTWARE\Lotus\Notes</key>
-  <name>Path</name>
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:ns1="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Object holds if IBM Lotus Notes is installed" id="oval:org.mitre.oval:obj:15861" version="1">
+  <ns1:set>
+        <ns1:object_reference>oval:ru.test.win:obj:1000</ns1:object_reference>
+        <ns1:object_reference>oval:ru.test.win:obj:1001</ns1:object_reference>
+      </ns1:set>
 </registry_object>

--- a/repository/objects/windows/registry_object/oval_ru.test.win_obj_1000.xml
+++ b/repository/objects/windows/registry_object/oval_ru.test.win_obj_1000.xml
@@ -1,0 +1,5 @@
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.test.win:obj:1000" version="0" comment="Object holds if IBM Lotus Notes is installed">
+      <hive>HKEY_LOCAL_MACHINE</hive>
+      <key>SOFTWARE\Lotus\Notes</key>
+      <name>Path</name>
+    </registry_object>

--- a/repository/objects/windows/registry_object/oval_ru.test.win_obj_1001.xml
+++ b/repository/objects/windows/registry_object/oval_ru.test.win_obj_1001.xml
@@ -1,0 +1,6 @@
+ <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:ru.test.win:obj:1001" version="0" comment="Object holds if 32-bit IBM Lotus Notes is installed">
+      <behaviors windows_view="32_bit" />
+	  <hive>HKEY_LOCAL_MACHINE</hive>
+      <key>SOFTWARE\Lotus\Notes</key>
+      <name>Path</name>
+    </registry_object>


### PR DESCRIPTION
The object oval:org.mitre.oval:obj:15861 was changed on the set of objects because Lotus Notes could be installed in 32-bit branch.