### PR TITLE
PETYA and MISCHA ransomware

### DIFF
--- a/repository/definitions/inventory/oval_ru.altx-soft.win_def_41754.xml
+++ b/repository/definitions/inventory/oval_ru.altx-soft.win_def_41754.xml
@@ -1,0 +1,32 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:ru.altx-soft.win:def:41754" version="3">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office 2016 is installed</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="cpe:/a:microsoft:office:2016" source="CPE" />
+    <oval-def:description>The application Microsoft Office 2016 is installed.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2015-10-13T15:03:37">
+          <oval-def:contributor organization="ALTX-SOFT">Leonid Golubtsov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criterion comment="Microsoft Office 2016 is installed" test_ref="oval:ru.altx-soft.win:tst:39468" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_32659.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_32659.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:32659" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Microsoft Office 2013 64-Bit Edition (KB3178710)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="mso2013-kb3178710-fullfile-x64-glb.exe" source="VENDOR" />
+    <oval-def:reference ref_id="ADV170005" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/ADV170005" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB3178710" ref_url="https://www.microsoft.com/en-us/download/details.aspx?id=55044" source="Microsoft" />
+    <oval-def:description>A security vulnerability exists in Microsoft Office 2013 64-Bit Edition that could allow arbitrary code to run when a maliciously modified file is opened. This update resolves that vulnerability.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Office 2013 is installed" definition_ref="oval:org.mitre.oval:def:15381" />
+    <oval-def:criterion comment="Check if the version of mso.dll is less than 15.0.4919.1000" test_ref="oval:ru.altx-soft.win:tst:48571" />
+    <oval-def:criterion comment="an architecture of Office 2013 is x64" test_ref="oval:ru.altx-soft.win:tst:46090" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_32660.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_32660.xml
@@ -1,0 +1,35 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:32660" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Microsoft Office 2013 32-Bit Edition (KB3178710)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="mso2013-kb3178710-fullfile-x86-glb.exe" source="VENDOR" />
+    <oval-def:reference ref_id="ADV170005" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/ADV170005" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB3178710" ref_url="https://www.microsoft.com/en-us/download/details.aspx?id=55059" source="Microsoft" />
+    <oval-def:description>A security vulnerability exists in Microsoft Office 2013 32-Bit Edition that could allow arbitrary code to run when a maliciously modified file is opened. This update resolves that vulnerability.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Office 2013 is installed" definition_ref="oval:org.mitre.oval:def:15381" />
+    <oval-def:criterion comment="Check if the version of mso.dll is less than 15.0.4919.1000" test_ref="oval:ru.altx-soft.win:tst:48571" />
+    <oval-def:criterion comment="an architecture of Office 2013 is x86" test_ref="oval:ru.altx-soft.win:tst:46089" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_32662.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_32662.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:32662" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Microsoft Office 2010 32-Bit Edition (KB3141538)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="mso2010-kb3141538-fullfile-x86-glb.exe" source="VENDOR" />
+    <oval-def:reference ref_id="ADV170005" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/ADV170005" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB3141538" ref_url="https://www.microsoft.com/en-us/download/details.aspx?id=55074" source="Microsoft" />
+    <oval-def:description>A security vulnerability exists in Microsoft Office 2010 32-Bit Edition that could allow arbitrary code to run when a maliciously modified file is opened. This update resolves that vulnerability.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Office 2010 is installed" definition_ref="oval:org.mitre.oval:def:12061" />
+    <oval-def:criterion comment="Check if the version of mso.dll is less than 14.0.7180.5000" test_ref="oval:ru.altx-soft.win:tst:48573" />
+    <oval-def:criterion comment="an architecture of Office 2010 is x86" test_ref="oval:ru.altx-soft.win:tst:46087" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_32663.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_32663.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:32663" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Microsoft Office 2010 64-Bit Edition (KB3141538)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="mso2010-kb3141538-fullfile-x64-glb.exe" source="VENDOR" />
+    <oval-def:reference ref_id="ADV170005" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/ADV170005" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB3141538" ref_url="https://www.microsoft.com/en-us/download/details.aspx?id=55075" source="Microsoft" />
+    <oval-def:description>A security vulnerability exists in Microsoft Office 2010 64-Bit Edition that could allow arbitrary code to run when a maliciously modified file is opened. This update resolves that vulnerability.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Office 2010 is installed" definition_ref="oval:org.mitre.oval:def:12061" />
+    <oval-def:criterion comment="Check if the version of mso.dll is less than 14.0.7180.5000" test_ref="oval:ru.altx-soft.win:tst:48573" />
+    <oval-def:criterion comment="an architecture of Office 2010 is x64" test_ref="oval:ru.altx-soft.win:tst:46088" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_33776.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_33776.xml
@@ -1,0 +1,38 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:33776" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Microsoft Office 2007 (KB3141529)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="mso2007-kb3141529-fullfile-x86-glb.exe" source="VENDOR" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB3141529" ref_url="https://www.microsoft.com/en-us/download/details.aspx?id=55071" source="Microsoft" />
+    <oval-def:description>A security vulnerability exists in Microsoft Office 2007 that could allow arbitrary code to run when a maliciously modified file is opened. This update resolves that vulnerability.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:modified comment="Added link to http://www.bdu.fstec.ru" date="2017-04-28T14:57:53">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:modified>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Office 2007 is installed" definition_ref="oval:org.mitre.oval:def:1211" />
+    <oval-def:criterion comment="Check if the version of mso.dll is less than 12.0.6766.5000" test_ref="oval:ru.altx-soft.win:tst:48572" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_33787.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_33787.xml
@@ -1,0 +1,31 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:33787" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Windows Vista, Windows Server 2008 (KB4014793)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="mpsyschk_598e97e96db741883dc8ad0b907ff0deee790c77.exe" ref_url="http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/03/mpsyschk_598e97e96db741883dc8ad0b907ff0deee790c77.exe" source="VENDOR" />
+    <oval-def:reference ref_id="windows6.0-kb4014793-x86_15e46c8e19c2e64de1227e60833f2ba869accc65.msu" ref_url="http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/03/windows6.0-kb4014793-x86_15e46c8e19c2e64de1227e60833f2ba869accc65.msu" source="VENDOR" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB4014793" ref_url="https://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4014793" source="Microsoft" />
+    <oval-def:description>A security issue has been identified in a Microsoft software product that could affect your system. You can help protect your system by installing this update from Microsoft.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criteria comment="either OS" operator="OR">
+      <oval-def:extend_definition comment="Microsoft Windows Vista (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:1282" />
+      <oval-def:extend_definition comment="Microsoft Windows Server 2008 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:4870" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="GDR / LDR" operator="OR">
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.0.6002.19755" test_ref="oval:ru.altx-soft.win:tst:48567" />
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is greater than or equal 6.0.6002.24000 and less than 6.0.6002.24078" test_ref="oval:ru.altx-soft.win:tst:48568" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_33788.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_33788.xml
@@ -1,0 +1,31 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:33788" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Windows Server 2008, Windows Vista for x64-based Systems (KB4014793)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="mpsyschk_b39674adcc0e38aad3045e5628cc2636568c1134.exe" ref_url="http://download.windowsupdate.com/c/msdownload/update/software/secu/2017/03/mpsyschk_b39674adcc0e38aad3045e5628cc2636568c1134.exe" source="VENDOR" />
+    <oval-def:reference ref_id="windows6.0-kb4014793-x64_0a2d18efbebcbde044306044aa613d5c1dc63bea.msu" ref_url="http://download.windowsupdate.com/c/msdownload/update/software/secu/2017/03/windows6.0-kb4014793-x64_0a2d18efbebcbde044306044aa613d5c1dc63bea.msu" source="VENDOR" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB4014793" ref_url="https://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4014793" source="Microsoft" />
+    <oval-def:description>A security issue has been identified in a Microsoft software product that could affect your system. You can help protect your system by installing this update from Microsoft.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criteria comment="either OS" operator="OR">
+      <oval-def:extend_definition comment="Microsoft Windows Server 2008 (64-bit) is installed" definition_ref="oval:org.mitre.oval:def:5356" />
+      <oval-def:extend_definition comment="Microsoft Windows Vista x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:2041" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="GDR / LDR" operator="OR">
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.0.6002.19755" test_ref="oval:ru.altx-soft.win:tst:48567" />
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is greater than or equal 6.0.6002.24000 and less than 6.0.6002.24078" test_ref="oval:ru.altx-soft.win:tst:48568" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_33789.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_33789.xml
@@ -1,0 +1,36 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:33789" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Microsoft Office 2016 32-Bit Edition (KB3178703)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="msodll302016-kb3178703-fullfile-x86-glb.exe" source="VENDOR" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB3178703" ref_url="https://www.microsoft.com/en-us/download/details.aspx?id=55077" source="Microsoft" />
+    <oval-def:description>A security vulnerability exists in Microsoft Office 2016 32-Bit Edition that could allow arbitrary code to run when a maliciously modified file is opened. This update resolves that vulnerability.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:ru.altx-soft.win:def:41754" />
+    <oval-def:criterion comment="Check if the version of mso30win32client.dll is less than 16.0.4522.1000" test_ref="oval:ru.altx-soft.win:tst:48566" />
+    <oval-def:criterion comment="an architecture of Office 2016 is x86" test_ref="oval:ru.altx-soft.win:tst:39471" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_33790.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_33790.xml
@@ -1,0 +1,36 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:33790" version="0">
+  <oval-def:metadata>
+    <oval-def:title>Security Update for Microsoft Office 2016 64-Bit Edition (KB3178703)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="msodll302016-kb3178703-fullfile-x64-glb.exe" source="VENDOR" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="KB3178703" ref_url="https://www.microsoft.com/en-us/download/details.aspx?id=55063" source="Microsoft" />
+    <oval-def:description>A security vulnerability exists in Microsoft Office 2016 64-Bit Edition that could allow arbitrary code to run when a maliciously modified file is opened. This update resolves that vulnerability.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T15:17:43">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:ru.altx-soft.win:def:41754" />
+    <oval-def:criterion comment="Check if the version of mso30win32client.dll is less than 16.0.4522.1000" test_ref="oval:ru.altx-soft.win:tst:48566" />
+    <oval-def:criterion comment="an architecture of Office 2016 is x64" test_ref="oval:ru.altx-soft.win:tst:39470" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_47356.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_47356.xml
@@ -1,0 +1,61 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:47356" version="0">
+  <oval-def:metadata>
+    <oval-def:title>April, 2017 Security Monthly Quality Rollup for Windows Server 2012 (KB4015551)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="KB4015551" ref_url="http://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4015551" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2013-6629" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2013-6629" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0058" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0058" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0158" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0158" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0160" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0160" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0163" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0163" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0166" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0166" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0168" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0168" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0169" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0169" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0180" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0180" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0182" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0182" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0183" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0183" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0184" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0184" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0185" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0185" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0186" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0186" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0188" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0188" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0191" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0191" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0192" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0192" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0201" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0201" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0210" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0210" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0211" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0211" source="Microsoft" />
+    <oval-def:reference ref_id="windows8-rt-kb4015551-x64_8e3457ab5a3108ede25df0240463ba16de7f87f8.msu" ref_url="http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/04/windows8-rt-kb4015551-x64_8e3457ab5a3108ede25df0240463ba16de7f87f8.msu" source="VENDOR" />
+    <oval-def:description>April, 2017 Security Monthly Quality Rollup for Windows Server 2012 (KB4015551)</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T19:03:22">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Windows Server 2012 is installed" definition_ref="oval:org.mitre.oval:def:16359" />
+    <oval-def:criteria comment="File versions" operator="OR">
+      <oval-def:criterion comment="Check if the version of Quartz.dll is less than 6.6.9200.22108" test_ref="oval:ru.altx-soft.win:tst:48478" />
+      <oval-def:criterion comment="Check if the version of Win32k.sys is less than 6.2.9200.22109" test_ref="oval:ru.altx-soft.win:tst:48494" />
+      <oval-def:criterion comment="Check if the version of Vbscript.dll is less than 5.8.9200.22108" test_ref="oval:ru.altx-soft.win:tst:48513" />
+      <oval-def:criterion comment="Check if the version of vmsif.dll is less than 6.2.9200.16384" test_ref="oval:ru.altx-soft.win:tst:48535" />
+      <oval-def:criterion comment="Check if the version of ntdsai.dll is less than 6.2.9200.22109" test_ref="oval:ru.altx-soft.win:tst:48546" />
+      <oval-def:criterion comment="Check if the version of Ntoskrnl.exe is less than 6.2.9200.22108" test_ref="oval:ru.altx-soft.win:tst:48553" />
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.2.9200.22106" test_ref="oval:ru.altx-soft.win:tst:48570" />
+      <oval-def:criteria comment="IE10" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Internet Explorer 10 is installed" definition_ref="oval:org.mitre.oval:def:15751" />
+        <oval-def:extend_definition comment="JScript 5.8 is installed" definition_ref="oval:org.mitre.oval:def:28817" />
+        <oval-def:criterion comment="Check if the version of Jscript.dll is less than 5.8.9200.22108" test_ref="oval:ru.altx-soft.win:tst:48575" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="IE10" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Internet Explorer 10 is installed" definition_ref="oval:org.mitre.oval:def:15751" />
+        <oval-def:criterion comment="Check if the version of Mshtml.dll is less than 10.0.9200.22121" test_ref="oval:ru.altx-soft.win:tst:48593" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if the version of Ole32.dll is less than 6.2.9200.22104" test_ref="oval:ru.altx-soft.win:tst:48597" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_47361.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_47361.xml
@@ -1,0 +1,56 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:47361" version="0">
+  <oval-def:metadata>
+    <oval-def:title>April, 2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="KB4015549" ref_url="http://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4015549" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2013-6629" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2013-6629" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0058" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0058" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0155" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0155" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0156" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0156" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0158" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0158" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0160" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0160" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0163" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0163" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0166" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0166" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0168" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0168" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0180" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0180" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0182" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0182" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0183" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0183" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0184" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0184" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0191" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0191" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0192" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0192" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0202" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0202" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0210" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0210" source="Microsoft" />
+    <oval-def:reference ref_id="windows6.1-kb4015549-x64_59cf25073f2e8615b01d9719a0a2e2a0a9a92937.msu" ref_url="http://download.windowsupdate.com/c/msdownload/update/software/secu/2017/04/windows6.1-kb4015549-x64_59cf25073f2e8615b01d9719a0a2e2a0a9a92937.msu" source="VENDOR" />
+    <oval-def:description>April, 2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T19:00:52">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criteria comment="OS section" operator="OR">
+      <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
+      <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:6438" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File versions" operator="OR">
+      <oval-def:criterion comment="Check if the version of Quartz.dll is less than 6.6.7601.23709" test_ref="oval:ru.altx-soft.win:tst:48475" />
+      <oval-def:criterion comment="Check if the version of Win32k.sys is less than 6.1.7601.23717" test_ref="oval:ru.altx-soft.win:tst:48491" />
+      <oval-def:criterion comment="Check if the version of Gdi32.dll is less than 6.1.7601.23739" test_ref="oval:ru.altx-soft.win:tst:48505" />
+      <oval-def:criterion comment="Check if the version of Storvsp.sys is less than 6.1.7601.23649" test_ref="oval:ru.altx-soft.win:tst:48538" />
+      <oval-def:criterion comment="Check if the version of ntdsai.dll is less than 6.1.7601.23717" test_ref="oval:ru.altx-soft.win:tst:48544" />
+      <oval-def:criterion comment="Check if the version of Ntoskrnl.exe is less than 6.1.7601.23714" test_ref="oval:ru.altx-soft.win:tst:48552" />
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.1.7601.23714" test_ref="oval:ru.altx-soft.win:tst:48569" />
+      <oval-def:criteria comment="IE11" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Internet Explorer 11 is installed" definition_ref="oval:org.mitre.oval:def:18343" />
+        <oval-def:criterion comment="Check if the version of Mshtml.dll is less than 11.0.9600.18639" test_ref="oval:ru.altx-soft.win:tst:48580" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_47362.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_47362.xml
@@ -1,0 +1,52 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:47362" version="0">
+  <oval-def:metadata>
+    <oval-def:title>April, 2017 Security Monthly Quality Rollup for Windows 7 (KB4015549)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="KB4015549" ref_url="http://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4015549" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2013-6629" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2013-6629" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0058" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0058" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0155" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0155" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0156" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0156" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0158" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0158" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0160" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0160" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0163" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0163" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0166" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0166" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0168" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0168" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0180" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0180" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0182" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0182" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0183" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0183" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0184" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0184" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0191" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0191" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0192" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0192" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0202" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0202" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0210" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0210" source="Microsoft" />
+    <oval-def:reference ref_id="windows6.1-kb4015549-x86_6d9f286d4e855de6cf9ed2e60ab76247c0c6b422.msu" ref_url="http://download.windowsupdate.com/c/msdownload/update/software/secu/2017/04/windows6.1-kb4015549-x86_6d9f286d4e855de6cf9ed2e60ab76247c0c6b422.msu" source="VENDOR" />
+    <oval-def:description>April, 2017 Security Monthly Quality Rollup for Windows 7 (KB4015549)</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T19:00:58">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+    <oval-def:criteria comment="File versions" operator="OR">
+      <oval-def:criterion comment="Check if the version of Quartz.dll is less than 6.6.7601.23709" test_ref="oval:ru.altx-soft.win:tst:48475" />
+      <oval-def:criterion comment="Check if the version of Win32k.sys is less than 6.1.7601.23717" test_ref="oval:ru.altx-soft.win:tst:48491" />
+      <oval-def:criterion comment="Check if the version of Gdi32.dll is less than 6.1.7601.23739" test_ref="oval:ru.altx-soft.win:tst:48505" />
+      <oval-def:criterion comment="Check if the version of Storvsp.sys is less than 6.1.7601.23649" test_ref="oval:ru.altx-soft.win:tst:48538" />
+      <oval-def:criterion comment="Check if the version of ntdsai.dll is less than 6.1.7601.23717" test_ref="oval:ru.altx-soft.win:tst:48544" />
+      <oval-def:criterion comment="Check if the version of Ntoskrnl.exe is less than 6.1.7601.23714" test_ref="oval:ru.altx-soft.win:tst:48552" />
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.1.7601.23714" test_ref="oval:ru.altx-soft.win:tst:48569" />
+      <oval-def:criteria comment="IE11" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Internet Explorer 11 is installed" definition_ref="oval:org.mitre.oval:def:18343" />
+        <oval-def:criterion comment="Check if the version of Mshtml.dll is less than 11.0.9600.18639" test_ref="oval:ru.altx-soft.win:tst:48580" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_47756.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_47756.xml
@@ -1,0 +1,46 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:47756" version="0">
+  <oval-def:metadata>
+    <oval-def:title>April, 2017 Security Only Quality Update for Windows 7 (KB4015546)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="KB4015546" ref_url="http://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4015546" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2013-6629" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2013-6629" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0058" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0058" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0155" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0155" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0156" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0156" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0158" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0158" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0160" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0160" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0163" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0163" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0166" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0166" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0168" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0168" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0180" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0180" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0182" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0182" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0183" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0183" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0184" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0184" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0191" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0191" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0192" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0192" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="windows6.1-kb4015546-x86_a753365290d940872860776113f226436a18ca9b.msu" ref_url="http://download.windowsupdate.com/c/msdownload/update/software/secu/2017/03/windows6.1-kb4015546-x86_a753365290d940872860776113f226436a18ca9b.msu" source="VENDOR" />
+    <oval-def:description>April, 2017 Security Only Quality Update for Windows 7 (KB4015546)</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T19:00:58">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+    <oval-def:criteria comment="File versions" operator="OR">
+      <oval-def:criterion comment="Check if the version of Quartz.dll is less than 6.6.7601.23709" test_ref="oval:ru.altx-soft.win:tst:48475" />
+      <oval-def:criterion comment="Check if the version of Win32k.sys is less than 6.1.7601.23717" test_ref="oval:ru.altx-soft.win:tst:48491" />
+      <oval-def:criterion comment="Check if the version of Gdi32.dll is less than 6.1.7601.23739" test_ref="oval:ru.altx-soft.win:tst:48505" />
+      <oval-def:criterion comment="Check if the version of Storvsp.sys is less than 6.1.7601.23649" test_ref="oval:ru.altx-soft.win:tst:48538" />
+      <oval-def:criterion comment="Check if the version of ntdsai.dll is less than 6.1.7601.23717" test_ref="oval:ru.altx-soft.win:tst:48544" />
+      <oval-def:criterion comment="Check if the version of Ntoskrnl.exe is less than 6.1.7601.23714" test_ref="oval:ru.altx-soft.win:tst:48552" />
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.1.7601.23714" test_ref="oval:ru.altx-soft.win:tst:48569" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_47757.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_47757.xml
@@ -1,0 +1,50 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:47757" version="0">
+  <oval-def:metadata>
+    <oval-def:title>April, 2017 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="KB4015549" ref_url="http://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4015546" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2013-6629" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2013-6629" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0058" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0058" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0155" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0155" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0156" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0156" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0158" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0158" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0160" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0160" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0163" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0163" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0166" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0166" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0168" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0168" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0180" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0180" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0182" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0182" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0183" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0183" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0184" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0184" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0191" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0191" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0192" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0192" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="windows6.1-kb4015546-x64_4ff5653990d74c465d48adfba21aca6453be99aa.msu" ref_url="http://download.windowsupdate.com/c/msdownload/update/software/secu/2017/03/windows6.1-kb4015546-x64_4ff5653990d74c465d48adfba21aca6453be99aa.msu" source="VENDOR" />
+    <oval-def:description>April, 2017 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T19:00:52">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criteria comment="OS section" operator="OR">
+      <oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
+      <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:6438" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="File versions" operator="OR">
+      <oval-def:criterion comment="Check if the version of Quartz.dll is less than 6.6.7601.23709" test_ref="oval:ru.altx-soft.win:tst:48475" />
+      <oval-def:criterion comment="Check if the version of Win32k.sys is less than 6.1.7601.23717" test_ref="oval:ru.altx-soft.win:tst:48491" />
+      <oval-def:criterion comment="Check if the version of Gdi32.dll is less than 6.1.7601.23739" test_ref="oval:ru.altx-soft.win:tst:48505" />
+      <oval-def:criterion comment="Check if the version of Storvsp.sys is less than 6.1.7601.23649" test_ref="oval:ru.altx-soft.win:tst:48538" />
+      <oval-def:criterion comment="Check if the version of ntdsai.dll is less than 6.1.7601.23717" test_ref="oval:ru.altx-soft.win:tst:48544" />
+      <oval-def:criterion comment="Check if the version of Ntoskrnl.exe is less than 6.1.7601.23714" test_ref="oval:ru.altx-soft.win:tst:48552" />
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.1.7601.23714" test_ref="oval:ru.altx-soft.win:tst:48569" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_com.altx-soft.win_def_47761.xml
+++ b/repository/definitions/patch/oval_com.altx-soft.win_def_47761.xml
@@ -1,0 +1,61 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.altx-soft.win:def:47761" version="0">
+  <oval-def:metadata>
+    <oval-def:title>April, 2017 Security Only Quality Update for Windows Server 2012 (KB4015548)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="KB4015548" ref_url="http://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4015548" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2013-6629" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2013-6629" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0058" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0058" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0158" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0158" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0160" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0160" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0163" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0163" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0166" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0166" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0168" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0168" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0169" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0169" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0180" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0180" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0182" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0182" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0183" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0183" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0184" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0184" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0185" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0185" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0186" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0186" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0188" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0188" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0191" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0191" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0192" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0192" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0199" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0201" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0201" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0210" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0210" source="Microsoft" />
+    <oval-def:reference ref_id="CVE-2017-0211" ref_url="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-0211" source="Microsoft" />
+    <oval-def:reference ref_id="windows8-rt-kb4015548-x64_a8940ee070bcd9ed11b4a23ef3d9f53d94ccf1f4.msu" ref_url="http://download.windowsupdate.com/c/msdownload/update/software/secu/2017/04/windows8-rt-kb4015548-x64_a8940ee070bcd9ed11b4a23ef3d9f53d94ccf1f4.msu" source="VENDOR" />
+    <oval-def:description>April, 2017 Security Only Quality Update for Windows Server 2012 (KB4015548)</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-06-28T19:03:22">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Microsoft Windows Server 2012 is installed" definition_ref="oval:org.mitre.oval:def:16359" />
+    <oval-def:criteria comment="File versions" operator="OR">
+      <oval-def:criterion comment="Check if the version of Quartz.dll is less than 6.6.9200.22108" test_ref="oval:ru.altx-soft.win:tst:48478" />
+      <oval-def:criterion comment="Check if the version of Win32k.sys is less than 6.2.9200.22109" test_ref="oval:ru.altx-soft.win:tst:48494" />
+      <oval-def:criterion comment="Check if the version of Vbscript.dll is less than 5.8.9200.22108" test_ref="oval:ru.altx-soft.win:tst:48513" />
+      <oval-def:criterion comment="Check if the version of vmsif.dll is less than 6.2.9200.16384" test_ref="oval:ru.altx-soft.win:tst:48535" />
+      <oval-def:criterion comment="Check if the version of ntdsai.dll is less than 6.2.9200.22109" test_ref="oval:ru.altx-soft.win:tst:48546" />
+      <oval-def:criterion comment="Check if the version of Ntoskrnl.exe is less than 6.2.9200.22108" test_ref="oval:ru.altx-soft.win:tst:48553" />
+      <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.2.9200.22106" test_ref="oval:ru.altx-soft.win:tst:48570" />
+      <oval-def:criteria comment="IE10" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Internet Explorer 10 is installed" definition_ref="oval:org.mitre.oval:def:15751" />
+        <oval-def:extend_definition comment="JScript 5.8 is installed" definition_ref="oval:org.mitre.oval:def:28817" />
+        <oval-def:criterion comment="Check if the version of Jscript.dll is less than 5.8.9200.22108" test_ref="oval:ru.altx-soft.win:tst:48575" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="IE10" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Internet Explorer 10 is installed" definition_ref="oval:org.mitre.oval:def:15751" />
+        <oval-def:criterion comment="Check if the version of Mshtml.dll is less than 10.0.9200.22121" test_ref="oval:ru.altx-soft.win:tst:48593" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if the version of Ole32.dll is less than 6.2.9200.22104" test_ref="oval:ru.altx-soft.win:tst:48597" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/objects/windows/file_object/38000/oval_ru.altx-soft.win_obj_38197.xml
+++ b/repository/objects/windows/file_object/38000/oval_ru.altx-soft.win_obj_38197.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the information of vmsif.dll" id="oval:ru.altx-soft.win:obj:38197" version="2">
+  <path operation="pattern match" var_check="at least one" var_ref="oval:ru.altx-soft.win:var:66" />
+  <filename>vmsif.dll</filename>
+</file_object>

