### PR TITLE
The value of parameter check="all" was changed into "at least one" in…

### DIFF
--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_892.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_892.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if ogl.dll version is less than 4.0.7577.4498" id="oval:org.cisecurity:tst:892" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if ogl.dll version is less than 4.0.7577.4498" id="oval:org.cisecurity:tst:892" version="3">
   <object object_ref="oval:org.mitre.oval:obj:38846" />
   <state state_ref="oval:org.cisecurity:ste:725" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_896.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_896.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 14.0.7168.5000" id="oval:org.cisecurity:tst:896" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 14.0.7168.5000" id="oval:org.cisecurity:tst:896" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.cisecurity:ste:702" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_897.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_897.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if lynchtmlconv.exe version is less than 15.0.4815.1000" id="oval:org.cisecurity:tst:897" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if lynchtmlconv.exe version is less than 15.0.4815.1000" id="oval:org.cisecurity:tst:897" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24126" />
   <state state_ref="oval:org.cisecurity:ste:709" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_902.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_902.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mscorlib.dll is less than 4.6.1076.0" id="oval:org.cisecurity:tst:902" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mscorlib.dll is less than 4.6.1076.0" id="oval:org.cisecurity:tst:902" version="3">
   <object object_ref="oval:org.cisecurity:obj:227" />
   <state state_ref="oval:org.cisecurity:ste:716" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_909.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_909.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if excel.exe version is less than 14.0.7168.5000" id="oval:org.cisecurity:tst:909" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if excel.exe version is less than 14.0.7168.5000" id="oval:org.cisecurity:tst:909" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.cisecurity:ste:702" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_928.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_928.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Java Runtime Environment is less than 7 update 98" id="oval:org.cisecurity:tst:928" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Java Runtime Environment is less than 7 update 98" id="oval:org.cisecurity:tst:928" version="1">
   <object object_ref="oval:org.mitre.oval:obj:24174" />
   <state state_ref="oval:org.cisecurity:ste:733" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_929.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_929.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Java Runtime Environment is less than 8 update 75" id="oval:org.cisecurity:tst:929" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Java Runtime Environment is less than 8 update 75" id="oval:org.cisecurity:tst:929" version="1">
   <object object_ref="oval:org.mitre.oval:obj:38399" />
   <state state_ref="oval:org.cisecurity:ste:751" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_168.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_168.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 10.0.6815.0" id="oval:org.mitre.oval:tst:168" version="6">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 10.0.6815.0" id="oval:org.mitre.oval:tst:168" version="6">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:75" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_29.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_29.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 11.0.8103.0" id="oval:org.mitre.oval:tst:29" version="6">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 11.0.8103.0" id="oval:org.mitre.oval:tst:29" version="6">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:44" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_36.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_36.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 9.0.0.8930" id="oval:org.mitre.oval:tst:36" version="6">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 9.0.0.8930" id="oval:org.mitre.oval:tst:36" version="6">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:100" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1159.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1159.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.0.30319.36350" id="oval:org.cisecurity:tst:1159" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.0.30319.36350" id="oval:org.cisecurity:tst:1159" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.cisecurity:ste:929" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1160.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1160.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.0.30319.34294" id="oval:org.cisecurity:tst:1160" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.0.30319.34294" id="oval:org.cisecurity:tst:1160" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.cisecurity:ste:925" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1161.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1161.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 2.0.50727.8686" id="oval:org.cisecurity:tst:1161" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 2.0.50727.8686" id="oval:org.cisecurity:tst:1161" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.cisecurity:ste:926" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1162.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1162.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 2.0.50727.8690" id="oval:org.cisecurity:tst:1162" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 2.0.50727.8690" id="oval:org.cisecurity:tst:1162" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.cisecurity:ste:927" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1163.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1163.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.6.1075.0" id="oval:org.cisecurity:tst:1163" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.6.1075.0" id="oval:org.cisecurity:tst:1163" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.cisecurity:ste:930" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1164.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1164.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is greater than or equal to 2.0.50727.8600" id="oval:org.cisecurity:tst:1164" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is greater than or equal to 2.0.50727.8600" id="oval:org.cisecurity:tst:1164" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.mitre.oval:ste:31131" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1165.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1165.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 2.0.50727.4264" id="oval:org.cisecurity:tst:1165" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 2.0.50727.4264" id="oval:org.cisecurity:tst:1165" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.cisecurity:ste:923" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1166.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1166.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is greater than or equal to 4.0.30319.36000" id="oval:org.cisecurity:tst:1166" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is greater than or equal to 4.0.30319.36000" id="oval:org.cisecurity:tst:1166" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.mitre.oval:ste:27962" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1167.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1167.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.6.1081.0" id="oval:org.cisecurity:tst:1167" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.6.1081.0" id="oval:org.cisecurity:tst:1167" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.cisecurity:ste:928" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1168.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1168.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.0.30319.36351" id="oval:org.cisecurity:tst:1168" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of System.dll is less than 4.0.30319.36351" id="oval:org.cisecurity:tst:1168" version="1">
   <object object_ref="oval:org.cisecurity:obj:309" />
   <state state_ref="oval:org.cisecurity:ste:924" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1237.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1237.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 15.0.4823.1000" id="oval:org.cisecurity:tst:1237" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 15.0.4823.1000" id="oval:org.cisecurity:tst:1237" version="4">
   <object object_ref="oval:org.cisecurity:obj:323" />
   <state state_ref="oval:org.cisecurity:ste:986" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1238.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1238.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mso40uires.dll is less than 16.0.4297.1000" id="oval:org.cisecurity:tst:1238" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso40uires.dll is less than 16.0.4297.1000" id="oval:org.cisecurity:tst:1238" version="4">
   <object object_ref="oval:org.cisecurity:obj:321" />
   <state state_ref="oval:org.cisecurity:ste:987" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1239.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1239.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7169.5000" id="oval:org.cisecurity:tst:1239" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7169.5000" id="oval:org.cisecurity:tst:1239" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.cisecurity:ste:988" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1251.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1251.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if epsimp32.flt version is greater than or equal to 2012.1600.0000.0000" id="oval:org.cisecurity:tst:1251" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if epsimp32.flt version is greater than or equal to 2012.1600.0000.0000" id="oval:org.cisecurity:tst:1251" version="3">
   <object object_ref="oval:org.cisecurity:obj:334" />
   <state state_ref="oval:org.cisecurity:ste:997" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1254.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1254.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if epsimp32.flt version is less than 2012.1600.4288.1000" id="oval:org.cisecurity:tst:1254" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if epsimp32.flt version is less than 2012.1600.4288.1000" id="oval:org.cisecurity:tst:1254" version="3">
   <object object_ref="oval:org.cisecurity:obj:334" />
   <state state_ref="oval:org.cisecurity:ste:998" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1291.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1291.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 14.0.7169.5000" id="oval:org.cisecurity:tst:1291" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 14.0.7169.5000" id="oval:org.cisecurity:tst:1291" version="2">
   <object object_ref="oval:org.mitre.oval:obj:15988" />
   <state state_ref="oval:org.cisecurity:ste:988" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1294.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1294.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll is less than 14.0.7168.5000" id="oval:org.cisecurity:tst:1294" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll is less than 14.0.7168.5000" id="oval:org.cisecurity:tst:1294" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24602" />
   <state state_ref="oval:org.cisecurity:ste:702" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1296.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1296.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of oartconv.dll is less than 14.0.7169.5000" id="oval:org.cisecurity:tst:1296" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of oartconv.dll is less than 14.0.7169.5000" id="oval:org.cisecurity:tst:1296" version="2">
   <object object_ref="oval:org.mitre.oval:obj:15858" />
   <state state_ref="oval:org.cisecurity:ste:988" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1434.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1434.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1434" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1434" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.cisecurity:ste:1113" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1435.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1435.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 16.0.4390.1000" id="oval:org.cisecurity:tst:1435" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 16.0.4390.1000" id="oval:org.cisecurity:tst:1435" version="2">
   <object object_ref="oval:org.cisecurity:obj:351" />
   <state state_ref="oval:org.cisecurity:ste:1111" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1436.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1436.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1436" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1436" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.cisecurity:ste:1113" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1440.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1440.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of vviewdwg.dll is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1440" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of vviewdwg.dll is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1440" version="3">
   <object object_ref="oval:org.cisecurity:obj:354" />
   <state state_ref="oval:org.cisecurity:ste:1113" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1440.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1440.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of vviewdwg.dll is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1440" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of vviewdwg.dll is less than 14.0.7170.5000" id="oval:org.cisecurity:tst:1440" version="2">
   <object object_ref="oval:org.cisecurity:obj:354" />
   <state state_ref="oval:org.cisecurity:ste:1113" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1882.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1882.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if  Intrusion Detection System Core Driver for SEP is less than 15.0.6" id="oval:org.cisecurity:tst:1882" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if  Intrusion Detection System Core Driver for SEP is less than 15.0.6" id="oval:org.cisecurity:tst:1882" version="2">
   <object object_ref="oval:org.cisecurity:obj:423" />
   <state state_ref="oval:org.cisecurity:ste:1517" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1969.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1969.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 16.0.4312.1001" id="oval:org.cisecurity:tst:1969" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 16.0.4312.1001" id="oval:org.cisecurity:tst:1969" version="1">
   <object object_ref="oval:org.cisecurity:obj:335" />
   <state state_ref="oval:org.cisecurity:ste:1598" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1971.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1971.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7164.5001" id="oval:org.cisecurity:tst:1971" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7164.5001" id="oval:org.cisecurity:tst:1971" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.cisecurity:ste:1596" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1972.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1972.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4779.1001" id="oval:org.cisecurity:tst:1972" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 15.0.4779.1001" id="oval:org.cisecurity:tst:1972" version="1">
   <object object_ref="oval:org.mitre.oval:obj:492" />
   <state state_ref="oval:org.cisecurity:ste:1597" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1974.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1974.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7164.5001" id="oval:org.cisecurity:tst:1974" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7164.5001" id="oval:org.cisecurity:tst:1974" version="2">
   <object object_ref="oval:org.cisecurity:obj:218" />
   <state state_ref="oval:org.cisecurity:ste:1596" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1974.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1974.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7164.5001" id="oval:org.cisecurity:tst:1974" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7164.5001" id="oval:org.cisecurity:tst:1974" version="3">
   <object object_ref="oval:org.cisecurity:obj:218" />
   <state state_ref="oval:org.cisecurity:ste:1596" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1976.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1976.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 14.0.7174.5001" id="oval:org.cisecurity:tst:1976" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 14.0.7174.5001" id="oval:org.cisecurity:tst:1976" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.cisecurity:ste:1601" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1978.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1978.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if wwlibcxm.dll version is less than 14.0.7174.5001" id="oval:org.cisecurity:tst:1978" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if wwlibcxm.dll version is less than 14.0.7174.5001" id="oval:org.cisecurity:tst:1978" version="3">
   <object object_ref="oval:org.cisecurity:obj:218" />
   <state state_ref="oval:org.cisecurity:ste:1601" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1978.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1978.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if wwlibcxm.dll version is less than 14.0.7174.5001" id="oval:org.cisecurity:tst:1978" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if wwlibcxm.dll version is less than 14.0.7174.5001" id="oval:org.cisecurity:tst:1978" version="2">
   <object object_ref="oval:org.cisecurity:obj:218" />
   <state state_ref="oval:org.cisecurity:ste:1601" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1983.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1983.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 15.0.4867.1002" id="oval:org.cisecurity:tst:1983" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 15.0.4867.1002" id="oval:org.cisecurity:tst:1983" version="1">
   <object object_ref="oval:org.cisecurity:obj:215" />
   <state state_ref="oval:org.cisecurity:ste:1604" />
 </file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1984.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.cisecurity_tst_1984.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 16.0.4444.1003" id="oval:org.cisecurity:tst:1984" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if winword.exe version is less than 16.0.4444.1003" id="oval:org.cisecurity:tst:1984" version="1">
   <object object_ref="oval:org.cisecurity:obj:437" />
   <state state_ref="oval:org.cisecurity:ste:1603" />
 </file_test>

