### PR TITLE
Create oval_org.cisecurity_def_1861.xml

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1861.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1861.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:1861" version="14">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:1861" deprecated="true" version="14">
   <metadata>
     <title>Uninitialised memory access in webm video - CVE-2017-5017</title>
     <affected family="windows">


### PR DESCRIPTION
Definition oval:org.cisecurity:def:1861 should be deprecated because it applies for Mac only.