### PR TITLE
mspub.exe and pubconv.dll

### DIFF
--- a/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_94.xml
+++ b/repository/objects/windows/file_object/0000/oval_org.mitre.oval_obj_94.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="The path to mspub.exe" id="oval:org.mitre.oval:obj:94" version="6">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of mspub.exe (Office 2010)" id="oval:org.mitre.oval:obj:94" version="6">
   <path var_check="at least one" var_ref="oval:org.mitre.oval:var:297" />
   <filename>mspub.exe</filename>
 </file_object>

--- a/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_1.xml
+++ b/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_1.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of mspub.exe (Office 2003)" id="oval:ru.test.win:obj:1" version="0">
+  <path var_check="at least one" var_ref="oval:ru.test.win:var:1" />
+  <filename>mspub.exe</filename>
+</file_object>

--- a/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_10.xml
+++ b/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_10.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of pubconv.dll (Office 2007)" id="oval:ru.test.win:obj:10" version="0">
+  <path var_check="at least one" var_ref="oval:ru.altx-soft.win:var:209" />
+  <filename>pubconv.dll</filename>
+</file_object>

--- a/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_11.xml
+++ b/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_11.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of pubconv.dll (Office 2003)" id="oval:ru.test.win:obj:11" version="0">
+  <path var_check="at least one" var_ref="oval:ru.test.win:var:1" />
+  <filename>pubconv.dll</filename>
+</file_object>

--- a/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_2.xml
+++ b/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_2.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of mspub.exe (Office 2002)" id="oval:ru.test.win:obj:2" version="0">
+  <path var_check="at least one" var_ref="oval:ru.test.win:var:2" />
+  <filename>mspub.exe</filename>
+</file_object>

--- a/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_3.xml
+++ b/repository/objects/windows/file_object/0000/oval_ru.test.win_obj_3.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of mspub.exe (Office 2000)" id="oval:ru.test.win:obj:3" version="0">
+  <path var_check="at least one" var_ref="oval:ru.test.win:var:3" />
+  <filename>mspub.exe</filename>
+</file_object>

--- a/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2193.xml
+++ b/repository/objects/windows/file_object/2000/oval_org.mitre.oval_obj_2193.xml
@@ -1,4 +1,4 @@
-<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:org.mitre.oval:obj:2193" version="6">
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of pubconv.dll (Office 2010)" id="oval:org.mitre.oval:obj:2193" version="6">
   <path var_check="at least one" var_ref="oval:org.mitre.oval:var:297" />
   <filename>pubconv.dll</filename>
 </file_object>

--- a/repository/objects/windows/file_object/44000/oval_ru.altx-soft.win_obj_44294.xml
+++ b/repository/objects/windows/file_object/44000/oval_ru.altx-soft.win_obj_44294.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of mspub.exe (Office 2007)" id="oval:ru.altx-soft.win:obj:44294" version="0">
+  <path var_check="at least one" var_ref="oval:ru.altx-soft.win:var:209" />
+  <filename>mspub.exe</filename>
+</file_object>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_168.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_168.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 10.0.6815.0" id="oval:org.mitre.oval:tst:168" version="7">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:2" />
   <state state_ref="oval:org.mitre.oval:ste:75" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_29.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_29.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 11.0.8103.0" id="oval:org.mitre.oval:tst:29" version="7">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:44" />
 </file_test>

--- a/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_36.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.mitre.oval_tst_36.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 9.0.0.8930" id="oval:org.mitre.oval:tst:36" version="7">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:3" />
   <state state_ref="oval:org.mitre.oval:ste:100" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11140.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11140.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6861.0" id="oval:org.mitre.oval:tst:11140" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:2" />
   <state state_ref="oval:org.mitre.oval:ste:6540" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11272.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11272.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6527.5000" id="oval:org.mitre.oval:tst:11272" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:6599" />
 </file_test>

--- a/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11669.xml
+++ b/repository/tests/windows/file_test/11000/oval_org.mitre.oval_tst_11669.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8321.0" id="oval:org.mitre.oval:tst:11669" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:6490" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113072.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113072.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of pubconv.dll is less than 11.0.8410" id="oval:org.mitre.oval:tst:113072" version="5">
-  <object object_ref="oval:org.mitre.oval:obj:2193" />
+  <object object_ref="oval:ru.test.win:obj:11" />
   <state state_ref="oval:org.mitre.oval:ste:30026" />
 </file_test>

