### PR TITLE
kemanik_check_all_part2

### DIFF
--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_870.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_870.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if lynchtmlconv.exe version is less than 15.0.4815.1000" id="oval:org.cisecurity:tst:870" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if lynchtmlconv.exe version is less than 15.0.4815.1000" id="oval:org.cisecurity:tst:870" version="2">
   <object object_ref="oval:org.cisecurity:obj:230" />
   <state state_ref="oval:org.cisecurity:ste:709" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_876.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_876.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if ogl.dll version is less than 4.0.7577.4498" id="oval:org.cisecurity:tst:876" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if ogl.dll version is less than 4.0.7577.4498" id="oval:org.cisecurity:tst:876" version="4">
   <object object_ref="oval:org.mitre.oval:obj:24024" />
   <state state_ref="oval:org.cisecurity:ste:725" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_887.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_887.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 15.0.4815.1000" id="oval:org.cisecurity:tst:887" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 15.0.4815.1000" id="oval:org.cisecurity:tst:887" version="3">
   <object object_ref="oval:org.cisecurity:obj:215" />
   <state state_ref="oval:org.cisecurity:ste:708" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_894.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_894.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if wwlibcxm.dll version is less than 14.0.7168.5000" id="oval:org.cisecurity:tst:894" version="9">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if wwlibcxm.dll version is less than 14.0.7168.5000" id="oval:org.cisecurity:tst:894" version="9">
   <object object_ref="oval:org.cisecurity:obj:218" />
   <state state_ref="oval:org.cisecurity:ste:702" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_899.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_899.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if lynchtmlconv.exe version is less than 16.0.4366.1000" id="oval:org.cisecurity:tst:899" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if lynchtmlconv.exe version is less than 16.0.4366.1000" id="oval:org.cisecurity:tst:899" version="2">
   <object object_ref="oval:org.cisecurity:obj:222" />
   <state state_ref="oval:org.cisecurity:ste:707" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_930.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_930.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if excel.exe version is less than 16.0.4366.1000" id="oval:org.cisecurity:tst:930" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if excel.exe version is less than 16.0.4366.1000" id="oval:org.cisecurity:tst:930" version="1">
   <object object_ref="oval:org.cisecurity:obj:236" />
   <state state_ref="oval:org.cisecurity:ste:737" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_943.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_943.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if excel.exe version is less than 15.0.4815.1000" id="oval:org.cisecurity:tst:943" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if excel.exe version is less than 15.0.4815.1000" id="oval:org.cisecurity:tst:943" version="1">
   <object object_ref="oval:org.cisecurity:obj:233" />
   <state state_ref="oval:org.cisecurity:ste:734" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1240.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1240.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7169.5000" id="oval:org.cisecurity:tst:1240" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7169.5000" id="oval:org.cisecurity:tst:1240" version="5">
   <object object_ref="oval:org.cisecurity:obj:218" />
   <state state_ref="oval:org.cisecurity:ste:988" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1258.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1258.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 16.0.4378.1001" id="oval:org.cisecurity:tst:1258" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 16.0.4378.1001" id="oval:org.cisecurity:tst:1258" version="3">
   <object object_ref="oval:org.cisecurity:obj:335" />
   <state state_ref="oval:org.cisecurity:ste:1002" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1261.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1261.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4823.1000" id="oval:org.cisecurity:tst:1261" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4823.1000" id="oval:org.cisecurity:tst:1261" version="3">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.cisecurity:ste:986" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1428.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1428.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1428" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1428" version="3">
   <object object_ref="oval:org.cisecurity:obj:218" />
   <state state_ref="oval:org.cisecurity:ste:1113" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1430.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1430.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4833.1000" id="oval:org.cisecurity:tst:1430" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4833.1000" id="oval:org.cisecurity:tst:1430" version="2">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.cisecurity:ste:1110" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1431.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1431.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 16.0.4393.1000" id="oval:org.cisecurity:tst:1431" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 16.0.4393.1000" id="oval:org.cisecurity:tst:1431" version="2">
   <object object_ref="oval:org.cisecurity:obj:335" />
   <state state_ref="oval:org.cisecurity:ste:1114" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1439.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1439.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1439" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1439" version="2">
   <object object_ref="oval:org.cisecurity:obj:158" />
   <state state_ref="oval:org.cisecurity:ste:1113" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1441.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1441.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 15.0.4831.1000" id="oval:org.cisecurity:tst:1441" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 15.0.4831.1000" id="oval:org.cisecurity:tst:1441" version="2">
   <object object_ref="oval:org.cisecurity:obj:352" />
   <state state_ref="oval:org.cisecurity:ste:1116" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1442.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1442.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 16.0.4390.1000" id="oval:org.cisecurity:tst:1442" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 16.0.4390.1000" id="oval:org.cisecurity:tst:1442" version="2">
   <object object_ref="oval:org.cisecurity:obj:359" />
   <state state_ref="oval:org.cisecurity:ste:1111" />
 </file_test>