--- a/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100107.xml
+++ b/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100107.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7113.5001" id="oval:org.mitre.oval:tst:100107" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7113.5001" id="oval:org.mitre.oval:tst:100107" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:27634" />
 </file_test>

--- a/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100305.xml
+++ b/repository/tests/windows/file_test/100000/oval_org.mitre.oval_tst_100305.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll is less than 14.0.7113.5000" id="oval:org.mitre.oval:tst:100305" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll is less than 14.0.7113.5000" id="oval:org.mitre.oval:tst:100305" version="4">
   <object object_ref="oval:org.mitre.oval:obj:24602" />
   <state state_ref="oval:org.mitre.oval:ste:27680" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11038.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11038.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal to 9.2.0" id="oval:org.mitre.oval:tst:11038" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal to 9.2.0" id="oval:org.mitre.oval:tst:11038" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7123" />
   <state state_ref="oval:org.mitre.oval:ste:5787" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11053.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11053.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 9.3.2" id="oval:org.mitre.oval:tst:11053" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 9.3.2" id="oval:org.mitre.oval:tst:11053" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7301" />
   <state state_ref="oval:org.mitre.oval:ste:6656" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11095.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11095.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal to 8.1.7" id="oval:org.mitre.oval:tst:11095" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal to 8.1.7" id="oval:org.mitre.oval:tst:11095" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7461" />
   <state state_ref="oval:org.mitre.oval:ste:5773" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11124.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11124.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal to 9.2.0" id="oval:org.mitre.oval:tst:11124" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal to 9.2.0" id="oval:org.mitre.oval:tst:11124" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7301" />
   <state state_ref="oval:org.mitre.oval:ste:5787" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11140.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11140.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6861.0" id="oval:org.mitre.oval:tst:11140" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6861.0" id="oval:org.mitre.oval:tst:11140" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:6540" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11202.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11202.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal to 8.1.7" id="oval:org.mitre.oval:tst:11202" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal to 8.1.7" id="oval:org.mitre.oval:tst:11202" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7369" />
   <state state_ref="oval:org.mitre.oval:ste:5773" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11234.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11234.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 9.3.2" id="oval:org.mitre.oval:tst:11234" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 9.3.2" id="oval:org.mitre.oval:tst:11234" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7123" />
   <state state_ref="oval:org.mitre.oval:ste:6656" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11272.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11272.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6527.5000" id="oval:org.mitre.oval:tst:11272" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6527.5000" id="oval:org.mitre.oval:tst:11272" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:6599" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11538.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11538.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 8.2.2" id="oval:org.mitre.oval:tst:11538" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 8.2.2" id="oval:org.mitre.oval:tst:11538" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7369" />
   <state state_ref="oval:org.mitre.oval:ste:6740" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11669.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11669.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8321.0" id="oval:org.mitre.oval:tst:11669" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8321.0" id="oval:org.mitre.oval:tst:11669" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:6490" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11712.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11712.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 8.2.2" id="oval:org.mitre.oval:tst:11712" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 8.2.2" id="oval:org.mitre.oval:tst:11712" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7461" />
   <state state_ref="oval:org.mitre.oval:ste:6740" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112186.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112186.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.7.11 in VisualSVN Server" id="oval:org.mitre.oval:tst:112186" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.7.11 in VisualSVN Server" id="oval:org.mitre.oval:tst:112186" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30676" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112449.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112449.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.6 in VisualSVN Server" id="oval:org.mitre.oval:tst:112449" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.6 in VisualSVN Server" id="oval:org.mitre.oval:tst:112449" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30456" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112523.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112523.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.3 in VisualSVN Server" id="oval:org.mitre.oval:tst:112523" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.3 in VisualSVN Server" id="oval:org.mitre.oval:tst:112523" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30463" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112620.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112620.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.2 in VisualSVN Server" id="oval:org.mitre.oval:tst:112620" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.2 in VisualSVN Server" id="oval:org.mitre.oval:tst:112620" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30467" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112656.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112656.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.8.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:112656" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.8.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:112656" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30451" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112697.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112697.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.15 in VisualSVN Server" id="oval:org.mitre.oval:tst:112697" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.15 in VisualSVN Server" id="oval:org.mitre.oval:tst:112697" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30682" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112847.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112847.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.5 in VisualSVN Server" id="oval:org.mitre.oval:tst:112847" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.5 in VisualSVN Server" id="oval:org.mitre.oval:tst:112847" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30680" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112949.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112949.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.3.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:112949" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.3.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:112949" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30557" />
 </file_test>

--- a/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112959.xml
+++ b/repository/tests/windows/file_test/112000/oval_org.mitre.oval_tst_112959.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.14 in VisualSVN Server" id="oval:org.mitre.oval:tst:112959" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.14 in VisualSVN Server" id="oval:org.mitre.oval:tst:112959" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:30155" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113072.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113072.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of pubconv.dll is less than 11.0.8410" id="oval:org.mitre.oval:tst:113072" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of pubconv.dll is less than 11.0.8410" id="oval:org.mitre.oval:tst:113072" version="4">
   <object object_ref="oval:org.mitre.oval:obj:2193" />
   <state state_ref="oval:org.mitre.oval:ste:30026" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113263.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113263.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is greater than or equals to 2.3.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:113263" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is greater than or equals to 2.3.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:113263" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:30982" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113432.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113432.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is less than 2.2.27 in VisualSVN Server" id="oval:org.mitre.oval:tst:113432" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is less than 2.2.27 in VisualSVN Server" id="oval:org.mitre.oval:tst:113432" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:30715" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113438.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113438.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7121.5004" id="oval:org.mitre.oval:tst:113438" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7121.5004" id="oval:org.mitre.oval:tst:113438" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:31026" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113504.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113504.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is less than 2.4.8 in VisualSVN Server" id="oval:org.mitre.oval:tst:113504" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is less than 2.4.8 in VisualSVN Server" id="oval:org.mitre.oval:tst:113504" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:30893" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113552.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113552.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of pubconv.dll is less than 12.0.6694.5000" id="oval:org.mitre.oval:tst:113552" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of pubconv.dll is less than 12.0.6694.5000" id="oval:org.mitre.oval:tst:113552" version="4">
   <object object_ref="oval:org.mitre.oval:obj:2193" />
   <state state_ref="oval:org.mitre.oval:ste:30920" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113962.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113962.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Autohelper.dll is less than 15.0.4569.1000" id="oval:org.mitre.oval:tst:113962" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Autohelper.dll is less than 15.0.4569.1000" id="oval:org.mitre.oval:tst:113962" version="2">
   <object object_ref="oval:org.mitre.oval:obj:29070" />
   <state state_ref="oval:org.mitre.oval:ste:31371" />
 </file_test>

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114251.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114251.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of usp10.dll is less than 1.626.7601.22666" id="oval:org.mitre.oval:tst:114251" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of usp10.dll is less than 1.626.7601.22666" id="oval:org.mitre.oval:tst:114251" version="4">
   <object object_ref="oval:org.mitre.oval:obj:39196" />
   <state state_ref="oval:org.mitre.oval:ste:31425" />
 </file_test>

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114665.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114665.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 14.0.7125.5000" id="oval:org.mitre.oval:tst:114665" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 14.0.7125.5000" id="oval:org.mitre.oval:tst:114665" version="4">
   <object object_ref="oval:org.mitre.oval:obj:24602" />
   <state state_ref="oval:org.mitre.oval:ste:30833" />
 </file_test>

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114722.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114722.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.17016" id="oval:org.mitre.oval:tst:114722" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.17016" id="oval:org.mitre.oval:tst:114722" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:31652" />
 </file_test>

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114781.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114781.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 12.0.6700.5000" id="oval:org.mitre.oval:tst:114781" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 12.0.6700.5000" id="oval:org.mitre.oval:tst:114781" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6428" />
   <state state_ref="oval:org.mitre.oval:ste:31176" />
 </file_test>

