### PR TITLE
Update oval_org.cisecurity_tst_3607.xml

### DIFF
--- a/repository/tests/windows/file_test/3000/oval_org.cisecurity_tst_3607.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.cisecurity_tst_3607.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 53.0" id="oval:org.cisecurity:tst:3607" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:30347" />
+  <object object_ref="oval:org.mitre.oval:obj:30321" />
   <state state_ref="oval:org.cisecurity:ste:2679" />
 </file_test>


### PR DESCRIPTION
Object [oval:org.mitre.oval:obj:30347](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:30347) (ESR version) was replaced with [oval:org.mitre.oval:obj:30321](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.mitre.oval:obj:30321)(Mainline version) because test [oval:org.cisecurity:tst:3607](https://ovaldb.altx-soft.ru/OvalItem.aspx?id=oval:org.cisecurity:tst:3607) checks mainline release.