--- a/repository/tests/windows/file_test/10000/oval_org.mitre.oval_tst_10529.xml
+++ b/repository/tests/windows/file_test/10000/oval_org.mitre.oval_tst_10529.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.31.21.10" id="oval:org.mitre.oval:tst:10529" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.31.21.10" id="oval:org.mitre.oval:tst:10529" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:5686" />
 </file_test>

--- a/repository/tests/windows/file_test/10000/oval_org.mitre.oval_tst_10617.xml
+++ b/repository/tests/windows/file_test/10000/oval_org.mitre.oval_tst_10617.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Safari.exe version is less than 4.530.19.1 (4.0.2)" id="oval:org.mitre.oval:tst:10617" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Safari.exe version is less than 4.530.19.1 (4.0.2)" id="oval:org.mitre.oval:tst:10617" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:5434" />
 </file_test>

--- a/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100005.xml
+++ b/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100005.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4551.1509" id="oval:org.mitre.oval:tst:100005" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4551.1509" id="oval:org.mitre.oval:tst:100005" version="5">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.mitre.oval:ste:27961" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11000.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11000.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is equal to 4.531.9.1" id="oval:org.mitre.oval:tst:11000" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is equal to 4.531.9.1" id="oval:org.mitre.oval:tst:11000" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:5647" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11487.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11487.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.31.22.7" id="oval:org.mitre.oval:tst:11487" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.31.22.7" id="oval:org.mitre.oval:tst:11487" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:6183" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11627.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11627.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is 5.31.22.7" id="oval:org.mitre.oval:tst:11627" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is 5.31.22.7" id="oval:org.mitre.oval:tst:11627" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:6845" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112696.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112696.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than or equals to 5.33.19.4" id="oval:org.mitre.oval:tst:112696" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than or equals to 5.33.19.4" id="oval:org.mitre.oval:tst:112696" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30846" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113050.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113050.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.20.27" id="oval:org.mitre.oval:tst:113050" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.20.27" id="oval:org.mitre.oval:tst:113050" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30106" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113120.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113120.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.34.57.2" id="oval:org.mitre.oval:tst:113120" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.34.57.2" id="oval:org.mitre.oval:tst:113120" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30840" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113189.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113189.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is greater than or equals to 5.26.11.2" id="oval:org.mitre.oval:tst:113189" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is greater than or equals to 5.26.11.2" id="oval:org.mitre.oval:tst:113189" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30813" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113191.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113191.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is equal to 5.31.9" id="oval:org.mitre.oval:tst:113191" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is equal to 5.31.9" id="oval:org.mitre.oval:tst:113191" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30202" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113221.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113221.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.34.58.2" id="oval:org.mitre.oval:tst:113221" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.34.58.2" id="oval:org.mitre.oval:tst:113221" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30842" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113237.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113237.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.22.3" id="oval:org.mitre.oval:tst:113237" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.22.3" id="oval:org.mitre.oval:tst:113237" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30625" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113251.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113251.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is equal to 5.31.21.10" id="oval:org.mitre.oval:tst:113251" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is equal to 5.31.21.10" id="oval:org.mitre.oval:tst:113251" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30834" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113267.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113267.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.34.54.16" id="oval:org.mitre.oval:tst:113267" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.34.54.16" id="oval:org.mitre.oval:tst:113267" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:30101" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113403.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113403.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4605.1001" id="oval:org.mitre.oval:tst:113403" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4605.1001" id="oval:org.mitre.oval:tst:113403" version="5">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.mitre.oval:ste:30230" />
 </file_test>

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114759.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114759.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll (user level) is less than 4.0.7577.4446" id="oval:org.mitre.oval:tst:114759" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll (user level) is less than 4.0.7577.4446" id="oval:org.mitre.oval:tst:114759" version="5">
   <object object_ref="oval:org.mitre.oval:obj:24024" />
   <state state_ref="oval:org.mitre.oval:ste:31242" />
 </file_test>