--- a/repository/objects/windows/file_object/38000/oval_ru.altx-soft.win_obj_38232.xml
+++ b/repository/objects/windows/file_object/38000/oval_ru.altx-soft.win_obj_38232.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of mso.dll (Office 2013)" id="oval:ru.altx-soft.win:obj:38232" version="0">
+  <path var_check="at least one" var_ref="oval:ru.altx-soft.win:var:38030" />
+  <filename>mso.dll</filename>
+</file_object>

--- a/repository/objects/windows/file_object/43000/oval_ru.altx-soft.win_obj_43799.xml
+++ b/repository/objects/windows/file_object/43000/oval_ru.altx-soft.win_obj_43799.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds mso30win32client.dll for MS Office 2016 - MSI installed" id="oval:ru.altx-soft.win:obj:43799" version="0">
+  <path var_check="at least one" var_ref="oval:org.cisecurity:var:55" />
+  <filename>mso30win32client.dll</filename>
+</file_object>

--- a/repository/objects/windows/registry_object/38000/oval_ru.altx-soft.win_obj_38163.xml
+++ b/repository/objects/windows/registry_object/38000/oval_ru.altx-soft.win_obj_38163.xml
@@ -1,0 +1,6 @@
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Office 2016 InstallRoot Path" id="oval:ru.altx-soft.win:obj:38163" version="1">
+  <oval-def:set>
+    <oval-def:object_reference>oval:ru.altx-soft.win:obj:38164</oval-def:object_reference>
+    <oval-def:object_reference>oval:ru.altx-soft.win:obj:38165</oval-def:object_reference>
+  </oval-def:set>
+</registry_object>

