### PR TITLE
Fixes in Google Chrome vulnerabilities

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3355.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3355.xml
@@ -1,34 +1,34 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3355" version="2">
-  <metadata>
-    <title>Out-of-bounds access in V8 - CVE-2017-5121</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5121" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5121" source="CVE" />
-    <description>Out-of-bounds access in V8.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-03T16:55:06+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-10-06T13:32:25.761-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 61.0.3163.101" test_ref="oval:org.cisecurity:tst:4469" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3355" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Out-of-bounds access in V8 - CVE-2017-5121</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5121" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5121" source="CVE" />
+    <oval-def:description>Out-of-bounds access in V8.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-03T16:55:06+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-06T13:32:25.761-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 61.0.3163.100" test_ref="oval:org.cisecurity:tst:4469" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3356.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3356.xml
@@ -1,34 +1,34 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3356" version="2">
-  <metadata>
-    <title>Out-of-bounds access in V8 - CVE-2017-5122</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5122" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5122" source="CVE" />
-    <description>Out-of-bounds access in V8</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-03T16:55:06+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-10-06T13:32:25.761-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 61.0.3163.101" test_ref="oval:org.cisecurity:tst:4469" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3356" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Out-of-bounds access in V8 - CVE-2017-5122</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5122" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5122" source="CVE" />
+    <oval-def:description>Out-of-bounds access in V8</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-03T16:55:06+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-06T13:32:25.761-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 61.0.3163.100" test_ref="oval:org.cisecurity:tst:4469" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/states/windows/registry_state/3000/oval_org.cisecurity_ste_3260.xml
+++ b/repository/states/windows/registry_state/3000/oval_org.cisecurity_ste_3260.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Version is less than 61.0.3163.101" id="oval:org.cisecurity:ste:3260" version="1">
-  <value datatype="version" operation="less than">61.0.3163.101</value>
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Version is less than 61.0.3163.100" id="oval:org.cisecurity:ste:3260" version="1">
+  <value datatype="version" operation="less than">61.0.3163.100</value>
 </registry_state>

--- a/repository/tests/windows/registry_test/4000/oval_org.cisecurity_tst_4469.xml
+++ b/repository/tests/windows/registry_test/4000/oval_org.cisecurity_tst_4469.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Google Chrome version less than 61.0.3163.101" id="oval:org.cisecurity:tst:4469" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Google Chrome version less than 61.0.3163.100" id="oval:org.cisecurity:tst:4469" version="1">
   <object object_ref="oval:org.mitre.oval:obj:15888" />
   <state state_ref="oval:org.cisecurity:ste:3260" />
 </registry_test>


### PR DESCRIPTION
Version 61.0.3163.101 was changed on 61.0.3163.100 in CVE-2017-5121 and CVE-2017-5122 according [this article](https://chromereleases.googleblog.com/2017/09/stable-channel-update-for-desktop_21.html)