--- a/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114854.xml
+++ b/repository/tests/windows/file_test/114000/oval_org.mitre.oval_tst_114854.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll (Lync 2010) is less than 4.0.7577.4446" id="oval:org.mitre.oval:tst:114854" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll (Lync 2010) is less than 4.0.7577.4446" id="oval:org.mitre.oval:tst:114854" version="2">
   <object object_ref="oval:org.mitre.oval:obj:38846" />
   <state state_ref="oval:org.mitre.oval:ste:31242" />
 </file_test>

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115291.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115291.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.1.7601.22709" id="oval:org.mitre.oval:tst:115291" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.1.7601.22709" id="oval:org.mitre.oval:tst:115291" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:31776" />
 </file_test>

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115416.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115416.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.1.7601.18493" id="oval:org.mitre.oval:tst:115416" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.1.7601.18493" id="oval:org.mitre.oval:tst:115416" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:31593" />
 </file_test>

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115433.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115433.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.0.6002.19116" id="oval:org.mitre.oval:tst:115433" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.0.6002.19116" id="oval:org.mitre.oval:tst:115433" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:31812" />
 </file_test>

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115525.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115525.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.0.6002.23415" id="oval:org.mitre.oval:tst:115525" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.0.6002.23415" id="oval:org.mitre.oval:tst:115525" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:31890" />
 </file_test>

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115541.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115541.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.21135" id="oval:org.mitre.oval:tst:115541" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.21135" id="oval:org.mitre.oval:tst:115541" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:31622" />
 </file_test>

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115581.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115581.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.3.9600.16670" id="oval:org.mitre.oval:tst:115581" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.3.9600.16670" id="oval:org.mitre.oval:tst:115581" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:31920" />
 </file_test>

--- a/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115661.xml
+++ b/repository/tests/windows/file_test/115000/oval_org.mitre.oval_tst_115661.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is greater than or equal to 6.2.9200.21000" id="oval:org.mitre.oval:tst:115661" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is greater than or equal to 6.2.9200.21000" id="oval:org.mitre.oval:tst:115661" version="5">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:30959" />
 </file_test>

--- a/repository/tests/windows/file_test/121000/oval_org.mitre.oval_tst_121683.xml
+++ b/repository/tests/windows/file_test/121000/oval_org.mitre.oval_tst_121683.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 10.0.5750.0" id="oval:org.mitre.oval:tst:121683" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 10.0.5750.0" id="oval:org.mitre.oval:tst:121683" version="2">
   <object object_ref="oval:org.mitre.oval:obj:41803" />
   <state state_ref="oval:org.mitre.oval:ste:20006" />
 </file_test>

--- a/repository/tests/windows/file_test/121000/oval_org.mitre.oval_tst_121801.xml
+++ b/repository/tests/windows/file_test/121000/oval_org.mitre.oval_tst_121801.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.0.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:121801" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.0.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:121801" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:33357" />
 </file_test>

--- a/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122173.xml
+++ b/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122173.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 10.50.4321" id="oval:org.mitre.oval:tst:122173" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 10.50.4321" id="oval:org.mitre.oval:tst:122173" version="2">
   <object object_ref="oval:org.mitre.oval:obj:41803" />
   <state state_ref="oval:org.mitre.oval:ste:33246" />
 </file_test>

--- a/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122178.xml
+++ b/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122178.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 10.50.4251" id="oval:org.mitre.oval:tst:122178" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 10.50.4251" id="oval:org.mitre.oval:tst:122178" version="2">
   <object object_ref="oval:org.mitre.oval:obj:41803" />
   <state state_ref="oval:org.mitre.oval:ste:33475" />
 </file_test>

--- a/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122230.xml
+++ b/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122230.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 10.0.5869" id="oval:org.mitre.oval:tst:122230" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 10.0.5869" id="oval:org.mitre.oval:tst:122230" version="2">
   <object object_ref="oval:org.mitre.oval:obj:41803" />
   <state state_ref="oval:org.mitre.oval:ste:33603" />
 </file_test>

--- a/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122606.xml
+++ b/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122606.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.18 in VisualSVN Server" id="oval:org.mitre.oval:tst:122606" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.18 in VisualSVN Server" id="oval:org.mitre.oval:tst:122606" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:32842" />
 </file_test>

--- a/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122708.xml
+++ b/repository/tests/windows/file_test/122000/oval_org.mitre.oval_tst_122708.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.10 in VisualSVN Server" id="oval:org.mitre.oval:tst:122708" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.10 in VisualSVN Server" id="oval:org.mitre.oval:tst:122708" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:33595" />
 </file_test>

--- a/repository/tests/windows/file_test/125000/oval_org.mitre.oval_tst_125041.xml
+++ b/repository/tests/windows/file_test/125000/oval_org.mitre.oval_tst_125041.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7134.5000" id="oval:org.mitre.oval:tst:125041" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7134.5000" id="oval:org.mitre.oval:tst:125041" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:34041" />
 </file_test>

--- a/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135535.xml
+++ b/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135535.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.18620" id="oval:org.mitre.oval:tst:135535" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.18620" id="oval:org.mitre.oval:tst:135535" version="2">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:36988" />
 </file_test>

--- a/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135656.xml
+++ b/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135656.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.22827" id="oval:org.mitre.oval:tst:135656" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.22827" id="oval:org.mitre.oval:tst:135656" version="2">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:37460" />
 </file_test>

--- a/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135725.xml
+++ b/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135725.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.18622" id="oval:org.mitre.oval:tst:135725" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.18622" id="oval:org.mitre.oval:tst:135725" version="2">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:37380" />
 </file_test>

--- a/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135751.xml
+++ b/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135751.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.22828" id="oval:org.mitre.oval:tst:135751" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.22828" id="oval:org.mitre.oval:tst:135751" version="2">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:37290" />
 </file_test>

--- a/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135890.xml
+++ b/repository/tests/windows/file_test/135000/oval_org.mitre.oval_tst_135890.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7140.5000" id="oval:org.mitre.oval:tst:135890" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7140.5000" id="oval:org.mitre.oval:tst:135890" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:37210" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137799.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137799.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 14.0.7134.5000" id="oval:org.mitre.oval:tst:137799" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 14.0.7134.5000" id="oval:org.mitre.oval:tst:137799" version="3">
   <object object_ref="oval:org.mitre.oval:obj:15988" />
   <state state_ref="oval:org.mitre.oval:ste:38431" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137981.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137981.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Msosec.dll (office 2010) is less than 7.10.5078.0" id="oval:org.mitre.oval:tst:137981" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Msosec.dll (office 2010) is less than 7.10.5078.0" id="oval:org.mitre.oval:tst:137981" version="5">
   <object object_ref="oval:org.mitre.oval:obj:43355" />
   <state state_ref="oval:org.mitre.oval:ste:38353" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137981.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137981.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Msosec.dll (office 2010) is less than 7.10.5078.0" id="oval:org.mitre.oval:tst:137981" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Msosec.dll (office 2010) is less than 7.10.5078.0" id="oval:org.mitre.oval:tst:137981" version="4">
   <object object_ref="oval:org.mitre.oval:obj:43355" />
   <state state_ref="oval:org.mitre.oval:ste:38353" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137990.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137990.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7143.5000" id="oval:org.mitre.oval:tst:137990" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7143.5000" id="oval:org.mitre.oval:tst:137990" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.mitre.oval:ste:38286" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137993.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137993.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7143.5000" id="oval:org.mitre.oval:tst:137993" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7143.5000" id="oval:org.mitre.oval:tst:137993" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:38286" />
 </file_test>

