### PR TITLE
Deprecated Google Chrome

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3383.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3383.xml
@@ -1,36 +1,36 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3383" version="6">
-  <metadata>
-    <title>User information leak via Android intents - CVE-2017-5096</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5096" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5096" source="CVE" />
-    <description>User information leak via Android intents.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-10T23:08:24+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-10-13T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-10-27T11:35:13.104-04:00">INTERIM</status_change>
-        <status_change date="2017-11-10T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3383" version="6">
+  <oval-def:metadata>
+    <oval-def:title>User information leak via Android intents - CVE-2017-5096</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5096" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5096" source="CVE" />
+    <oval-def:description>User information leak via Android intents.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-10T23:08:24+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-13T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-10-27T11:35:13.104-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-11-10T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3433.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3433.xml
@@ -1,34 +1,34 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3433" version="5">
-  <metadata>
-    <title>Address spoofing in Omnibox - CVE-2017-5072</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5072" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5072" source="CVE" />
-    <description>Address spoofing in Omnibox</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-18T00:00:00+08:00">
-          <contributor organization="DTCC">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2017-10-20T13:32:25.761-04:00">DRAFT</status_change>
-        <status_change date="2017-11-03T14:00:00.000-05:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome + vulnerable version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 59.0.3071.86" test_ref="oval:org.cisecurity:tst:4659" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3433" version="5">
+  <oval-def:metadata>
+    <oval-def:title>Address spoofing in Omnibox - CVE-2017-5072</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5072" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5072" source="CVE" />
+    <oval-def:description>Address spoofing in Omnibox</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-18T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-20T13:32:25.761-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-11-03T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome + vulnerable version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 59.0.3071.86" test_ref="oval:org.cisecurity:tst:4659" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3443.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3443.xml
@@ -1,34 +1,34 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3443" version="5">
-  <metadata>
-    <title>Insufficient hardening in credit card editor - CVE-2017-5082</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5082" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5082" source="CVE" />
-    <description>Insufficient hardening in credit card editor</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-18T00:00:00+08:00">
-          <contributor organization="DTCC">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2017-10-20T13:32:25.761-04:00">DRAFT</status_change>
-        <status_change date="2017-11-03T14:00:00.000-05:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome + vulnerable version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 59.0.3071.86" test_ref="oval:org.cisecurity:tst:4659" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3443" version="5">
+  <oval-def:metadata>
+    <oval-def:title>Insufficient hardening in credit card editor - CVE-2017-5082</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5082" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5082" source="CVE" />
+    <oval-def:description>Insufficient hardening in credit card editor</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-18T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-20T13:32:25.761-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-11-03T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome + vulnerable version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 59.0.3071.86" test_ref="oval:org.cisecurity:tst:4659" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3469.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3469.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3469" version="5">
-  <metadata>
-    <title>Out-of-bounds write in PPAPI - CVE-2017-5099</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5099" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5099" source="CVE" />
-    <description>Out-of-bounds write in PPAPI.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-06T14:26:32+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-10-20T13:32:25.761-04:00">DRAFT</status_change>
-        <status_change date="2017-11-03T14:00:00.000-05:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3469" version="5">
+  <oval-def:metadata>
+    <oval-def:title>Out-of-bounds write in PPAPI - CVE-2017-5099</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5099" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5099" source="CVE" />
+    <oval-def:description>Out-of-bounds write in PPAPI.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-06T14:26:32+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-20T13:32:25.761-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-11-03T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3471.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3471.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3471" version="5">
-  <metadata>
-    <title>Out-of-bounds read in Skia - CVE-2017-5097</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5097" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5097" source="CVE" />
-    <description>Out-of-bounds read in Skia.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-06T14:26:32+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-10-20T13:32:25.761-04:00">DRAFT</status_change>
-        <status_change date="2017-11-03T14:00:00.000-05:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3471" version="5">
+  <oval-def:metadata>
+    <oval-def:title>Out-of-bounds read in Skia - CVE-2017-5097</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5097" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5097" source="CVE" />
+    <oval-def:description>Out-of-bounds read in Skia.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-06T14:26:32+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-20T13:32:25.761-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-11-03T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3487.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3487.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3487" version="4">
-  <metadata>
-    <title>UI spoofing in browser - CVE-2017-5104</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5104" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5104" source="CVE" />
-    <description>UI spoofing in browser.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-06T14:26:32+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-10-27T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-11-10T14:00:00.000-05:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3487" version="4">
+  <oval-def:metadata>
+    <oval-def:title>UI spoofing in browser - CVE-2017-5104</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5104" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5104" source="CVE" />
+    <oval-def:description>UI spoofing in browser.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-06T14:26:32+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-27T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-11-10T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3499.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3499.xml
@@ -1,34 +1,34 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3499" version="5">
-  <metadata>
-    <title>Domain spoofing in Omnibox - CVE-2017-5089</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5089" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5089" source="CVE" />
-    <description>Insufficient Policy Enforcement in Omnibox in Google Chrome prior to 59.0.3071.104 for Mac allowed a remote attacker to perform domain spoofing via a crafted domain name.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-27T00:00:00+08:00">
-          <contributor organization="DTCC">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2017-10-27T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-11-10T14:00:00.000-05:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome + vulnerable version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 59.0.3071.104" test_ref="oval:org.cisecurity:tst:3596" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3499" version="5">
+  <oval-def:metadata>
+    <oval-def:title>Domain spoofing in Omnibox - CVE-2017-5089</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5089" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5089" source="CVE" />
+    <oval-def:description>Insufficient Policy Enforcement in Omnibox in Google Chrome prior to 59.0.3071.104 for Mac allowed a remote attacker to perform domain spoofing via a crafted domain name.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-27T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-27T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-11-10T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome + vulnerable version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 59.0.3071.104" test_ref="oval:org.cisecurity:tst:3596" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3500.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3500.xml
@@ -1,34 +1,34 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3500" version="4">
-  <metadata>
-    <title>Pointer disclosure in SQLite - CVE-2017-6991</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-6991" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-6991" source="CVE" />
-    <description>Pointer disclosure in SQLite</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-27T00:00:00+08:00">
-          <contributor organization="DTCC">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2017-10-27T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-11-10T14:00:00.000-05:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome + vulnerable version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3500" version="4">
+  <oval-def:metadata>
+    <oval-def:title>Pointer disclosure in SQLite - CVE-2017-6991</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-6991" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-6991" source="CVE" />
+    <oval-def:description>Pointer disclosure in SQLite</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-27T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-27T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-11-10T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome + vulnerable version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 60.0.3112.78" test_ref="oval:org.cisecurity:tst:4491" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3526.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3526.xml
@@ -1,31 +1,31 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3526" version="3">
-  <metadata>
-    <title>Inappropriate javascript execution on WebUI pages - CVE-2017-5085</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-5085" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5085" source="CVE" />
-    <description>Inappropriate implementation in Bookmarks in Google Chrome prior to 59 for iOS allowed a remote attacker who convinced the user to perform certain operations to run JavaScript on chrome:// pages via a crafted bookmark.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-27T21:50:44+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2017-11-03T12:00:00.000-05:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 59.0.3071.86" test_ref="oval:org.cisecurity:tst:4659" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3526" version="3">
+  <oval-def:metadata>
+    <oval-def:title>Inappropriate javascript execution on WebUI pages - CVE-2017-5085</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-5085" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5085" source="CVE" />
+    <oval-def:description>Inappropriate implementation in Bookmarks in Google Chrome prior to 59 for iOS allowed a remote attacker who convinced the user to perform certain operations to run JavaScript on chrome:// pages via a crafted bookmark.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-27T21:50:44+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-11-03T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 59.0.3071.86" test_ref="oval:org.cisecurity:tst:4659" />
+  </oval-def:criteria>
+</oval-def:definition>


### PR DESCRIPTION
This definitions on Google Chrome should be deprecated because vulnerabilities are not on Windows.