### PR TITLE
Update oval_org.cisecurity_def_1406.xml

### DIFF
--- a/repository/definitions/inventory/oval_org.cisecurity_def_1406.xml
+++ b/repository/definitions/inventory/oval_org.cisecurity_def_1406.xml
@@ -9,6 +9,7 @@
       <platform>Microsoft Windows Server 2008 R2</platform>
       <platform>Microsoft Windows Server 2012</platform>
       <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
       <product>Microsoft Lync 2013</product>
     </affected>
     <reference ref_id="cpe:/a:microsoft:lync:2013:sp1" source="CPE" />
@@ -24,7 +25,10 @@
     </oval_repository>
   </metadata>
   <criteria>
+    <criteria comment="Microsoft Office 2013 SP1 is installed" operator="OR">
+		  			<extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+		  			<extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+		</criteria>
     <extend_definition comment="Microsoft Lync 2013 is installed" definition_ref="oval:org.mitre.oval:def:15643" />
-    <criterion comment="Check if Microsoft Office products 2013 SP1 is installed" test_ref="oval:org.mitre.oval:tst:100308" />
   </criteria>
 </definition>


### PR DESCRIPTION
replaced oval:org.mitre.oval:tst:100308 with ext. def for MS Office 2013 SP1 to handle both 32 and 64 bit.