--- a/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137996.xml
+++ b/repository/tests/windows/file_test/137000/oval_org.mitre.oval_tst_137996.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msores.dll is less than 15.0.4697.1000" id="oval:org.mitre.oval:tst:137996" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of msores.dll is less than 15.0.4697.1000" id="oval:org.mitre.oval:tst:137996" version="2">
   <object object_ref="oval:org.mitre.oval:obj:29126" />
   <state state_ref="oval:org.mitre.oval:ste:37582" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138001.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138001.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 12.0.6718.5000" id="oval:org.mitre.oval:tst:138001" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 12.0.6718.5000" id="oval:org.mitre.oval:tst:138001" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:38152" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138006.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138006.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Msosec.dll (office 2013) is less than 7.10.5078.0" id="oval:org.mitre.oval:tst:138006" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Msosec.dll (office 2013) is less than 7.10.5078.0" id="oval:org.mitre.oval:tst:138006" version="2">
   <object object_ref="oval:org.mitre.oval:obj:42815" />
   <state state_ref="oval:org.mitre.oval:ste:38353" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138129.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138129.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of oartconv.dll is less than 14.0.7134.5000" id="oval:org.mitre.oval:tst:138129" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of oartconv.dll is less than 14.0.7134.5000" id="oval:org.mitre.oval:tst:138129" version="3">
   <object object_ref="oval:org.mitre.oval:obj:15858" />
   <state state_ref="oval:org.mitre.oval:ste:38431" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138167.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138167.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138167" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of oart.dll is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138167" version="3">
   <object object_ref="oval:org.mitre.oval:obj:15988" />
   <state state_ref="oval:org.mitre.oval:ste:38731" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138219.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138219.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7145.5001" id="oval:org.mitre.oval:tst:138219" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7145.5001" id="oval:org.mitre.oval:tst:138219" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:38398" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138288.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138288.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 12.0.6721.5000" id="oval:org.mitre.oval:tst:138288" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 12.0.6721.5000" id="oval:org.mitre.oval:tst:138288" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:38644" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138349.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138349.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7145.5001" id="oval:org.mitre.oval:tst:138349" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7145.5001" id="oval:org.mitre.oval:tst:138349" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.mitre.oval:ste:38398" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138354.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138354.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of pptview.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138354" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of pptview.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138354" version="4">
   <object object_ref="oval:org.mitre.oval:obj:16025" />
   <state state_ref="oval:org.mitre.oval:ste:38731" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138354.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138354.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of pptview.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138354" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of pptview.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138354" version="5">
   <object object_ref="oval:org.mitre.oval:obj:16025" />
   <state state_ref="oval:org.mitre.oval:ste:38731" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138418.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138418.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7147.5000" id="oval:org.mitre.oval:tst:138418" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7147.5000" id="oval:org.mitre.oval:tst:138418" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:38336" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138529.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138529.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 14.0.7148.5000" id="oval:org.mitre.oval:tst:138529" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 14.0.7148.5000" id="oval:org.mitre.oval:tst:138529" version="4">
   <object object_ref="oval:org.mitre.oval:obj:24602" />
   <state state_ref="oval:org.mitre.oval:ste:38798" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138552.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138552.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of oartconv.dll is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138552" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of oartconv.dll is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138552" version="3">
   <object object_ref="oval:org.mitre.oval:obj:15858" />
   <state state_ref="oval:org.mitre.oval:ste:38731" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138593.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138593.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138593" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138593" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.mitre.oval:ste:38731" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138611.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138611.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138611" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7149.5000" id="oval:org.mitre.oval:tst:138611" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:38731" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138666.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138666.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll (Lync 2010) is less than 4.0.7577.4461" id="oval:org.mitre.oval:tst:138666" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll (Lync 2010) is less than 4.0.7577.4461" id="oval:org.mitre.oval:tst:138666" version="2">
   <object object_ref="oval:org.mitre.oval:obj:38846" />
   <state state_ref="oval:org.mitre.oval:ste:38377" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138781.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138781.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.18847" id="oval:org.mitre.oval:tst:138781" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.18847" id="oval:org.mitre.oval:tst:138781" version="1">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:38981" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138802.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138802.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Autohelper.DLL is less than 15.0.4709.1000" id="oval:org.mitre.oval:tst:138802" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Autohelper.DLL is less than 15.0.4709.1000" id="oval:org.mitre.oval:tst:138802" version="1">
   <object object_ref="oval:org.mitre.oval:obj:29070" />
   <state state_ref="oval:org.mitre.oval:ste:38521" />
 </file_test>

--- a/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138807.xml
+++ b/repository/tests/windows/file_test/138000/oval_org.mitre.oval_tst_138807.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 12.0.6719.5000" id="oval:org.mitre.oval:tst:138807" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 12.0.6719.5000" id="oval:org.mitre.oval:tst:138807" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6428" />
   <state state_ref="oval:org.mitre.oval:ste:38466" />
 </file_test>

--- a/repository/tests/windows/file_test/139000/oval_org.mitre.oval_tst_139052.xml
+++ b/repository/tests/windows/file_test/139000/oval_org.mitre.oval_tst_139052.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.23049" id="oval:org.mitre.oval:tst:139052" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.23049" id="oval:org.mitre.oval:tst:139052" version="1">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:39005" />
 </file_test>

--- a/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141097.xml
+++ b/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141097.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7153.5000" id="oval:org.mitre.oval:tst:141097" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7153.5000" id="oval:org.mitre.oval:tst:141097" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.mitre.oval:ste:39808" />
 </file_test>

--- a/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141421.xml
+++ b/repository/tests/windows/file_test/141000/oval_org.mitre.oval_tst_141421.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7153.5002" id="oval:org.mitre.oval:tst:141421" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7153.5002" id="oval:org.mitre.oval:tst:141421" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:39685" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2047.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2047.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll is less than 14.0.7157.5000" id="oval:org.cisecurity:tst:2047" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll is less than 14.0.7157.5000" id="oval:org.cisecurity:tst:2047" version="1">
   <object object_ref="oval:org.mitre.oval:obj:24602" />
   <state state_ref="oval:org.cisecurity:ste:1649" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2048.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2048.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of lynchtmlconv.exe is less than 16.0.4288.1000" id="oval:org.cisecurity:tst:2048" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of lynchtmlconv.exe is less than 16.0.4288.1000" id="oval:org.cisecurity:tst:2048" version="1">
   <object object_ref="oval:org.cisecurity:obj:222" />
   <state state_ref="oval:org.cisecurity:ste:1647" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2049.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2049.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Communicator.exe is less than 4.0.7577.4478" id="oval:org.cisecurity:tst:2049" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Communicator.exe is less than 4.0.7577.4478" id="oval:org.cisecurity:tst:2049" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.cisecurity:ste:1646" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2050.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2050.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of lynchtmlconv.exe is less than 15.0.4753.1000" id="oval:org.cisecurity:tst:2050" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of lynchtmlconv.exe is less than 15.0.4753.1000" id="oval:org.cisecurity:tst:2050" version="1">
   <object object_ref="oval:org.cisecurity:obj:230" />
   <state state_ref="oval:org.cisecurity:ste:1645" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2052.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2052.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll is less than 12.0.6728.5000" id="oval:org.cisecurity:tst:2052" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ogl.dll is less than 12.0.6728.5000" id="oval:org.cisecurity:tst:2052" version="1">
   <object object_ref="oval:org.mitre.oval:obj:6428" />
   <state state_ref="oval:org.cisecurity:ste:1650" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2076.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2076.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4875.1000" id="oval:org.cisecurity:tst:2076" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 15.0.4875.1000" id="oval:org.cisecurity:tst:2076" version="1">
   <object object_ref="oval:org.mitre.oval:obj:662" />
   <state state_ref="oval:org.cisecurity:ste:1670" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2077.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2077.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7176.5000" id="oval:org.cisecurity:tst:2077" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7176.5000" id="oval:org.cisecurity:tst:2077" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.cisecurity:ste:1668" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2079.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2079.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7176.5000" id="oval:org.cisecurity:tst:2079" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of wwlibcxm.dll is less than 14.0.7176.5000" id="oval:org.cisecurity:tst:2079" version="1">
   <object object_ref="oval:org.cisecurity:obj:218" />
   <state state_ref="oval:org.cisecurity:ste:1668" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2081.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2081.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7176.5000" id="oval:org.cisecurity:tst:2081" version="1">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7176.5000" id="oval:org.cisecurity:tst:2081" version="1">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.cisecurity:ste:1668" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2082.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2082.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 16.0.4456.1003" id="oval:org.cisecurity:tst:2082" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 16.0.4456.1003" id="oval:org.cisecurity:tst:2082" version="1">
   <object object_ref="oval:org.cisecurity:obj:236" />
   <state state_ref="oval:org.cisecurity:ste:1669" />
 </file_test>

--- a/repository/tests/windows/file_test/20000/oval_org.mitre.oval_tst_20828.xml
+++ b/repository/tests/windows/file_test/20000/oval_org.mitre.oval_tst_20828.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 9.3.1" id="oval:org.mitre.oval:tst:20828" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 9.3.1" id="oval:org.mitre.oval:tst:20828" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7301" />
   <state state_ref="oval:org.mitre.oval:ste:6635" />
 </file_test>

--- a/repository/tests/windows/file_test/20000/oval_org.mitre.oval_tst_20841.xml
+++ b/repository/tests/windows/file_test/20000/oval_org.mitre.oval_tst_20841.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 9.3.1" id="oval:org.mitre.oval:tst:20841" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 9.3.1" id="oval:org.mitre.oval:tst:20841" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7123" />
   <state state_ref="oval:org.mitre.oval:ste:6635" />
 </file_test>

--- a/repository/tests/windows/file_test/20000/oval_org.mitre.oval_tst_20897.xml
+++ b/repository/tests/windows/file_test/20000/oval_org.mitre.oval_tst_20897.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 8.2.1" id="oval:org.mitre.oval:tst:20897" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 8.2.1" id="oval:org.mitre.oval:tst:20897" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7369" />
   <state state_ref="oval:org.mitre.oval:ste:6659" />
 </file_test>