--- a/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113552.xml
+++ b/repository/tests/windows/file_test/113000/oval_org.mitre.oval_tst_113552.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of pubconv.dll is less than 12.0.6694.5000" id="oval:org.mitre.oval:tst:113552" version="5">
-  <object object_ref="oval:org.mitre.oval:obj:2193" />
+  <object object_ref="oval:ru.test.win:obj:10" />
   <state state_ref="oval:org.mitre.oval:ste:30920" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27543.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27543.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6535.5002" id="oval:org.mitre.oval:tst:27543" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:6998" />
 </file_test>

--- a/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27728.xml
+++ b/repository/tests/windows/file_test/27000/oval_org.mitre.oval_tst_27728.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8324.0" id="oval:org.mitre.oval:tst:27728" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:7082" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3774.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.mitre.oval_tst_3774.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of pubconv.dll is less than 12.0.6023.5000" id="oval:org.mitre.oval:tst:3774" version="7">
-  <object object_ref="oval:org.mitre.oval:obj:2193" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:3587" />
 </file_test>

--- a/repository/tests/windows/file_test/4000/oval_org.mitre.oval_tst_4000.xml
+++ b/repository/tests/windows/file_test/4000/oval_org.mitre.oval_tst_4000.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 12.0.6023.5000" id="oval:org.mitre.oval:tst:4000" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:3587" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41524.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41524.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6867.0" id="oval:org.mitre.oval:tst:41524" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:2" />
   <state state_ref="oval:org.mitre.oval:ste:12083" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41652.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41652.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6546.5000" id="oval:org.mitre.oval:tst:41652" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:11746" />
 </file_test>

--- a/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41823.xml
+++ b/repository/tests/windows/file_test/41000/oval_org.mitre.oval_tst_41823.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8329.0" id="oval:org.mitre.oval:tst:41823" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:11983" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7678.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7678.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8200.0" id="oval:org.mitre.oval:tst:7678" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:3333" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7723.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7723.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6840.0" id="oval:org.mitre.oval:tst:7723" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:2" />
   <state state_ref="oval:org.mitre.oval:ste:3465" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7731.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7731.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 9.0.8932.0" id="oval:org.mitre.oval:tst:7731" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:3" />
   <state state_ref="oval:org.mitre.oval:ste:3344" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7781.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7781.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 9.0.8931.0" id="oval:org.mitre.oval:tst:7781" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:3" />
   <state state_ref="oval:org.mitre.oval:ste:3752" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7824.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7824.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6308.5000" id="oval:org.mitre.oval:tst:7824" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:3259" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7961.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7961.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 10.0.6842.0" id="oval:org.mitre.oval:tst:7961" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:2" />
   <state state_ref="oval:org.mitre.oval:ste:3921" />
 </file_test>

--- a/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7976.xml
+++ b/repository/tests/windows/file_test/7000/oval_org.mitre.oval_tst_7976.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8212.0" id="oval:org.mitre.oval:tst:7976" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:3936" />
 </file_test>

--- a/repository/tests/windows/file_test/77000/oval_org.mitre.oval_tst_77919.xml
+++ b/repository/tests/windows/file_test/77000/oval_org.mitre.oval_tst_77919.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 11.0.8342" id="oval:org.mitre.oval:tst:77919" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:18360" />
 </file_test>

--- a/repository/tests/windows/file_test/77000/oval_org.mitre.oval_tst_77931.xml
+++ b/repository/tests/windows/file_test/77000/oval_org.mitre.oval_tst_77931.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6652.5000" id="oval:org.mitre.oval:tst:77931" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:18094" />
 </file_test>

--- a/repository/tests/windows/file_test/8000/oval_org.mitre.oval_tst_8997.xml
+++ b/repository/tests/windows/file_test/8000/oval_org.mitre.oval_tst_8997.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is greater than or equal 12.0.0.0" id="oval:org.mitre.oval:tst:8997" version="5">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:4449" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81094.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81094.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mspub.exe is less than 11.0.8402" id="oval:org.mitre.oval:tst:81094" version="5">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.test.win:obj:1" />
   <state state_ref="oval:org.mitre.oval:ste:20557" />
 </file_test>

--- a/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81217.xml
+++ b/repository/tests/windows/file_test/81000/oval_org.mitre.oval_tst_81217.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of Mspub.exe is less than 12.0.6676.5000" id="oval:org.mitre.oval:tst:81217" version="5">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:20695" />
 </file_test>

--- a/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9333.xml
+++ b/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9333.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of mspub.exe is less than 13.0.0.0" id="oval:org.mitre.oval:tst:9333" version="5">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:4287" />
 </file_test>

