### PR TITLE
RHSA-2016:2098 and CESA-2016:2098

### DIFF
--- a/repository/definitions/patch/oval_com.test.nix_def_27054.xml
+++ b/repository/definitions/patch/oval_com.test.nix_def_27054.xml
@@ -1,0 +1,42 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:com.test.nix:def:27054" version="0">
+  <oval-def:metadata>
+    <oval-def:title>RHSA-2016:2098 -- kernel security update (Important)</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>Red Hat Enterprise Linux 7</oval-def:platform>
+      <oval-def:platform>CentOS Linux 7</oval-def:platform>
+      <oval-def:product>kernel</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="RHSA-2016:2098" ref_url="https://rhn.redhat.com/errata/RHSA-2016-2098.html" source="VENDOR" />
+    <oval-def:reference ref_id="CESA-2016:2098" ref_url="http://lists.centos.org/pipermail/centos-announce/2016-October/022133.html" source="CESA-2016:2098" />
+    <oval-def:reference ref_id="CVE-2016-5195" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5195" source="CVE" />
+    <oval-def:description>A race condition was found in the way the Linux kernel's memory subsystem handled the copy-on-write (COW) breakage of private read-only memory mappings. An unprivileged, local user could use this flaw to gain write access to otherwise read-only memory mappings and thus increase their privileges on the system.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-07-18T16:20:26">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criteria comment="Operation system section" operator="OR">
+      <oval-def:extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 7" definition_ref="oval:org.mitre.oval:def:24953" />
+      <oval-def:extend_definition comment="The operating system installed on the system is CentOS Linux 7.x" definition_ref="oval:org.mitre.oval:def:24773" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Packages match section" operator="OR">
+      <oval-def:criterion comment="kernel is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63670" />
+      <oval-def:criterion comment="kernel-abi-whitelists is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63671" />
+      <oval-def:criterion comment="kernel-debug is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63672" />
+      <oval-def:criterion comment="kernel-debug-devel is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63673" />
+      <oval-def:criterion comment="kernel-devel is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63674" />
+      <oval-def:criterion comment="kernel-doc is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63675" />
+      <oval-def:criterion comment="kernel-headers is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63676" />
+      <oval-def:criterion comment="kernel-tools is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63677" />
+      <oval-def:criterion comment="kernel-tools-libs is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63678" />
+      <oval-def:criterion comment="kernel-tools-libs-devel is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63679" />
+      <oval-def:criterion comment="perf is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63680" />
+      <oval-def:criterion comment="python-perf is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:ru.altx-soft.nix:tst:63681" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/states/linux/rpminfo_state/13000/oval_ru.altx-soft.nix_ste_13257.xml
+++ b/repository/states/linux/rpminfo_state/13000/oval_ru.altx-soft.nix_ste_13257.xml
@@ -1,0 +1,3 @@
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="version is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:ste:13257" version="0">
+  <evr datatype="evr_string" operation="less than">0:3.10.0-327.36.3.el7</evr>
+</rpminfo_state>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63670.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63670.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63670" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:14285" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63671.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63671.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-abi-whitelists is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63671" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:29639" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63672.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63672.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-debug is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63672" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:14957" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63673.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63673.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-debug-devel is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63673" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:15023" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63674.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63674.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-devel is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63674" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:13732" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63675.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63675.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-doc is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63675" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:13422" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63676.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63676.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-headers is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63676" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:14830" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63677.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63677.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-tools is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63677" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:39295" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63678.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63678.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-tools-libs is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63678" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:38896" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63679.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63679.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="kernel-tools-libs-devel is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63679" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:38758" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63680.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63680.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="perf is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63680" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:29062" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63681.xml
+++ b/repository/tests/linux/rpminfo_test/63000/oval_ru.altx-soft.nix_tst_63681.xml
@@ -1,0 +1,4 @@
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="python-perf is earlier than 0:3.10.0-327.36.3.el7" id="oval:ru.altx-soft.nix:tst:63681" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:28972" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:13257" />
+</rpminfo_test>


### PR DESCRIPTION
Path on RedHat and Centos which close CVE-2016-5195 vulnerability