### PR TITLE
Updated oval_org.cisecurity_def_1996.xml object

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1996.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1996.xml
@@ -84,7 +84,7 @@
         <extend_definition comment="Microsoft Windows 10 Version 1607 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:1379" />
         <extend_definition comment="Microsoft Windows Server 2016 is installed" definition_ref="oval:org.cisecurity:def:1269" />
       </criteria>
-      <criterion comment="Check if Gdi32.dll version is less than 10.0.14393.206" test_ref="oval:org.cisecurity:tst:2699" />
+      <criterion comment="Check if Gdi32full.dll version is less than 10.0.14393.953" test_ref="oval:org.cisecurity:tst:2699" />
     </criteria>
   </criteria>
 </definition>


### PR DESCRIPTION
Updated oval_org.cisecurity_def_1996.xml object from Gdi32 to Gdi32full in windows 10 1607/server 2016.