--- a/repository/objects/windows/registry_object/38000/oval_ru.altx-soft.win_obj_38164.xml
+++ b/repository/objects/windows/registry_object/38000/oval_ru.altx-soft.win_obj_38164.xml
@@ -1,0 +1,6 @@
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="32 bit Office 2016 InstallRoot!Path" id="oval:ru.altx-soft.win:obj:38164" version="1">
+  <behaviors windows_view="32_bit" />
+  <hive>HKEY_LOCAL_MACHINE</hive>
+  <key operation="pattern match">^SOFTWARE\\Microsoft\\Office\\16.0\\.+\\InstallRoot$</key>
+  <name>Path</name>
+</registry_object>

--- a/repository/objects/windows/registry_object/38000/oval_ru.altx-soft.win_obj_38165.xml
+++ b/repository/objects/windows/registry_object/38000/oval_ru.altx-soft.win_obj_38165.xml
@@ -1,0 +1,5 @@
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Native Office 2016 InstallRoot!Path" id="oval:ru.altx-soft.win:obj:38165" version="1">
+  <hive>HKEY_LOCAL_MACHINE</hive>
+  <key operation="pattern match">^SOFTWARE\\Microsoft\\Office\\16.0\\.+\\InstallRoot$</key>
+  <name>Path</name>
+</registry_object>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6625.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6625.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.6.7601.23709" id="oval:ru.altx-soft.win:ste:6625" version="0">
+  <version datatype="version" operation="less than">6.6.7601.23709</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6628.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6628.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.6.9200.22108" id="oval:ru.altx-soft.win:ste:6628" version="0">
+  <version datatype="version" operation="less than">6.6.9200.22108</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6632.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6632.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.0.6002.19755" id="oval:ru.altx-soft.win:ste:6632" version="0">
+  <version datatype="version" operation="less than">6.0.6002.19755</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6633.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6633.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is greater than or equal 6.0.6002.24000" id="oval:ru.altx-soft.win:ste:6633" version="0">
+  <version datatype="version" operation="greater than or equal">6.0.6002.24000</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6634.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6634.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.0.6002.24078" id="oval:ru.altx-soft.win:ste:6634" version="0">
+  <version datatype="version" operation="less than">6.0.6002.24078</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6642.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6642.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.1.7601.23717" id="oval:ru.altx-soft.win:ste:6642" version="0">
+  <version datatype="version" operation="less than">6.1.7601.23717</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6645.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6645.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.2.9200.22109" id="oval:ru.altx-soft.win:ste:6645" version="0">
+  <version datatype="version" operation="less than">6.2.9200.22109</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6656.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6656.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.1.7601.23739" id="oval:ru.altx-soft.win:ste:6656" version="0">
+  <version datatype="version" operation="less than">6.1.7601.23739</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6661.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6661.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 5.8.9200.22108" id="oval:ru.altx-soft.win:ste:6661" version="0">
+  <version datatype="version" operation="less than">5.8.9200.22108</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6674.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6674.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.2.9200.16384" id="oval:ru.altx-soft.win:ste:6674" version="0">
+  <version datatype="version" operation="less than">6.2.9200.16384</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6677.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6677.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.1.7601.23649" id="oval:ru.altx-soft.win:ste:6677" version="0">
+  <version datatype="version" operation="less than">6.1.7601.23649</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6682.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6682.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.1.7601.23714" id="oval:ru.altx-soft.win:ste:6682" version="0">
+  <version datatype="version" operation="less than">6.1.7601.23714</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6683.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6683.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.2.9200.22108" id="oval:ru.altx-soft.win:ste:6683" version="0">
+  <version datatype="version" operation="less than">6.2.9200.22108</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6685.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6685.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 14.0.7180.5000" id="oval:ru.altx-soft.win:ste:6685" version="0">
+  <version datatype="version" operation="less than">14.0.7180.5000</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6686.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6686.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 12.0.6766.5000" id="oval:ru.altx-soft.win:ste:6686" version="0">
+  <version datatype="version" operation="less than">12.0.6766.5000</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6687.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6687.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 15.0.4919.1000" id="oval:ru.altx-soft.win:ste:6687" version="0">
+  <version datatype="version" operation="less than">15.0.4919.1000</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6690.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6690.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 16.0.4522.1000" id="oval:ru.altx-soft.win:ste:6690" version="0">
+  <version datatype="version" operation="less than">16.0.4522.1000</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6691.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6691.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.2.9200.22106" id="oval:ru.altx-soft.win:ste:6691" version="0">
+  <version datatype="version" operation="less than">6.2.9200.22106</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6695.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6695.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 11.0.9600.18639" id="oval:ru.altx-soft.win:ste:6695" version="0">
+  <version datatype="version" operation="less than">11.0.9600.18639</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6700.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6700.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 10.0.9200.22121" id="oval:ru.altx-soft.win:ste:6700" version="0">
+  <version datatype="version" operation="less than">10.0.9200.22121</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6704.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6704.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 6.2.9200.22104" id="oval:ru.altx-soft.win:ste:6704" version="0">
+  <version datatype="version" operation="less than">6.2.9200.22104</version>
+</file_state>

