### PR TITLE
Avoid using obj:6126

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_6716.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_6716.xml
@@ -251,12 +251,10 @@
     <criteria comment="Microsoft Visual Studio 2008" operator="AND">
       <extend_definition comment="Microsoft Visual Studio 2008 is installed" definition_ref="oval:org.mitre.oval:def:5401" />
       <criterion comment="the version of ATL90.dll is less than 9.0.21022.218" test_ref="oval:org.mitre.oval:tst:10046" />
-      <criterion comment="ATL90.dll exists" test_ref="oval:org.mitre.oval:tst:115651" />
     </criteria>
     <criteria comment="Microsoft Visual Studio 2008 SP1" operator="AND">
       <extend_definition comment="Microsoft Visual Studio 2008 Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:6205" />
       <criterion comment="the version of ATL90.dll is less than 9.0.30729.4148" test_ref="oval:org.mitre.oval:tst:10261" />
-      <criterion comment="ATL90.dll exists" test_ref="oval:org.mitre.oval:tst:115651" />
     </criteria>
     <criteria comment="Microsoft Visual C++ 2005 Redistributable Package" operator="AND">
       <extend_definition comment="Microsoft Visual C++ 2005 Redistributable Package is installed" definition_ref="oval:org.mitre.oval:def:29007" />

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_7581.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_7581.xml
@@ -160,12 +160,10 @@
     <criteria comment="Microsoft Visual Studio 2008" operator="AND">
       <extend_definition comment="Microsoft Visual Studio 2008 is installed" definition_ref="oval:org.mitre.oval:def:5401" />
       <criterion comment="the version of ATL90.dll is less than 9.0.21022.218" test_ref="oval:org.mitre.oval:tst:10046" />
-      <criterion comment="ATL90.dll exists" test_ref="oval:org.mitre.oval:tst:115651" />
     </criteria>
     <criteria comment="Microsoft Visual Studio 2008 SP1" operator="AND">
       <extend_definition comment="Microsoft Visual Studio 2008 Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:6205" />
       <criterion comment="the version of ATL90.dll is less than 9.0.30729.4148" test_ref="oval:org.mitre.oval:tst:10261" />
-      <criterion comment="ATL90.dll exists" test_ref="oval:org.mitre.oval:tst:115651" />
     </criteria>
     <criteria comment="Microsoft Visual C++ 2005 Redistributable Package" operator="AND">
       <extend_definition comment="Microsoft Visual C++ 2005 Redistributable Package is installed" definition_ref="oval:org.mitre.oval:def:29007" />

--- a/repository/variables/oval_org.mitre.oval_var_974.xml
+++ b/repository/variables/oval_org.mitre.oval_var_974.xml
@@ -1,6 +1,6 @@
 <oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="The Microsoft Visual Studio 2008 ...Common7\IDE\Xml subdirectory" datatype="string" id="oval:org.mitre.oval:var:974" version="1">
   <oval-def:concat>
-    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:6126" />
-    <oval-def:literal_component>Common7\IDE\Xml</oval-def:literal_component>
+    <oval-def:object_component item_field="value" object_ref="oval:org.mitre.oval:obj:6400" />
+    <oval-def:literal_component>Xml</oval-def:literal_component>
   </oval-def:concat>
 </oval-def:local_variable>


### PR DESCRIPTION
Changed all variables and tests that used obj:6126 because it use regular expression which is performed for a very long time