--- a/repository/tests/windows/file_test/20000/oval_org.mitre.oval_tst_20935.xml
+++ b/repository/tests/windows/file_test/20000/oval_org.mitre.oval_tst_20935.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 8.2.1" id="oval:org.mitre.oval:tst:20935" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 8.2.1" id="oval:org.mitre.oval:tst:20935" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7461" />
   <state state_ref="oval:org.mitre.oval:ste:6659" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27214.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27214.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6535.5002" id="oval:org.mitre.oval:tst:27214" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6535.5002" id="oval:org.mitre.oval:tst:27214" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:7189" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27463.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27463.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 8.2.3" id="oval:org.mitre.oval:tst:27463" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 8.2.3" id="oval:org.mitre.oval:tst:27463" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7461" />
   <state state_ref="oval:org.mitre.oval:ste:7153" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27543.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27543.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6535.5002" id="oval:org.mitre.oval:tst:27543" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6535.5002" id="oval:org.mitre.oval:tst:27543" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:6998" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27605.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27605.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 9.3.3" id="oval:org.mitre.oval:tst:27605" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than 9.3.3" id="oval:org.mitre.oval:tst:27605" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7301" />
   <state state_ref="oval:org.mitre.oval:ste:7092" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27716.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27716.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 9.3.3" id="oval:org.mitre.oval:tst:27716" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 9.3.3" id="oval:org.mitre.oval:tst:27716" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7123" />
   <state state_ref="oval:org.mitre.oval:ste:7092" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27728.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27728.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8324.0" id="oval:org.mitre.oval:tst:27728" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8324.0" id="oval:org.mitre.oval:tst:27728" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:7082" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27747.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27747.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 8.2.3" id="oval:org.mitre.oval:tst:27747" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than 8.2.3" id="oval:org.mitre.oval:tst:27747" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7369" />
   <state state_ref="oval:org.mitre.oval:ste:7153" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3772.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3772.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mso.dll is less than 12.00.6017.5000" id="oval:org.mitre.oval:tst:3772" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mso.dll is less than 12.00.6017.5000" id="oval:org.mitre.oval:tst:3772" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:3243" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3774.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3774.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of pubconv.dll is less than 12.0.6023.5000" id="oval:org.mitre.oval:tst:3774" version="6">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of pubconv.dll is less than 12.0.6023.5000" id="oval:org.mitre.oval:tst:3774" version="6">
   <object object_ref="oval:org.mitre.oval:obj:2193" />
   <state state_ref="oval:org.mitre.oval:ste:3587" />
 </file_test>

--- a/repository/tests/windows/file_test/4000/oval_org.mitre.oval_tst_4000.xml
+++ b/repository/tests/windows/file_test/4000/oval_org.mitre.oval_tst_4000.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 12.0.6023.5000" id="oval:org.mitre.oval:tst:4000" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 12.0.6023.5000" id="oval:org.mitre.oval:tst:4000" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:3587" />
 </file_test>

--- a/repository/tests/windows/file_test/40000/oval_org.mitre.oval_tst_40904.xml
+++ b/repository/tests/windows/file_test/40000/oval_org.mitre.oval_tst_40904.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal 8.2.4" id="oval:org.mitre.oval:tst:40904" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal 8.2.4" id="oval:org.mitre.oval:tst:40904" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7369" />
   <state state_ref="oval:org.mitre.oval:ste:11658" />
 </file_test>

--- a/repository/tests/windows/file_test/40000/oval_org.mitre.oval_tst_40936.xml
+++ b/repository/tests/windows/file_test/40000/oval_org.mitre.oval_tst_40936.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal to 9.3.3" id="oval:org.mitre.oval:tst:40936" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal to 9.3.3" id="oval:org.mitre.oval:tst:40936" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7123" />
   <state state_ref="oval:org.mitre.oval:ste:11367" />
 </file_test>

--- a/repository/tests/windows/file_test/40000/oval_org.mitre.oval_tst_40955.xml
+++ b/repository/tests/windows/file_test/40000/oval_org.mitre.oval_tst_40955.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 14.0.5126.5000" id="oval:org.mitre.oval:tst:40955" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 14.0.5126.5000" id="oval:org.mitre.oval:tst:40955" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:11653" />
 </file_test>

--- a/repository/tests/windows/file_test/40000/oval_org.mitre.oval_tst_40970.xml
+++ b/repository/tests/windows/file_test/40000/oval_org.mitre.oval_tst_40970.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal 9.3.4" id="oval:org.mitre.oval:tst:40970" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal 9.3.4" id="oval:org.mitre.oval:tst:40970" version="4">
   <object object_ref="oval:org.mitre.oval:obj:7123" />
   <state state_ref="oval:org.mitre.oval:ste:11499" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41205.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41205.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if MSO.dll file version in Microsoft Office Groove is less than or equal to 12.0.4518.1014" deprecated="true" id="oval:org.mitre.oval:tst:41205" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if MSO.dll file version in Microsoft Office Groove is less than or equal to 12.0.4518.1014" deprecated="true" id="oval:org.mitre.oval:tst:41205" version="3">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:11650" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41324.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41324.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal to 8.2.3" id="oval:org.mitre.oval:tst:41324" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal to 8.2.3" id="oval:org.mitre.oval:tst:41324" version="5">
   <object object_ref="oval:org.mitre.oval:obj:7461" />
   <state state_ref="oval:org.mitre.oval:ste:11596" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41491.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41491.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6545.5004" id="oval:org.mitre.oval:tst:41491" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6545.5004" id="oval:org.mitre.oval:tst:41491" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:11428" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41504.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41504.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal to 9.3.3" id="oval:org.mitre.oval:tst:41504" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal to 9.3.3" id="oval:org.mitre.oval:tst:41504" version="5">
   <object object_ref="oval:org.mitre.oval:obj:7301" />
   <state state_ref="oval:org.mitre.oval:ste:11367" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41524.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41524.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6867.0" id="oval:org.mitre.oval:tst:41524" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6867.0" id="oval:org.mitre.oval:tst:41524" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:12083" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41535.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41535.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal to 8.2.3" id="oval:org.mitre.oval:tst:41535" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Acrobat library is less than or equal to 8.2.3" id="oval:org.mitre.oval:tst:41535" version="3">
   <object object_ref="oval:org.mitre.oval:obj:7369" />
   <state state_ref="oval:org.mitre.oval:ste:11596" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41553.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41553.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if MSO.dll file version in Microsoft Office Groove SP2 is less than or equal to 12.0.6425.1000" deprecated="true" id="oval:org.mitre.oval:tst:41553" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if MSO.dll file version in Microsoft Office Groove SP2 is less than or equal to 12.0.6425.1000" deprecated="true" id="oval:org.mitre.oval:tst:41553" version="3">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:11049" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41570.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41570.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal 9.3.4" id="oval:org.mitre.oval:tst:41570" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal 9.3.4" id="oval:org.mitre.oval:tst:41570" version="5">
   <object object_ref="oval:org.mitre.oval:obj:7301" />
   <state state_ref="oval:org.mitre.oval:ste:11499" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41646.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41646.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal 8.2.4" id="oval:org.mitre.oval:tst:41646" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Adobe Reader library is less than or equal 8.2.4" id="oval:org.mitre.oval:tst:41646" version="5">
   <object object_ref="oval:org.mitre.oval:obj:7461" />
   <state state_ref="oval:org.mitre.oval:ste:11658" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41652.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41652.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6546.5000" id="oval:org.mitre.oval:tst:41652" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6546.5000" id="oval:org.mitre.oval:tst:41652" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:11746" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41780.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41780.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if MSO.dll file version in Microsoft Office Groove SP1 is less than or equal to 12.0.6213.1000" deprecated="true" id="oval:org.mitre.oval:tst:41780" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if MSO.dll file version in Microsoft Office Groove SP1 is less than or equal to 12.0.6213.1000" deprecated="true" id="oval:org.mitre.oval:tst:41780" version="3">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:11940" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41823.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41823.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8329.0" id="oval:org.mitre.oval:tst:41823" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8329.0" id="oval:org.mitre.oval:tst:41823" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:11983" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42586.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42586.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check the existence of EScript.api in Adobe Reader 8" id="oval:org.mitre.oval:tst:42586" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check the existence of EScript.api in Adobe Reader 8" id="oval:org.mitre.oval:tst:42586" version="3">
   <object object_ref="oval:org.mitre.oval:obj:15343" />
   <state state_ref="oval:org.mitre.oval:ste:12206" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42641.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42641.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6554.5001" id="oval:org.mitre.oval:tst:42641" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6554.5001" id="oval:org.mitre.oval:tst:42641" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:12333" />
 </file_test>

--- a/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42714.xml
+++ b/repository/tests/windows/file_test/42000/oval_org.mitre.oval_tst_42714.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check the existence of EScript.api in Adobe Reader 9" id="oval:org.mitre.oval:tst:42714" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check the existence of EScript.api in Adobe Reader 9" id="oval:org.mitre.oval:tst:42714" version="3">
   <object object_ref="oval:org.mitre.oval:obj:15772" />
   <state state_ref="oval:org.mitre.oval:ste:12206" />
 </file_test>