--- a/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6971.xml
+++ b/repository/states/windows/file_state/6000/oval_ru.altx-soft.win_ste_6971.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is greater than 11.0.9600.16384" id="oval:ru.altx-soft.win:ste:6971" version="0">
+  <version datatype="version" operation="greater than">11.0.9600.16384</version>
+</file_state>

--- a/repository/states/windows/registry_state/4000/oval_ru.altx-soft.win_ste_4441.xml
+++ b/repository/states/windows/registry_state/4000/oval_ru.altx-soft.win_ste_4441.xml
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="registry windows_view 32_bit" id="oval:ru.altx-soft.win:ste:4441" version="1">
+  <windows_view>32_bit</windows_view>
+</registry_state>

--- a/repository/states/windows/registry_state/4000/oval_ru.altx-soft.win_ste_4442.xml
+++ b/repository/states/windows/registry_state/4000/oval_ru.altx-soft.win_ste_4442.xml
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="registry windows_view 64_bit" id="oval:ru.altx-soft.win:ste:4442" version="1">
+  <windows_view>64_bit</windows_view>
+</registry_state>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48475.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48475.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Quartz.dll is less than 6.6.7601.23709" id="oval:ru.altx-soft.win:tst:48475" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:704" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6625" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48478.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48478.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Quartz.dll is less than 6.6.9200.22108" id="oval:ru.altx-soft.win:tst:48478" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:704" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6628" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48491.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48491.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Win32k.sys is less than 6.1.7601.23717" id="oval:ru.altx-soft.win:tst:48491" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:570" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6642" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48494.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48494.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Win32k.sys is less than 6.2.9200.22109" id="oval:ru.altx-soft.win:tst:48494" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:570" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6645" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48505.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48505.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Gdi32.dll is less than 6.1.7601.23739" id="oval:ru.altx-soft.win:tst:48505" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:279" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6656" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48513.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48513.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Vbscript.dll is less than 5.8.9200.22108" id="oval:ru.altx-soft.win:tst:48513" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:7742" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6661" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48535.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48535.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of vmsif.dll is less than 6.2.9200.16384" id="oval:ru.altx-soft.win:tst:48535" version="0">
+  <object object_ref="oval:ru.altx-soft.win:obj:38197" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6674" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48538.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48538.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Storvsp.sys is less than 6.1.7601.23649" id="oval:ru.altx-soft.win:tst:48538" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:159" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6677" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48544.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48544.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ntdsai.dll is less than 6.1.7601.23717" id="oval:ru.altx-soft.win:tst:48544" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:5687" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6642" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48546.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48546.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ntdsai.dll is less than 6.2.9200.22109" id="oval:ru.altx-soft.win:tst:48546" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:5687" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6645" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48552.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48552.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ntoskrnl.exe is less than 6.1.7601.23714" id="oval:ru.altx-soft.win:tst:48552" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:335" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6682" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48553.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48553.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ntoskrnl.exe is less than 6.2.9200.22108" id="oval:ru.altx-soft.win:tst:48553" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:335" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6683" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48566.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48566.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso30win32client.dll is less than 16.0.4522.1000" id="oval:ru.altx-soft.win:tst:48566" version="0">
+  <object object_ref="oval:ru.altx-soft.win:obj:43799" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6690" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48567.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48567.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Wordpad.exe is less than 6.0.6002.19755" id="oval:ru.altx-soft.win:tst:48567" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:389" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6632" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48568.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48568.xml
@@ -1,0 +1,5 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Wordpad.exe is greater than or equal 6.0.6002.24000 and less than 6.0.6002.24078" id="oval:ru.altx-soft.win:tst:48568" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:389" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6633" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6634" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48569.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48569.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Wordpad.exe is less than 6.1.7601.23714" id="oval:ru.altx-soft.win:tst:48569" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:389" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6682" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48570.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48570.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Wordpad.exe is less than 6.2.9200.22106" id="oval:ru.altx-soft.win:tst:48570" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:389" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6691" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48571.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48571.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 15.0.4919.1000" id="oval:ru.altx-soft.win:tst:48571" version="0">
+  <object object_ref="oval:ru.altx-soft.win:obj:38232" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6687" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48572.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48572.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 12.0.6766.5000" id="oval:ru.altx-soft.win:tst:48572" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:2308" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6686" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48573.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48573.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of mso.dll is less than 14.0.7180.5000" id="oval:ru.altx-soft.win:tst:48573" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:15322" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6685" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48575.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48575.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Jscript.dll is less than 5.8.9200.22108" id="oval:ru.altx-soft.win:tst:48575" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:564" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6661" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48580.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48580.xml
@@ -1,0 +1,5 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mshtml.dll is less than 11.0.9600.18639" id="oval:ru.altx-soft.win:tst:48580" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:222" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6695" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6971" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48593.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48593.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mshtml.dll is less than 10.0.9200.22121" id="oval:ru.altx-soft.win:tst:48593" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:222" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6700" />
+</file_test>