--- a/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135486.xml
+++ b/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135486.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4675.1000" id="oval:org.mitre.oval:tst:135486" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4675.1000" id="oval:org.mitre.oval:tst:135486" version="5">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.mitre.oval:ste:37423" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137642.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137642.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4693.1000" id="oval:org.mitre.oval:tst:137642" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4693.1000" id="oval:org.mitre.oval:tst:137642" version="3">
   <object object_ref="oval:org.mitre.oval:obj:662" />
   <state state_ref="oval:org.mitre.oval:ste:37922" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137994.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137994.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 15.0.4719.1000" id="oval:org.mitre.oval:tst:137994" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 15.0.4719.1000" id="oval:org.mitre.oval:tst:137994" version="1">
   <object object_ref="oval:org.mitre.oval:obj:26893" />
   <state state_ref="oval:org.mitre.oval:ste:38245" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138083.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138083.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 8.5.1.4" id="oval:org.mitre.oval:tst:138083" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 8.5.1.4" id="oval:org.mitre.oval:tst:138083" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38726" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138223.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138223.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 3.0.0.2" id="oval:org.mitre.oval:tst:138223" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 3.0.0.2" id="oval:org.mitre.oval:tst:138223" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38882" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138256.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138256.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4711.1001" id="oval:org.mitre.oval:tst:138256" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4711.1001" id="oval:org.mitre.oval:tst:138256" version="5">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.mitre.oval:ste:38597" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138370.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138370.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll (Lync 2010 Attendee for user) is less than 4.0.7577.4461" id="oval:org.mitre.oval:tst:138370" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll (Lync 2010 Attendee for user) is less than 4.0.7577.4461" id="oval:org.mitre.oval:tst:138370" version="4">
   <object object_ref="oval:org.mitre.oval:obj:24024" />
   <state state_ref="oval:org.mitre.oval:ste:38377" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138392.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138392.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 8.0.1" id="oval:org.mitre.oval:tst:138392" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 8.0.1" id="oval:org.mitre.oval:tst:138392" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38156" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138394.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138394.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4701.1001" id="oval:org.mitre.oval:tst:138394" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4701.1001" id="oval:org.mitre.oval:tst:138394" version="5">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.mitre.oval:ste:37567" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138497.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138497.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4719.1000" id="oval:org.mitre.oval:tst:138497" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4719.1000" id="oval:org.mitre.oval:tst:138497" version="3">
   <object object_ref="oval:org.mitre.oval:obj:662" />
   <state state_ref="oval:org.mitre.oval:ste:38245" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138507.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138507.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 8.0.0" id="oval:org.mitre.oval:tst:138507" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 8.0.0" id="oval:org.mitre.oval:tst:138507" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38806" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138518.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138518.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4719.1000" id="oval:org.mitre.oval:tst:138518" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4719.1000" id="oval:org.mitre.oval:tst:138518" version="5">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.mitre.oval:ste:38245" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138551.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138551.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 8.5" id="oval:org.mitre.oval:tst:138551" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 8.5" id="oval:org.mitre.oval:tst:138551" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38821" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138571.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138571.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version ppcore.dll is less than 15.0.4719.1000" id="oval:org.mitre.oval:tst:138571" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version ppcore.dll is less than 15.0.4719.1000" id="oval:org.mitre.oval:tst:138571" version="1">
   <object object_ref="oval:org.mitre.oval:obj:44001" />
   <state state_ref="oval:org.mitre.oval:ste:38245" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138612.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138612.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 3.0.0.1" id="oval:org.mitre.oval:tst:138612" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 3.0.0.1" id="oval:org.mitre.oval:tst:138612" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38858" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138653.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138653.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 7.0.4" id="oval:org.mitre.oval:tst:138653" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 7.0.4" id="oval:org.mitre.oval:tst:138653" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38483" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138657.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138657.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 4.2.1" id="oval:org.mitre.oval:tst:138657" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 4.2.1" id="oval:org.mitre.oval:tst:138657" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38836" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138672.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138672.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of osf.dll is less than 15.0.4725.1000" id="oval:org.mitre.oval:tst:138672" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of osf.dll is less than 15.0.4725.1000" id="oval:org.mitre.oval:tst:138672" version="1">
   <object object_ref="oval:org.mitre.oval:obj:43997" />
   <state state_ref="oval:org.mitre.oval:ste:39069" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138685.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138685.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 4.6" id="oval:org.mitre.oval:tst:138685" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 4.6" id="oval:org.mitre.oval:tst:138685" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38438" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138693.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138693.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is equal to 8.5" id="oval:org.mitre.oval:tst:138693" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is equal to 8.5" id="oval:org.mitre.oval:tst:138693" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38545" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138741.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138741.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 5:0a" id="oval:org.mitre.oval:tst:138741" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 5:0a" id="oval:org.mitre.oval:tst:138741" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38859" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138776.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138776.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 6.5.6" id="oval:org.mitre.oval:tst:138776" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 6.5.6" id="oval:org.mitre.oval:tst:138776" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38668" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138810.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138810.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is equal to 7.0" id="oval:org.mitre.oval:tst:138810" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is equal to 7.0" id="oval:org.mitre.oval:tst:138810" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38764" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138813.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138813.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 6.0.1" id="oval:org.mitre.oval:tst:138813" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 6.0.1" id="oval:org.mitre.oval:tst:138813" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38770" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138897.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138897.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 8.0" id="oval:org.mitre.oval:tst:138897" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 8.0" id="oval:org.mitre.oval:tst:138897" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38823" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138900.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138900.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 7.0.0" id="oval:org.mitre.oval:tst:138900" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is greater than or equal to 7.0.0" id="oval:org.mitre.oval:tst:138900" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38658" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138910.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138910.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 5.2" id="oval:org.mitre.oval:tst:138910" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 5.2" id="oval:org.mitre.oval:tst:138910" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38473" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138913.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138913.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 8.5.2.2" id="oval:org.mitre.oval:tst:138913" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Determine if the version of Lotus Notes is less than or equal to 8.5.2.2" id="oval:org.mitre.oval:tst:138913" version="2">
   <object object_ref="oval:org.mitre.oval:obj:44121" />
   <state state_ref="oval:org.mitre.oval:ste:38665" />
 </file_test>

