### PR TITLE
kemanik_google_chrome

### DIFF
--- a/repository/objects/windows/registry_object/0000/oval_org.cisecurity_obj_397.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.cisecurity_obj_397.xml
@@ -1,5 +1,5 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry key holding the version of Google Chrome (admin install for all users)" id="oval:org.cisecurity:obj:397" version="3">
   <hive>HKEY_LOCAL_MACHINE</hive>
-  <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome</key>
-  <name>Version</name>
+  <key var_check="at least one" var_ref="oval:ru.test.win:var:1" />
+  <name>DisplayVersion</name>
 </registry_object>

--- a/repository/objects/windows/registry_object/0000/oval_org.cisecurity_obj_432.xml
+++ b/repository/objects/windows/registry_object/0000/oval_org.cisecurity_obj_432.xml
@@ -1,6 +1,7 @@
-<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:ns1="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The registry key to check if Google Chrome is installed in the Local machine" id="oval:org.cisecurity:obj:432" version="4">
-  <ns1:set>
-    <ns1:object_reference>oval:org.cisecurity:obj:431</ns1:object_reference>
-    <ns1:object_reference>oval:org.mitre.oval:obj:15822</ns1:object_reference>
-  </ns1:set>
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The registry key to check if Google Chrome is installed in the Local machine" id="oval:org.cisecurity:obj:432" version="4">
+  <oval-def:set>
+    <oval-def:object_reference>oval:org.mitre.oval:obj:41928</oval-def:object_reference>
+    <oval-def:object_reference>oval:org.mitre.oval:obj:41329</oval-def:object_reference>
+    <oval-def:filter action="include">oval:org.mitre.oval:ste:11937</oval-def:filter>
+  </oval-def:set>
 </registry_object>

--- a/repository/objects/windows/registry_object/16000/oval_org.mitre.oval_obj_16406.xml
+++ b/repository/objects/windows/registry_object/16000/oval_org.mitre.oval_obj_16406.xml
@@ -1,6 +1,6 @@
 <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The registry key holding the version of Google Chrome (admin install for all users) 32bit" id="oval:org.mitre.oval:obj:16406" version="5">
   <behaviors windows_view="32_bit" />
   <hive>HKEY_LOCAL_MACHINE</hive>
-  <key>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome</key>
-  <name>Version</name>
+  <key var_check="at least one" var_ref="oval:ru.test.win:var:1" />
+  <name>DisplayVersion</name>
 </registry_object>

--- a/repository/variables/oval_ru.test.win_var_1.xml
+++ b/repository/variables/oval_ru.test.win_var_1.xml
@@ -1,0 +1,3 @@
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Full key path of Google Chrome from uninstall registry key" datatype="string" id="oval:ru.test.win:var:1" version="0">
+  <oval-def:object_component item_field="key" object_ref="oval:org.cisecurity:obj:432" />
+</oval-def:local_variable>


### PR DESCRIPTION
The version 60.0.3112.113 of Google Chrome doesn't exist in "\Uninstall\Google Chrome" that's why the check was changed