### PR TITLE
Update oval_org.mitre.oval_obj_15474.xml

### DIFF
--- a/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15474.xml
+++ b/repository/objects/windows/registry_object/15000/oval_org.mitre.oval_obj_15474.xml
@@ -1,6 +1,6 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds if Kaspersky 6.0 or higher is installed" id="oval:org.mitre.oval:obj:15474" version="4">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
-  <key operation="pattern match">^SOFTWARE\\KasperskyLab\\protected\\AVP[\d\.]+\\environment$</key>
+  <key operation="pattern match">^SOFTWARE\\KasperskyLab\\(protected\\)?AVP[\d\.]+\\environment$</key>
   <name>ProductType</name>
 </registry_object>


### PR DESCRIPTION
Regular expression was changed because the object doesn't collect necessary items on Kaspersky 2016 and 2017.