### PR TITLE
Changed checked platforms in oval:org.cisecurity:def:474

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_474.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_474.xml
@@ -1,48 +1,49 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:474" version="53">
-  <metadata>
-    <title>Internet Explorer Memory Corruption Vulnerability - CVE-2016-0164 (MS16-037)</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <product>Microsoft Internet Explorer 10</product>
-      <product>Microsoft Internet Explorer 11</product>
-    </affected>
-    <reference ref_id="CVE-2016-0164" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0164" source="CVE" />
-    <description>Microsoft Internet Explorer 10 and 11 allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted web site, aka "Internet Explorer Memory Corruption Vulnerability."</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2016-04-20T23:05:00+08:00">
-          <contributor organization="The Depository Trust and Clearing Corporation">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2016-04-29T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2016-05-14T15:00:00.000-04:00">INTERIM</status_change>
-        <status_change date="2016-05-27T15:00:00.000-04:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria operator="OR">
-    <criteria comment="Internet Explorer 10 is installed + Windows Server 2012 + vulnerable file version" operator="AND">
-      <extend_definition comment="Microsoft Internet Explorer 10 is installed" definition_ref="oval:org.mitre.oval:def:15751" />
-      <extend_definition comment="Microsoft Windows Server 2012 is installed" definition_ref="oval:org.mitre.oval:def:16359" />
-      <criterion comment="Check if the version of mshtml.dll is less than 10.0.9200.21811" test_ref="oval:org.cisecurity:tst:780" />
-    </criteria>
-    <criteria comment="Internet Explorer 11 is installed + vulnerable windows OS + vulnerable file version" operator="AND">
-      <extend_definition comment="Microsoft Internet Explorer 11 is installed" definition_ref="oval:org.mitre.oval:def:18343" />
-      <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
-        <criteria comment="R2/Win7/2012/2012 R2 Server + vulnerable file version" operator="AND">
-          <criteria comment="R2/Win7/2012/2012 R2 Server version" operator="OR">
-            <extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
-            <extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
-            <extend_definition comment="Microsoft Windows Server 2012 is installed" definition_ref="oval:org.mitre.oval:def:16359" />
-          </criteria>
-          <criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.18283" test_ref="oval:org.cisecurity:tst:794" />
-        </criteria>
-      </criteria>
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:474" version="53">
+  <oval-def:metadata>
+    <oval-def:title>Internet Explorer Memory Corruption Vulnerability - CVE-2016-0164 (MS16-037)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:product>Microsoft Internet Explorer 10</oval-def:product>
+      <oval-def:product>Microsoft Internet Explorer 11</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-0164" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0164" source="CVE" />
+    <oval-def:description>Microsoft Internet Explorer 10 and 11 allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted web site, aka "Internet Explorer Memory Corruption Vulnerability."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-04-20T23:05:00+08:00">
+          <oval-def:contributor organization="The Depository Trust and Clearing Corporation">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2016-04-29T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2016-05-14T15:00:00.000-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2016-05-27T15:00:00.000-04:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criteria comment="Internet Explorer 10 is installed + Windows Server 2012 + vulnerable file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Internet Explorer 10 is installed" definition_ref="oval:org.mitre.oval:def:15751" />
+      <oval-def:extend_definition comment="Microsoft Windows Server 2012 is installed" definition_ref="oval:org.mitre.oval:def:16359" />
+      <oval-def:criterion comment="Check if the version of mshtml.dll is less than 10.0.9200.21811" test_ref="oval:org.cisecurity:tst:780" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Internet Explorer 11 is installed + vulnerable windows OS + vulnerable file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Internet Explorer 11 is installed" definition_ref="oval:org.mitre.oval:def:18343" />
+      <oval-def:criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
+        <oval-def:criteria comment="R2/Win7/8.1/2012 R2 Server + vulnerable file version" operator="AND">
+          <oval-def:criteria comment="R2/Win7/8.1/2012 R2 Server version" operator="OR">
+            <oval-def:extend_definition comment="Microsoft Windows 7 is installed" definition_ref="oval:org.mitre.oval:def:12541" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 is installed" definition_ref="oval:org.mitre.oval:def:12754" />
+            <oval-def:extend_definition comment="Microsoft Windows 8.1 is installed" definition_ref="oval:org.mitre.oval:def:18863" />
+            <oval-def:extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
+          </oval-def:criteria>
+          <oval-def:criterion comment="Check if the version of mshtml.dll is less than 11.0.9600.18283" test_ref="oval:org.cisecurity:tst:794" />
+        </oval-def:criteria>
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>


### PR DESCRIPTION
Changed checked platforms in section "Internet Explorer 11 is installed + vulnerable windows OS + vulnerable file version" according [MS16-037](https://technet.microsoft.com/library/security/MS16-037). Instead Microsoft Windows Server 2012 are Microsoft Windows 8.1 and Microsoft Windows Server 2012 R2.