### PR TITLE
Update oval_org.mitre.oval_def_6082.xml

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_6082.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_6082.xml
@@ -68,5 +68,9 @@
   </metadata>
   <criteria>
     <criterion comment="Check if SQL Server instances with version greater than 2005.90.0.0 and less than 2007.100.0.0 exist" test_ref="oval:org.cisecurity:tst:4601" />
+    <criteria operator="OR" comment="32\64 SQLPath">
+			<criterion comment="Check if 64-bit SQLPath of Microsoft SQL Server instances exist" test_ref="oval:org.cisecurity:tst:4597" />	
+			<criterion comment="Check if 32-bit SQLPath of Microsoft SQL Server instances exist" test_ref="oval:org.cisecurity:tst:4593" />
+		</criteria>
   </criteria>
 </definition>


### PR DESCRIPTION
An error result returns because oval:org.mitre.oval:obj:12103 does not exist. New criterions helps escape error.