--- a/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141304.xml
+++ b/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141304.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4737.1003" id="oval:org.mitre.oval:tst:141304" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4737.1003" id="oval:org.mitre.oval:tst:141304" version="5">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.mitre.oval:ste:39581" />
 </file_test>

--- a/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141320.xml
+++ b/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141320.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version ppcore.dll is less than 15.0.4737.1003" id="oval:org.mitre.oval:tst:141320" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version ppcore.dll is less than 15.0.4737.1003" id="oval:org.mitre.oval:tst:141320" version="1">
   <object object_ref="oval:org.mitre.oval:obj:44001" />
   <state state_ref="oval:org.mitre.oval:ste:39789" />
 </file_test>

--- a/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141327.xml
+++ b/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141327.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4737.1000" id="oval:org.mitre.oval:tst:141327" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4737.1000" id="oval:org.mitre.oval:tst:141327" version="3">
   <object object_ref="oval:org.mitre.oval:obj:662" />
   <state state_ref="oval:org.mitre.oval:ste:39652" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27458.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27458.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.16.0" id="oval:org.mitre.oval:tst:27458" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.16.0" id="oval:org.mitre.oval:tst:27458" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:6780" />
 </file_test>

--- a/repository/tests/windows/file_test/39000/oval_org.mitre.oval_tst_39988.xml
+++ b/repository/tests/windows/file_test/39000/oval_org.mitre.oval_tst_39988.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.17.8" id="oval:org.mitre.oval:tst:39988" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.17.8" id="oval:org.mitre.oval:tst:39988" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:11125" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41116.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41116.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.18.5" id="oval:org.mitre.oval:tst:41116" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Apple Safari version is less than 5.33.18.5" id="oval:org.mitre.oval:tst:41116" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:11935" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41175.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41175.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apple Safari version is less than 5.0.3 (5.33.19.4)" id="oval:org.mitre.oval:tst:41175" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apple Safari version is less than 5.0.3 (5.33.19.4)" id="oval:org.mitre.oval:tst:41175" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:12001" />
 </file_test>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43597.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43597.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 14.0.6106.5000" id="oval:org.mitre.oval:tst:43597" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 14.0.6106.5000" id="oval:org.mitre.oval:tst:43597" version="4">
   <object object_ref="oval:org.cisecurity:obj:158" />
   <state state_ref="oval:org.mitre.oval:ste:12737" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79678.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79678.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6123.5006" id="oval:org.mitre.oval:tst:79678" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6123.5006" id="oval:org.mitre.oval:tst:79678" version="3">
   <object object_ref="oval:org.cisecurity:obj:157" />
   <state state_ref="oval:org.mitre.oval:ste:19930" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79686.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79686.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if version of ogl.dll (Lync 2010 Attendee for user) is less than 4.0.7577.4098" id="oval:org.mitre.oval:tst:79686" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if version of ogl.dll (Lync 2010 Attendee for user) is less than 4.0.7577.4098" id="oval:org.mitre.oval:tst:79686" version="5">
   <object object_ref="oval:org.mitre.oval:obj:24024" />
   <state state_ref="oval:org.mitre.oval:ste:19700" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80072.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80072.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6120.5000" id="oval:org.mitre.oval:tst:80072" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6120.5000" id="oval:org.mitre.oval:tst:80072" version="3">
   <object object_ref="oval:org.cisecurity:obj:157" />
   <state state_ref="oval:org.mitre.oval:ste:19741" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80198.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80198.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of uc.dll is less than 4.0.7577.4103  (user install)" id="oval:org.mitre.oval:tst:80198" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of uc.dll is less than 4.0.7577.4103  (user install)" id="oval:org.mitre.oval:tst:80198" version="5">
   <object object_ref="oval:org.mitre.oval:obj:24133" />
   <state state_ref="oval:org.mitre.oval:ste:19924" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80468.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80468.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 14.0.7100.5000" id="oval:org.mitre.oval:tst:80468" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of visio.exe is less than 14.0.7100.5000" id="oval:org.mitre.oval:tst:80468" version="4">
   <object object_ref="oval:org.cisecurity:obj:158" />
   <state state_ref="oval:org.mitre.oval:ste:20274" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80688.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80688.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6134.5004" id="oval:org.mitre.oval:tst:80688" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of infopath.exe is less than 14.0.6134.5004" id="oval:org.mitre.oval:tst:80688" version="3">
   <object object_ref="oval:org.cisecurity:obj:157" />
   <state state_ref="oval:org.mitre.oval:ste:20146" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80795.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80795.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of uc.dll is less than 4.0.7577.4378 (user install)" id="oval:org.mitre.oval:tst:80795" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of uc.dll is less than 4.0.7577.4378 (user install)" id="oval:org.mitre.oval:tst:80795" version="5">
   <object object_ref="oval:org.mitre.oval:obj:24133" />
   <state state_ref="oval:org.mitre.oval:ste:20725" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80902.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80902.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of onenote.Exe is less than 14.0.6134.5000" id="oval:org.mitre.oval:tst:80902" version="7">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of onenote.Exe is less than 14.0.6134.5000" id="oval:org.mitre.oval:tst:80902" version="7">
   <object object_ref="oval:org.cisecurity:obj:159" />
   <state state_ref="oval:org.mitre.oval:ste:19698" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81687.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81687.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll (Lync 2010 Attendee for user) is less than 4.0.7577.4392" id="oval:org.mitre.oval:tst:81687" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll (Lync 2010 Attendee for user) is less than 4.0.7577.4392" id="oval:org.mitre.oval:tst:81687" version="5">
   <object object_ref="oval:org.mitre.oval:obj:24024" />
   <state state_ref="oval:org.mitre.oval:ste:20900" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86282.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86282.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4535.1507" id="oval:org.mitre.oval:tst:86282" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4535.1507" id="oval:org.mitre.oval:tst:86282" version="3">
   <object object_ref="oval:org.mitre.oval:obj:662" />
   <state state_ref="oval:org.mitre.oval:ste:24004" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86684.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86684.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4535.1003" id="oval:org.mitre.oval:tst:86684" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4535.1003" id="oval:org.mitre.oval:tst:86684" version="3">
   <object object_ref="oval:org.mitre.oval:obj:662" />
   <state state_ref="oval:org.mitre.oval:ste:23755" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87148.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87148.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Exsec32.dll is less than 14.0.7109.5000" id="oval:org.mitre.oval:tst:87148" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Exsec32.dll is less than 14.0.7109.5000" id="oval:org.mitre.oval:tst:87148" version="1">
   <object object_ref="oval:org.mitre.oval:obj:25973" />
   <state state_ref="oval:org.mitre.oval:ste:24068" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87197.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87197.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Exsec32.dll is less than 15.0.4551.1001" id="oval:org.mitre.oval:tst:87197" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Exsec32.dll is less than 15.0.4551.1001" id="oval:org.mitre.oval:tst:87197" version="1">
   <object object_ref="oval:org.mitre.oval:obj:26347" />
   <state state_ref="oval:org.mitre.oval:ste:24271" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87208.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87208.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 15.0.4535.1507" id="oval:org.mitre.oval:tst:87208" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 15.0.4535.1507" id="oval:org.mitre.oval:tst:87208" version="2">
   <object object_ref="oval:org.mitre.oval:obj:26893" />
   <state state_ref="oval:org.mitre.oval:ste:24004" />
 </file_test>

