### PR TITLE
Updated_oval_org.cisecurity_def_1775-1776

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1775.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1775.xml
@@ -40,7 +40,7 @@
       <criterion comment="Check if Java SE Development Kit 1.6 version is less than 6.0.1320" test_ref="oval:org.cisecurity:tst:2503" />
     </criteria>
     <criteria comment="Java SE Runtime Environment 1.6 is installed + version" operator="AND">
-      <extend_definition comment="Java SE Runtime Environment 6 is installed" definition_ref="oval:org.mitre.oval:def:16050" />
+      <extend_definition comment="Java SE Runtime Environment 6 is installed" definition_ref="oval:org.mitre.oval:def:16362" />
       <criterion comment="Check if Java SE Runtime Environment 1.6 version is less than 6.0.1320" test_ref="oval:org.cisecurity:tst:2507" />
     </criteria>
     <criteria comment="Java SE Development Kit 1.7 is installed + version" operator="AND">

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1775.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1775.xml
@@ -22,7 +22,7 @@
     </affected>
     <reference ref_id="CVE-2017-3272" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3272" source="CVE" />
     <reference ref_id="CPUJAN2017" ref_url="http://www.oracle.com/technetwork/security-advisory/cpujan2017-2881727.html" source="CPUJAN2017" />
-    <description>Unspecified vulnerability in Oracle Java SE 7u121, and 8u112; Java SE Embedded 8u111</description>
+    <description>Vulnerability in the Java SE, Java SE Embedded component of Oracle Java SE (subcomponent: Libraries). Supported versions that are affected are Java SE: 6u131, 7u121 and 8u112; Java SE Embedded: 8u111. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Java SE Embedded. Successful attacks require human interaction from a person other than the attacker and while the vulnerability is in Java SE, Java SE Embedded, attacks may significantly impact additional products. Successful attacks of this vulnerability can result in takeover of Java SE, Java SE Embedded. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS v3.0 Base Score 9.6 (Confidentiality, Integrity and Availability impacts).</description>
     <oval_repository>
       <dates>
         <submitted date="2017-01-27T23:59:00+08:00">

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1776.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1776.xml
@@ -20,7 +20,7 @@
     </affected>
     <reference ref_id="CVE-2017-3289" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3289" source="CVE" />
     <reference ref_id="CPUJAN2017" ref_url="http://www.oracle.com/technetwork/security-advisory/cpujan2017-2881727.html" source="CPUJAN2017" />
-    <description>Unspecified vulnerability in Oracle Java SE 7u121, and 8u112; Java SE Embedded 8u111</description>
+    <description>Vulnerability in the Java SE, Java SE Embedded component of Oracle Java SE (subcomponent: Hotspot). Supported versions that are affected are Java SE: 7u121 and 8u112; Java SE Embedded: 8u111. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Java SE Embedded. Successful attacks require human interaction from a person other than the attacker and while the vulnerability is in Java SE, Java SE Embedded, attacks may significantly impact additional products. Successful attacks of this vulnerability can result in takeover of Java SE, Java SE Embedded. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets, that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code (e.g., code installed by an administrator). CVSS v3.0 Base Score 9.6 (Confidentiality, Integrity and Availability impacts).</description>
     <oval_repository>
       <dates>
         <submitted date="2017-01-27T23:59:00+08:00">


### PR DESCRIPTION
**Updated descriptions of oval:org.cisecurity:def:1775 and oval:org.cisecurity:def:1776
**Corrected extend def for Java SE Runtime 6