--- a/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43478.xml
+++ b/repository/tests/windows/file_test/43000/oval_org.mitre.oval_tst_43478.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6562.5003" id="oval:org.mitre.oval:tst:43478" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6562.5003" id="oval:org.mitre.oval:tst:43478" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:12070" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7678.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7678.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8200.0" id="oval:org.mitre.oval:tst:7678" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8200.0" id="oval:org.mitre.oval:tst:7678" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:3333" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7723.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7723.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6840.0" id="oval:org.mitre.oval:tst:7723" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6840.0" id="oval:org.mitre.oval:tst:7723" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:3465" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7731.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7731.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 9.0.8932.0" id="oval:org.mitre.oval:tst:7731" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 9.0.8932.0" id="oval:org.mitre.oval:tst:7731" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:3344" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7781.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7781.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 9.0.8931.0" id="oval:org.mitre.oval:tst:7781" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 9.0.8931.0" id="oval:org.mitre.oval:tst:7781" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:3752" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7824.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7824.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6308.5000" id="oval:org.mitre.oval:tst:7824" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6308.5000" id="oval:org.mitre.oval:tst:7824" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:3259" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7961.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7961.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6842.0" id="oval:org.mitre.oval:tst:7961" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6842.0" id="oval:org.mitre.oval:tst:7961" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:3921" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7976.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7976.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8212.0" id="oval:org.mitre.oval:tst:7976" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8212.0" id="oval:org.mitre.oval:tst:7976" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:3936" />
 </file_test>

--- a/repository/tests/windows/file_test/77000/oval_org.mitre.oval_tst_77919.xml
+++ b/repository/tests/windows/file_test/77000/oval_org.mitre.oval_tst_77919.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8342" id="oval:org.mitre.oval:tst:77919" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8342" id="oval:org.mitre.oval:tst:77919" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:18360" />
 </file_test>

--- a/repository/tests/windows/file_test/77000/oval_org.mitre.oval_tst_77931.xml
+++ b/repository/tests/windows/file_test/77000/oval_org.mitre.oval_tst_77931.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6652.5000" id="oval:org.mitre.oval:tst:77931" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6652.5000" id="oval:org.mitre.oval:tst:77931" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:18094" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79363.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79363.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of communicator.exe is less than 4.0.7577.4109 (for Lync 2010)" id="oval:org.mitre.oval:tst:79363" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of communicator.exe is less than 4.0.7577.4109 (for Lync 2010)" id="oval:org.mitre.oval:tst:79363" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.mitre.oval:ste:19709" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79658.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79658.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Acees.dll is less than 14.0.6015.1000" id="oval:org.mitre.oval:tst:79658" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Acees.dll is less than 14.0.6015.1000" id="oval:org.mitre.oval:tst:79658" version="5">
   <object object_ref="oval:org.mitre.oval:obj:23177" />
   <state state_ref="oval:org.mitre.oval:ste:19578" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79829.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79829.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Vviewer.dll file version is less than 14.0.6119.5000" id="oval:org.mitre.oval:tst:79829" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Vviewer.dll file version is less than 14.0.6119.5000" id="oval:org.mitre.oval:tst:79829" version="4">
   <object object_ref="oval:org.mitre.oval:obj:23136" />
   <state state_ref="oval:org.mitre.oval:ste:19489" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79849.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79849.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Msmdsrv.exe is less than 8.0.2304.0" id="oval:org.mitre.oval:tst:79849" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Msmdsrv.exe is less than 8.0.2304.0" id="oval:org.mitre.oval:tst:79849" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23620" />
   <state state_ref="oval:org.mitre.oval:ste:20039" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79972.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79972.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if version of Communicator.exe (Lync 2010) is less than 4.0.7577.4098" id="oval:org.mitre.oval:tst:79972" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if version of Communicator.exe (Lync 2010) is less than 4.0.7577.4098" id="oval:org.mitre.oval:tst:79972" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.mitre.oval:ste:19700" />
 </file_test>

--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79988.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79988.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mso.dll file version is less than 12.0.6662.5000" id="oval:org.mitre.oval:tst:79988" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Mso.dll file version is less than 12.0.6662.5000" id="oval:org.mitre.oval:tst:79988" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:20009" />
 </file_test>

--- a/repository/tests/windows/file_test/8000/oval_org.mitre.oval_tst_8962.xml
+++ b/repository/tests/windows/file_test/8000/oval_org.mitre.oval_tst_8962.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6320.5000" id="oval:org.mitre.oval:tst:8962" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Mso.dll version is less than 12.0.6320.5000" id="oval:org.mitre.oval:tst:8962" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:4003" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80004.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80004.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ipeditor.dll is less than 14.0.6120.5000" id="oval:org.mitre.oval:tst:80004" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ipeditor.dll is less than 14.0.6120.5000" id="oval:org.mitre.oval:tst:80004" version="5">
   <object object_ref="oval:org.mitre.oval:obj:23360" />
   <state state_ref="oval:org.mitre.oval:ste:19741" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80015.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80015.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if version of Communicator.exe (Communicator 2007 R2) is less than 3.5.6907.253" id="oval:org.mitre.oval:tst:80015" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if version of Communicator.exe (Communicator 2007 R2) is less than 3.5.6907.253" id="oval:org.mitre.oval:tst:80015" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.mitre.oval:ste:19665" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80108.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80108.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.6123.5005" id="oval:org.mitre.oval:tst:80108" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.6123.5005" id="oval:org.mitre.oval:tst:80108" version="4">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:19952" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80118.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80118.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Vislib.dll file version is less than 14.0.6122.5000" id="oval:org.mitre.oval:tst:80118" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Vislib.dll file version is less than 14.0.6122.5000" id="oval:org.mitre.oval:tst:80118" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24263" />
   <state state_ref="oval:org.mitre.oval:ste:19934" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80221.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80221.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ipeditor.dll is less than 14.0.6126.5000" id="oval:org.mitre.oval:tst:80221" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ipeditor.dll is less than 14.0.6126.5000" id="oval:org.mitre.oval:tst:80221" version="5">
   <object object_ref="oval:org.mitre.oval:obj:23360" />
   <state state_ref="oval:org.mitre.oval:ste:20000" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80230.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80230.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of communicator.exe is less than 3.5.6907.261" id="oval:org.mitre.oval:tst:80230" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of communicator.exe is less than 3.5.6907.261" id="oval:org.mitre.oval:tst:80230" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.mitre.oval:ste:19181" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80393.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80393.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.6129.5000" id="oval:org.mitre.oval:tst:80393" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.6129.5000" id="oval:org.mitre.oval:tst:80393" version="4">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:20008" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80464.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80464.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.6126.5003" id="oval:org.mitre.oval:tst:80464" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.6126.5003" id="oval:org.mitre.oval:tst:80464" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.mitre.oval:ste:19902" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80507.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80507.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Msascui.exe is less than 4.2.0223.0" id="oval:org.mitre.oval:tst:80507" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Msascui.exe is less than 4.2.0223.0" id="oval:org.mitre.oval:tst:80507" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24100" />
   <state state_ref="oval:org.mitre.oval:ste:20389" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80676.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80676.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of communicator.exe is less than 4.0.7577.4388 (for lync 2010)" id="oval:org.mitre.oval:tst:80676" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of communicator.exe is less than 4.0.7577.4388 (for lync 2010)" id="oval:org.mitre.oval:tst:80676" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.mitre.oval:ste:19761" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80878.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80878.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of communicator.exe is less than 3.5.6907.268" id="oval:org.mitre.oval:tst:80878" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of communicator.exe is less than 3.5.6907.268" id="oval:org.mitre.oval:tst:80878" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.mitre.oval:ste:20702" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80925.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80925.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Vviewer.dll is less than 14.0.6131.5002" id="oval:org.mitre.oval:tst:80925" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Vviewer.dll is less than 14.0.6131.5002" id="oval:org.mitre.oval:tst:80925" version="4">
   <object object_ref="oval:org.mitre.oval:obj:23136" />
   <state state_ref="oval:org.mitre.oval:ste:20303" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80929.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80929.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.16579" id="oval:org.mitre.oval:tst:80929" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.16579" id="oval:org.mitre.oval:tst:80929" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:21094" />
 </file_test>

