### PR TITLE
Update oval_org.mitre.oval_obj_12171.xml

### DIFF
--- a/repository/objects/windows/file_object/12000/oval_org.mitre.oval_obj_12171.xml
+++ b/repository/objects/windows/file_object/12000/oval_org.mitre.oval_obj_12171.xml
@@ -1,4 +1,4 @@
 <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:12171" version="1">
   <path var_check="at least one" var_ref="oval:org.mitre.oval:var:37" />
-  <filename>VMWareService.exe</filename>
+  <filename operation="pattern match">^(VMWareService|vmtoolsd)\.exe$</filename>
 </file_object>


### PR DESCRIPTION
Pattern match was added because the name of the file changed in last versions