--- a/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48597.xml
+++ b/repository/tests/windows/file_test/48000/oval_ru.altx-soft.win_tst_48597.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Ole32.dll is less than 6.2.9200.22104" id="oval:ru.altx-soft.win:tst:48597" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:44044" />
+  <state state_ref="oval:ru.altx-soft.win:ste:6704" />
+</file_test>

--- a/repository/tests/windows/registry_test/39000/oval_ru.altx-soft.win_tst_39468.xml
+++ b/repository/tests/windows/registry_test/39000/oval_ru.altx-soft.win_tst_39468.xml
@@ -1,0 +1,3 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Microsoft Office 2016 is installed" id="oval:ru.altx-soft.win:tst:39468" version="1">
+  <object object_ref="oval:ru.altx-soft.win:obj:38163" />
+</registry_test>

--- a/repository/tests/windows/registry_test/39000/oval_ru.altx-soft.win_tst_39470.xml
+++ b/repository/tests/windows/registry_test/39000/oval_ru.altx-soft.win_tst_39470.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="an architecture of Office 2016 is x64" id="oval:ru.altx-soft.win:tst:39470" version="2">
+  <object object_ref="oval:ru.altx-soft.win:obj:38163" />
+  <state state_ref="oval:ru.altx-soft.win:ste:4442" />
+</registry_test>

