### PR TITLE
Updated oval_org.cisecurity_def_1491.xml

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1491.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1491.xml
@@ -12,7 +12,7 @@
       <platform>Microsoft Windows 10</platform>
       <product>Microsoft SQL Server 2016</product>
     </affected>
-    <reference ref_id="CVE-2016-7214" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7214" source="CVE" />
+    <reference ref_id="CVE-2016-7249" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7249" source="CVE" />
     <description>Microsoft SQL Server 2016 does not properly perform a cast of an unspecified pointer, which allows remote authenticated users to gain privileges via unknown vectors, aka "SQL RDBMS Engine Elevation of Privilege Vulnerability."</description>
     <oval_repository>
       <dates>


### PR DESCRIPTION
Corrected ref_id from CVE-2016-7214 to CVE-2016-7249