--- a/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9924.xml
+++ b/repository/tests/windows/file_test/9000/oval_org.mitre.oval_tst_9924.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Mspub.exe is less than 12.0.6501.5000" id="oval:org.mitre.oval:tst:9924" version="6">
-  <object object_ref="oval:org.mitre.oval:obj:94" />
+  <object object_ref="oval:ru.altx-soft.win:obj:44294" />
   <state state_ref="oval:org.mitre.oval:ste:4898" />
 </file_test>

--- a/repository/variables/oval_org.mitre.oval_var_297.xml
+++ b/repository/variables/oval_org.mitre.oval_var_297.xml
@@ -1,5 +1,5 @@
-<local_variable xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The path to mspub.exe" datatype="string" id="oval:org.mitre.oval:var:297" version="5">
-  <regex_capture pattern="^(.*[^\\])\\?$">
-    <object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23941" />
-  </regex_capture>
-</local_variable>
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to Office Publisher 2010 InstallRoot" datatype="string" id="oval:org.mitre.oval:var:297" version="5">
+  <oval-def:regex_capture pattern="^(.*[^\\])\\?$">
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:23941" />
+  </oval-def:regex_capture>
+</oval-def:local_variable>

--- a/repository/variables/oval_ru.altx-soft.win_var_209.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_209.xml
@@ -1,0 +1,3 @@
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to mspub.exe (Office 2007)" datatype="string" id="oval:ru.altx-soft.win:var:209" version="0">
+  <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:2560" />
+</oval-def:local_variable>

--- a/repository/variables/oval_ru.altx-soft.win_var_209.xml
+++ b/repository/variables/oval_ru.altx-soft.win_var_209.xml
@@ -1,3 +1,3 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to mspub.exe (Office 2007)" datatype="string" id="oval:ru.altx-soft.win:var:209" version="0">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to Office Publisher 2007 InstallRoot" datatype="string" id="oval:ru.altx-soft.win:var:209" version="0">
   <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:2560" />
 </oval-def:local_variable>

--- a/repository/variables/oval_ru.test.win_var_1.xml
+++ b/repository/variables/oval_ru.test.win_var_1.xml
@@ -1,3 +1,3 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to mspub.exe (Office 2003)" datatype="string" id="oval:ru.test.win:var:1" version="0">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to Office Publisher 2003 InstallRoot" datatype="string" id="oval:ru.test.win:var:1" version="0">
   <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:158" />
 </oval-def:local_variable>

--- a/repository/variables/oval_ru.test.win_var_1.xml
+++ b/repository/variables/oval_ru.test.win_var_1.xml
@@ -1,0 +1,3 @@
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to mspub.exe (Office 2003)" datatype="string" id="oval:ru.test.win:var:1" version="0">
+  <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:158" />
+</oval-def:local_variable>

--- a/repository/variables/oval_ru.test.win_var_2.xml
+++ b/repository/variables/oval_ru.test.win_var_2.xml
@@ -1,0 +1,3 @@
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to mspub.exe (Office 2002)" datatype="string" id="oval:ru.test.win:var:2" version="0">
+  <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:189" />
+</oval-def:local_variable>

--- a/repository/variables/oval_ru.test.win_var_2.xml
+++ b/repository/variables/oval_ru.test.win_var_2.xml
@@ -1,3 +1,3 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to mspub.exe (Office 2002)" datatype="string" id="oval:ru.test.win:var:2" version="0">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to Office Publisher 2002 InstallRoot" datatype="string" id="oval:ru.test.win:var:2" version="0">
   <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:189" />
 </oval-def:local_variable>

--- a/repository/variables/oval_ru.test.win_var_3.xml
+++ b/repository/variables/oval_ru.test.win_var_3.xml
@@ -1,3 +1,3 @@
-<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to mspub.exe (Office 2000)" datatype="string" id="oval:ru.test.win:var:3" version="0">
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to Office Publisher 2000 InstallRoot" datatype="string" id="oval:ru.test.win:var:3" version="0">
   <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:109" />
 </oval-def:local_variable>

--- a/repository/variables/oval_ru.test.win_var_3.xml
+++ b/repository/variables/oval_ru.test.win_var_3.xml
@@ -1,0 +1,3 @@
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Variable holds the path to mspub.exe (Office 2000)" datatype="string" id="oval:ru.test.win:var:3" version="0">
+  <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:109" />
+</oval-def:local_variable>


### PR DESCRIPTION
oval:org.mitre.oval:obj:94 should be used for MS Publisher 2010 only but it used for Publisher 2000 - 2010.

oval:org.mitre.oval:obj:2193 should be used for MS Publisher 2010 only but it used for Publisher 2003 - 2010.