--- a/repository/tests/windows/registry_test/39000/oval_ru.altx-soft.win_tst_39471.xml
+++ b/repository/tests/windows/registry_test/39000/oval_ru.altx-soft.win_tst_39471.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="an architecture of Office 2016 is x86" id="oval:ru.altx-soft.win:tst:39471" version="2">
+  <object object_ref="oval:ru.altx-soft.win:obj:38163" />
+  <state state_ref="oval:ru.altx-soft.win:ste:4441" />
+</registry_test>

--- a/repository/tests/windows/registry_test/46000/oval_ru.altx-soft.win_tst_46087.xml
+++ b/repository/tests/windows/registry_test/46000/oval_ru.altx-soft.win_tst_46087.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="an architecture of Office 2010 is x86" id="oval:ru.altx-soft.win:tst:46087" version="1">
+  <object object_ref="oval:org.mitre.oval:obj:23452" />
+  <state state_ref="oval:ru.altx-soft.win:ste:4441" />
+</registry_test>

--- a/repository/tests/windows/registry_test/46000/oval_ru.altx-soft.win_tst_46088.xml
+++ b/repository/tests/windows/registry_test/46000/oval_ru.altx-soft.win_tst_46088.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="an architecture of Office 2010 is x64" id="oval:ru.altx-soft.win:tst:46088" version="1">
+  <object object_ref="oval:org.mitre.oval:obj:23452" />
+  <state state_ref="oval:ru.altx-soft.win:ste:4442" />
+</registry_test>