--- a/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80968.xml
+++ b/repository/tests/windows/file_test/80000/oval_org.mitre.oval_tst_80968.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ipeditor.dll is less than 14.0.6134.5004" id="oval:org.mitre.oval:tst:80968" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ipeditor.dll is less than 14.0.6134.5004" id="oval:org.mitre.oval:tst:80968" version="5">
   <object object_ref="oval:org.mitre.oval:obj:23360" />
   <state state_ref="oval:org.mitre.oval:ste:20146" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81094.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81094.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mspub.exe is less than 11.0.8402" id="oval:org.mitre.oval:tst:81094" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mspub.exe is less than 11.0.8402" id="oval:org.mitre.oval:tst:81094" version="4">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:20557" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81158.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81158.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is less than 6.1.7600.21531" id="oval:org.mitre.oval:tst:81158" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is less than 6.1.7600.21531" id="oval:org.mitre.oval:tst:81158" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24512" />
   <state state_ref="oval:org.mitre.oval:ste:20863" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81205.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81205.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.0.6002.18817" id="oval:org.mitre.oval:tst:81205" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.0.6002.18817" id="oval:org.mitre.oval:tst:81205" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:20532" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81210.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81210.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mspub.exe is less than 14.0.6137.5000" id="oval:org.mitre.oval:tst:81210" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mspub.exe is less than 14.0.6137.5000" id="oval:org.mitre.oval:tst:81210" version="4">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:20391" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81217.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81217.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mspub.exe is less than 12.0.6676.5000" id="oval:org.mitre.oval:tst:81217" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mspub.exe is less than 12.0.6676.5000" id="oval:org.mitre.oval:tst:81217" version="4">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:20695" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81226.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81226.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is greater than or equal 6.2.9200.20000" id="oval:org.mitre.oval:tst:81226" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is greater than or equal 6.2.9200.20000" id="oval:org.mitre.oval:tst:81226" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:20223" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81354.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81354.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of lynchtmlconv.exe is less than 15.0.4517.1003" id="oval:org.mitre.oval:tst:81354" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of lynchtmlconv.exe is less than 15.0.4517.1003" id="oval:org.mitre.oval:tst:81354" version="4">
   <object object_ref="oval:org.mitre.oval:obj:24126" />
   <state state_ref="oval:org.mitre.oval:ste:20711" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81490.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81490.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll (Lync 2010) is less than 4.0.7577.4392" id="oval:org.mitre.oval:tst:81490" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll (Lync 2010) is less than 4.0.7577.4392" id="oval:org.mitre.oval:tst:81490" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.mitre.oval:ste:20900" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81522.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81522.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is greater than or equal to 6.1.7601.22000" id="oval:org.mitre.oval:tst:81522" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is greater than or equal to 6.1.7601.22000" id="oval:org.mitre.oval:tst:81522" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24512" />
   <state state_ref="oval:org.mitre.oval:ste:20456" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81555.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81555.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is less than 6.1.7601.18170" id="oval:org.mitre.oval:tst:81555" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is less than 6.1.7601.18170" id="oval:org.mitre.oval:tst:81555" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24512" />
   <state state_ref="oval:org.mitre.oval:ste:20249" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81676.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81676.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is less than 6.1.7601.22341" id="oval:org.mitre.oval:tst:81676" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is less than 6.1.7601.22341" id="oval:org.mitre.oval:tst:81676" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24512" />
   <state state_ref="oval:org.mitre.oval:ste:20899" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81753.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81753.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.16581" id="oval:org.mitre.oval:tst:81753" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.16581" id="oval:org.mitre.oval:tst:81753" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:20664" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81777.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81777.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is less than 6.1.7600.17316" id="oval:org.mitre.oval:tst:81777" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is less than 6.1.7600.17316" id="oval:org.mitre.oval:tst:81777" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24512" />
   <state state_ref="oval:org.mitre.oval:ste:20989" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81820.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81820.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.1.7601.18126" id="oval:org.mitre.oval:tst:81820" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.1.7601.18126" id="oval:org.mitre.oval:tst:81820" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:20585" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81824.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81824.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.20685" id="oval:org.mitre.oval:tst:81824" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.20685" id="oval:org.mitre.oval:tst:81824" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:20646" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81834.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81834.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is greater than or equal to 6.1.7600.21000" id="oval:org.mitre.oval:tst:81834" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mpclient.dll is greater than or equal to 6.1.7600.21000" id="oval:org.mitre.oval:tst:81834" version="3">
   <object object_ref="oval:org.mitre.oval:obj:24512" />
   <state state_ref="oval:org.mitre.oval:ste:19667" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81858.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81858.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 14.0.7102.5000" id="oval:org.mitre.oval:tst:81858" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 14.0.7102.5000" id="oval:org.mitre.oval:tst:81858" version="4">
   <object object_ref="oval:org.mitre.oval:obj:24602" />
   <state state_ref="oval:org.mitre.oval:ste:21170" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81888.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81888.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.0.6002.23094" id="oval:org.mitre.oval:tst:81888" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.0.6002.23094" id="oval:org.mitre.oval:tst:81888" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:20590" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81901.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81901.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.1.7601.22296" id="oval:org.mitre.oval:tst:81901" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.1.7601.22296" id="oval:org.mitre.oval:tst:81901" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:20719" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81916.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81916.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.20682" id="oval:org.mitre.oval:tst:81916" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jntfiltr.dll is less than 6.2.9200.20682" id="oval:org.mitre.oval:tst:81916" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23616" />
   <state state_ref="oval:org.mitre.oval:ste:20261" />
 </file_test>

--- a/repository/tests/windows/file_test/85000/oval_org.mitre.oval_tst_85970.xml
+++ b/repository/tests/windows/file_test/85000/oval_org.mitre.oval_tst_85970.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.18195" id="oval:org.mitre.oval:tst:85970" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.18195" id="oval:org.mitre.oval:tst:85970" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:23953" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86013.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86013.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of outlook.exe is less than 14.0.7105.5000" id="oval:org.mitre.oval:tst:86013" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of outlook.exe is less than 14.0.7105.5000" id="oval:org.mitre.oval:tst:86013" version="2">
   <object object_ref="oval:org.mitre.oval:obj:26468" />
   <state state_ref="oval:org.mitre.oval:ste:23634" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86128.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86128.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.5.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86128" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.5.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86128" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:23962" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86393.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86393.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.8.16 in VisualSVN Server" id="oval:org.mitre.oval:tst:86393" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.8.16 in VisualSVN Server" id="oval:org.mitre.oval:tst:86393" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:23989" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86460.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86460.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 0.9.7.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86460" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 0.9.7.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86460" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:23823" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86466.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86466.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7104.5000" id="oval:org.mitre.oval:tst:86466" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7104.5000" id="oval:org.mitre.oval:tst:86466" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.mitre.oval:ste:23691" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86487.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86487.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.identityserver.dll is less than 6.1.7600.17337" id="oval:org.mitre.oval:tst:86487" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.identityserver.dll is less than 6.1.7600.17337" id="oval:org.mitre.oval:tst:86487" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:23778" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86500.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86500.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.3.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:86500" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.3.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:86500" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24144" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86513.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86513.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.13 in VisualSVN Server" id="oval:org.mitre.oval:tst:86513" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.13 in VisualSVN Server" id="oval:org.mitre.oval:tst:86513" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24135" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86524.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86524.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7600.17338" id="oval:org.mitre.oval:tst:86524" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7600.17338" id="oval:org.mitre.oval:tst:86524" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:23787" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86562.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86562.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.7.13 in VisualSVN Server" id="oval:org.mitre.oval:tst:86562" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.7.13 in VisualSVN Server" id="oval:org.mitre.oval:tst:86562" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24181" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86583.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86583.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is greater than or equal to 6.1.7601.22000" id="oval:org.mitre.oval:tst:86583" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is greater than or equal to 6.1.7601.22000" id="oval:org.mitre.oval:tst:86583" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:20456" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86600.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86600.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is greater than or equals to 1.3.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86600" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is greater than or equals to 1.3.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86600" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:24279" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86620.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86620.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of msptls.dll is less than 12.0.6682.5000" id="oval:org.mitre.oval:tst:86620" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of msptls.dll is less than 12.0.6682.5000" id="oval:org.mitre.oval:tst:86620" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23346" />
   <state state_ref="oval:org.mitre.oval:ste:23499" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86629.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86629.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.8.17 in VisualSVN Server" id="oval:org.mitre.oval:tst:86629" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.8.17 in VisualSVN Server" id="oval:org.mitre.oval:tst:86629" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24193" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86638.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86638.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.16 in VisualSVN Server" id="oval:org.mitre.oval:tst:86638" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.16 in VisualSVN Server" id="oval:org.mitre.oval:tst:86638" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24072" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86639.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86639.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.7.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86639" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.7.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86639" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24028" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86648.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86648.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL is less than or equals to 1.0.0.3 in VisualSVN Server" id="oval:org.mitre.oval:tst:86648" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL is less than or equals to 1.0.0.3 in VisualSVN Server" id="oval:org.mitre.oval:tst:86648" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24090" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86656.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86656.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.22370" id="oval:org.mitre.oval:tst:86656" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.22370" id="oval:org.mitre.oval:tst:86656" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:23633" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86657.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86657.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 12.0.6683.5000" id="oval:org.mitre.oval:tst:86657" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 12.0.6683.5000" id="oval:org.mitre.oval:tst:86657" version="2">
   <object object_ref="oval:org.mitre.oval:obj:2308" />
   <state state_ref="oval:org.mitre.oval:ste:23249" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86665.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86665.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7106.5001" id="oval:org.mitre.oval:tst:86665" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of winword.exe is less than 14.0.7106.5001" id="oval:org.mitre.oval:tst:86665" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23900" />
   <state state_ref="oval:org.mitre.oval:ste:23950" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86666.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86666.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.5.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:86666" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.5.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:86666" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24097" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86706.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86706.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.6.13 in VisualSVN Server" id="oval:org.mitre.oval:tst:86706" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.6.13 in VisualSVN Server" id="oval:org.mitre.oval:tst:86706" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24155" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86739.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86739.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.4.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86739" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.4.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86739" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:23865" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86740.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86740.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is greater than or equals to 2.0.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86740" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is greater than or equals to 2.0.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86740" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:24219" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86762.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86762.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.22371" id="oval:org.mitre.oval:tst:86762" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of microsoft.identityserver.dll is less than 6.1.7601.22371" id="oval:org.mitre.oval:tst:86762" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26783" />
   <state state_ref="oval:org.mitre.oval:ste:23483" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86768.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86768.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.17 in VisualSVN Server" id="oval:org.mitre.oval:tst:86768" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.17 in VisualSVN Server" id="oval:org.mitre.oval:tst:86768" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:23990" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86809.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86809.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.8.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86809" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.8.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86809" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24278" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86811.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86811.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is less than 2.2.25 in VisualSVN Server" id="oval:org.mitre.oval:tst:86811" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is less than 2.2.25 in VisualSVN Server" id="oval:org.mitre.oval:tst:86811" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:23699" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86817.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86817.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.11 in VisualSVN Server" id="oval:org.mitre.oval:tst:86817" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.11 in VisualSVN Server" id="oval:org.mitre.oval:tst:86817" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24229" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86833.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86833.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:86833" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:86833" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:23851" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86860.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86860.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 1.0.0.10 in VisualSVN Server" id="oval:org.mitre.oval:tst:86860" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 1.0.0.10 in VisualSVN Server" id="oval:org.mitre.oval:tst:86860" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:23970" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86899.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86899.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is less than 2.0.65 in VisualSVN Server" id="oval:org.mitre.oval:tst:86899" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is less than 2.0.65 in VisualSVN Server" id="oval:org.mitre.oval:tst:86899" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:24257" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86913.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86913.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.13 in VisualSVN Server" id="oval:org.mitre.oval:tst:86913" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.13 in VisualSVN Server" id="oval:org.mitre.oval:tst:86913" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:23884" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86919.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86919.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is less than 2.2.21 in VisualSVN Server" id="oval:org.mitre.oval:tst:86919" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is less than 2.2.21 in VisualSVN Server" id="oval:org.mitre.oval:tst:86919" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:24164" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86935.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86935.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 0.9.6.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86935" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 0.9.6.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86935" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:23996" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86939.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86939.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.23 in VisualSVN Server" id="oval:org.mitre.oval:tst:86939" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.23 in VisualSVN Server" id="oval:org.mitre.oval:tst:86939" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:23923" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86943.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86943.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.3.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86943" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.3.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86943" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24021" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86948.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86948.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 1.0.1.3 in VisualSVN Server" id="oval:org.mitre.oval:tst:86948" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 1.0.1.3 in VisualSVN Server" id="oval:org.mitre.oval:tst:86948" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24092" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86949.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86949.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 1.0.0.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86949" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 1.0.0.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:86949" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24196" />
 </file_test>

