### PR TITLE
Kemanik duplicates

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_453.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_453.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:453" version="49">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:453" deprecated="true" version="49">
   <metadata>
     <title>Memory Corruption Vulnerability – CVE-2015-2502 (MS15-093)</title>
     <affected family="windows">

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_469.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_469.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:469" version="50">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:469" deprecated="true" version="50">
   <metadata>
     <title>Microsoft Browser Memory Corruption Vulnerability - CVE-2016-0154 (MS16-037)</title>
     <affected family="windows">


### PR DESCRIPTION
Paires of definitions
oval:org.cisecurity:def:514 and oval:org.cisecurity:def:469
oval:org.cisecurity:def:451 and oval:org.cisecurity:def:453
are duplicates.