--- a/repository/tests/windows/registry_test/46000/oval_ru.altx-soft.win_tst_46089.xml
+++ b/repository/tests/windows/registry_test/46000/oval_ru.altx-soft.win_tst_46089.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="an architecture of Office 2013 is x86" id="oval:ru.altx-soft.win:tst:46089" version="1">
+  <object object_ref="oval:org.mitre.oval:obj:23980" />
+  <state state_ref="oval:ru.altx-soft.win:ste:4441" />
+</registry_test>

--- a/repository/tests/windows/registry_test/46000/oval_ru.altx-soft.win_tst_46090.xml
+++ b/repository/tests/windows/registry_test/46000/oval_ru.altx-soft.win_tst_46090.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="an architecture of Office 2013 is x64" id="oval:ru.altx-soft.win:tst:46090" version="1">
+  <object object_ref="oval:org.mitre.oval:obj:23980" />
+  <state state_ref="oval:ru.altx-soft.win:ste:4442" />
+</registry_test>

--- a/repository/variables/oval_ru.altx-soft.win_var_38030.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_38030.xml
@@ -1,0 +1,6 @@
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The shared Office 2013 directory" datatype="string" id="oval:ru.altx-soft.win:var:38030" version="4">
+  <oval-def:concat>
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:281" />
+    <oval-def:literal_component>\Microsoft Shared\OFFICE15</oval-def:literal_component>
+  </oval-def:concat>
+</oval-def:local_variable>

--- a/repository/variables/oval_ru.altx-soft.win_var_66.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_66.xml
@@ -1,0 +1,9 @@
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="DriverStore directory" datatype="string" id="oval:ru.altx-soft.win:var:66" version="0">
+  <oval-def:concat>
+    <oval-def:literal_component>^</oval-def:literal_component>
+    <oval-def:escape_regex>
+      <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:219" />
+    </oval-def:escape_regex>
+    <oval-def:literal_component>\\System32\\DriverStore\\FileRepository\\.*$</oval-def:literal_component>
+  </oval-def:concat>
+</oval-def:local_variable>


### PR DESCRIPTION
Hello,
There are [security patches](https://ovaldb.altx-soft.ru/Definitions.aspx?reference=CVE-2017-0199&class=patch&namespace=com.altx-soft.win) which check that PETYA and MISCHA ransomware doesn't threat the computer.