--- a/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86958.xml
+++ b/repository/tests/windows/file_test/86000/oval_org.mitre.oval_tst_86958.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Oart.dll is less than 14.0.7108.5000" id="oval:org.mitre.oval:tst:86958" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Oart.dll is less than 14.0.7108.5000" id="oval:org.mitre.oval:tst:86958" version="4">
   <object object_ref="oval:org.mitre.oval:obj:15988" />
   <state state_ref="oval:org.mitre.oval:ste:24343" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87019.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87019.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.1.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:87019" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.1.1 in VisualSVN Server" id="oval:org.mitre.oval:tst:87019" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24184" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87040.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87040.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is less than or equals to 1.3.68 in VisualSVN Server" id="oval:org.mitre.oval:tst:87040" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is less than or equals to 1.3.68 in VisualSVN Server" id="oval:org.mitre.oval:tst:87040" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:23324" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87043.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87043.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.4.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87043" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.4.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87043" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24226" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87044.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87044.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 0.9.8.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87044" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 0.9.8.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87044" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24251" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87048.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87048.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.10 in VisualSVN Server" id="oval:org.mitre.oval:tst:87048" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.10 in VisualSVN Server" id="oval:org.mitre.oval:tst:87048" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24161" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87054.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87054.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is less than 2.2.20 in VisualSVN Server" id="oval:org.mitre.oval:tst:87054" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP Server version is less than 2.2.20 in VisualSVN Server" id="oval:org.mitre.oval:tst:87054" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:23992" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87055.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87055.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.21 in VisualSVN Server" id="oval:org.mitre.oval:tst:87055" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.6.21 in VisualSVN Server" id="oval:org.mitre.oval:tst:87055" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24176" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87056.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87056.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.9 in VisualSVN Server" id="oval:org.mitre.oval:tst:87056" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.7.9 in VisualSVN Server" id="oval:org.mitre.oval:tst:87056" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:23926" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87060.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87060.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is greater than or equals to 2.2.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87060" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache HTTP version is greater than or equals to 2.2.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87060" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26768" />
   <state state_ref="oval:org.mitre.oval:ste:24165" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87065.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87065.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.5.8 in VisualSVN Server" id="oval:org.mitre.oval:tst:87065" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.5.8 in VisualSVN Server" id="oval:org.mitre.oval:tst:87065" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24100" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87067.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87067.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Oartconv.dll is less than 14.0.7108.5000" id="oval:org.mitre.oval:tst:87067" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Oartconv.dll is less than 14.0.7108.5000" id="oval:org.mitre.oval:tst:87067" version="4">
   <object object_ref="oval:org.mitre.oval:obj:15858" />
   <state state_ref="oval:org.mitre.oval:ste:24343" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87070.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87070.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.2.2 in VisualSVN Server" id="oval:org.mitre.oval:tst:87070" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version equals to 0.9.2.2 in VisualSVN Server" id="oval:org.mitre.oval:tst:87070" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:23888" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87073.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87073.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL is less than 1.0.0.3 in VisualSVN Server" id="oval:org.mitre.oval:tst:87073" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL is less than 1.0.0.3 in VisualSVN Server" id="oval:org.mitre.oval:tst:87073" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24294" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87081.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87081.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.8.24 in VisualSVN Server" id="oval:org.mitre.oval:tst:87081" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is less than or equals to 0.9.8.24 in VisualSVN Server" id="oval:org.mitre.oval:tst:87081" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24297" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87082.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87082.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.5.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87082" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.5.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87082" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24060" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87088.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87088.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.6.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87088" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is greater than or equals to 1.6.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87088" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24113" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87089.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87089.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.2 in VisualSVN Server" id="oval:org.mitre.oval:tst:87089" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Apache Subversion version is less than 1.8.2 in VisualSVN Server" id="oval:org.mitre.oval:tst:87089" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26605" />
   <state state_ref="oval:org.mitre.oval:ste:24029" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87118.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87118.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 0.9.8.8 in VisualSVN Server" id="oval:org.mitre.oval:tst:87118" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 0.9.8.8 in VisualSVN Server" id="oval:org.mitre.oval:tst:87118" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:23893" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87122.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87122.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7109.5000" id="oval:org.mitre.oval:tst:87122" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of excel.exe is less than 14.0.7109.5000" id="oval:org.mitre.oval:tst:87122" version="3">
   <object object_ref="oval:org.mitre.oval:obj:23971" />
   <state state_ref="oval:org.mitre.oval:ste:24068" />
 </file_test>

--- a/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87129.xml
+++ b/repository/tests/windows/file_test/87000/oval_org.mitre.oval_tst_87129.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 1.0.1.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87129" version="3">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if OpenSSL version is greater than or equals to 1.0.1.0 in VisualSVN Server" id="oval:org.mitre.oval:tst:87129" version="3">
   <object object_ref="oval:org.mitre.oval:obj:26794" />
   <state state_ref="oval:org.mitre.oval:ste:24041" />
 </file_test>

--- a/repository/tests/windows/file_test/89000/oval_org.mitre.oval_tst_89069.xml
+++ b/repository/tests/windows/file_test/89000/oval_org.mitre.oval_tst_89069.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 14.0.7110.5004" id="oval:org.mitre.oval:tst:89069" version="4">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 14.0.7110.5004" id="oval:org.mitre.oval:tst:89069" version="4">
   <object object_ref="oval:org.mitre.oval:obj:24602" />
   <state state_ref="oval:org.mitre.oval:ste:24769" />
 </file_test>

--- a/repository/tests/windows/file_test/89000/oval_org.mitre.oval_tst_89595.xml
+++ b/repository/tests/windows/file_test/89000/oval_org.mitre.oval_tst_89595.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 12.0.6688.5000" id="oval:org.mitre.oval:tst:89595" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ogl.dll is less than 12.0.6688.5000" id="oval:org.mitre.oval:tst:89595" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6428" />
   <state state_ref="oval:org.mitre.oval:ste:25332" />
 </file_test>

--- a/repository/tests/windows/file_test/89000/oval_org.mitre.oval_tst_89762.xml
+++ b/repository/tests/windows/file_test/89000/oval_org.mitre.oval_tst_89762.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Communicator.exe (Lync 2010) is less than 4.0.7577.4415" id="oval:org.mitre.oval:tst:89762" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Communicator.exe (Lync 2010) is less than 4.0.7577.4415" id="oval:org.mitre.oval:tst:89762" version="2">
   <object object_ref="oval:org.mitre.oval:obj:23751" />
   <state state_ref="oval:org.mitre.oval:ste:25668" />
 </file_test>

--- a/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9231.xml
+++ b/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9231.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Ogl.dll version is less than 12.0.6325.5000" id="oval:org.mitre.oval:tst:9231" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Ogl.dll version is less than 12.0.6325.5000" id="oval:org.mitre.oval:tst:9231" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6428" />
   <state state_ref="oval:org.mitre.oval:ste:3438" />
 </file_test>

--- a/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9924.xml
+++ b/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9924.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6501.5000" id="oval:org.mitre.oval:tst:9924" version="5">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6501.5000" id="oval:org.mitre.oval:tst:9924" version="5">
   <object object_ref="oval:org.mitre.oval:obj:94" />
   <state state_ref="oval:org.mitre.oval:ste:4898" />
 </file_test>

--- a/repository/tests/windows/file_test/90000/oval_org.mitre.oval_tst_90017.xml
+++ b/repository/tests/windows/file_test/90000/oval_org.mitre.oval_tst_90017.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Autohelper.dll is less than 15.0.4547.1000" id="oval:org.mitre.oval:tst:90017" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Autohelper.dll is less than 15.0.4547.1000" id="oval:org.mitre.oval:tst:90017" version="2">
   <object object_ref="oval:org.mitre.oval:obj:29070" />
   <state state_ref="oval:org.mitre.oval:ste:25125" />
 </file_test>


### PR DESCRIPTION
The value of parameter check="all" was changed into "at least one" in tests which use objects with the variable that collects several values because of the set of objects. It was made to avoid false negative results.

Changed pull request #590