--- a/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9531.xml
+++ b/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9531.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Safari.exe version is less than or equal to 4.528.16.0" id="oval:org.mitre.oval:tst:9531" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Safari.exe version is less than or equal to 4.528.16.0" id="oval:org.mitre.oval:tst:9531" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:4655" />
 </file_test>

--- a/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9703.xml
+++ b/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9703.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Safari.exe version is less than or equal to 3.525.27.1" id="oval:org.mitre.oval:tst:9703" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Safari.exe version is less than or equal to 3.525.27.1" id="oval:org.mitre.oval:tst:9703" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:4467" />
 </file_test>

--- a/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9789.xml
+++ b/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9789.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Safari.exe version is less than or equal to 4.528.16.0" id="oval:org.mitre.oval:tst:9789" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Safari.exe version is less than or equal to 4.528.16.0" id="oval:org.mitre.oval:tst:9789" version="4">
   <object object_ref="oval:org.mitre.oval:obj:6668" />
   <state state_ref="oval:org.mitre.oval:ste:4718" />
 </file_test>

--- a/repository/tests/windows/file_test/90000/oval_org.mitre.oval_tst_90019.xml
+++ b/repository/tests/windows/file_test/90000/oval_org.mitre.oval_tst_90019.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll (Lync 2010 Attendee for user) is less than 4.0.7577.4415" id="oval:org.mitre.oval:tst:90019" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll (Lync 2010 Attendee for user) is less than 4.0.7577.4415" id="oval:org.mitre.oval:tst:90019" version="5">
   <object object_ref="oval:org.mitre.oval:obj:24024" />
   <state state_ref="oval:org.mitre.oval:ste:25668" />
 </file_test>


### PR DESCRIPTION
The value of parameter check="all" was changed into "at least one" in tests which use objects with the variable that collects several values because of the set of objects. It was made to avoid false negative results.