### PR TITLE
Fixes for Linux OS inventory definitions

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_15459.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_15459.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:15459" version="18">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:15459" version="19">
   <metadata>
     <title>Oracle Linux 5.x</title>
     <affected family="unix">
@@ -24,13 +24,15 @@
         </modified>
         <status_change date="2014-03-17T11:25:31.931-04:00">INTERIM</status_change>
         <status_change date="2014-04-07T04:01:57.431-04:00">ACCEPTED</status_change>
+        <modified comment="EDITED oval:org.mitre.oval:def:15459 - Removed criterion checking for the unix family, as this causes a false-positive when the rpm_test is not applicable." date="2018-01-19T10:23:00.000-05:00">
+          <contributor organization="Joval">David A. Solin</contributor>
+        </modified>
       </dates>
       <status>ACCEPTED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>
   <criteria>
-    <criterion comment="the installed operating system is part of the Unix family" test_ref="oval:org.mitre.oval:tst:4424" />
     <criterion comment="Oracle Linux 5.x is installed" test_ref="oval:org.mitre.oval:tst:80718" />
   </criteria>
 </definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_15802.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_15802.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:15802" version="18">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:15802" version="19">
   <metadata>
     <title>The operating system installed on the system is CentOS Linux 5.x</title>
     <affected family="unix">
@@ -24,13 +24,15 @@
         </modified>
         <status_change date="2014-01-15T12:21:47.538-05:00">INTERIM</status_change>
         <status_change date="2014-02-03T04:00:37.998-05:00">ACCEPTED</status_change>
+        <modified comment="EDITED oval:org.mitre.oval:def:15459 - Removed criterion checking for the unix family, as this causes a false-positive when the rpm_test is not applicable." date="2018-01-19T10:23:00.000-05:00">
+          <contributor organization="Joval">David A. Solin</contributor>
+        </modified>
       </dates>
       <status>ACCEPTED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>
   <criteria>
-    <criterion comment="the installed operating system is part of the Unix family" test_ref="oval:org.mitre.oval:tst:4424" />
     <criterion comment="CentOS Linux 5.x is installed" test_ref="oval:org.mitre.oval:tst:80416" />
   </criteria>
 </definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_16337.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_16337.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:16337" version="16">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:16337" version="17">
   <metadata>
     <title>The operating system installed on the system is CentOS Linux 6.x</title>
     <affected family="unix">
@@ -19,13 +19,15 @@
         </modified>
         <status_change date="2014-01-15T12:21:47.462-05:00">INTERIM</status_change>
         <status_change date="2014-02-03T04:00:42.138-05:00">ACCEPTED</status_change>
+        <modified comment="EDITED oval:org.mitre.oval:def:15459 - Removed criterion checking for the unix family, as this causes a false-positive when the rpm_test is not applicable." date="2018-01-19T10:23:00.000-05:00">
+          <contributor organization="Joval">David A. Solin</contributor>
+        </modified>
       </dates>
       <status>ACCEPTED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>
   <criteria>
-    <criterion comment="the installed operating system is part of the Unix family" test_ref="oval:org.mitre.oval:tst:4424" />
     <criterion comment="CentOS Linux 6.x is installed" test_ref="oval:org.mitre.oval:tst:80900" />
   </criteria>
 </definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_16594.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_16594.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:16594" version="15">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:16594" version="16">
   <metadata>
     <title>Oracle Linux 6.x</title>
     <affected family="unix">
@@ -19,13 +19,15 @@
         </modified>
         <status_change date="2014-03-17T11:25:31.979-04:00">INTERIM</status_change>
         <status_change date="2014-04-07T04:02:00.553-04:00">ACCEPTED</status_change>
+        <modified comment="EDITED oval:org.mitre.oval:def:16594 - Removed criterion checking for the unix family, as this causes a false-positive when the rpm_test is not applicable." date="2018-01-19T10:23:00.000-05:00">
+          <contributor organization="Joval">David A. Solin</contributor>
+        </modified>
       </dates>
       <status>ACCEPTED</status>
       <min_schema_version>5.3</min_schema_version>
     </oval_repository>
   </metadata>
   <criteria>
-    <criterion comment="the installed operating system is part of the Unix family" test_ref="oval:org.mitre.oval:tst:4424" />
     <criterion comment="Oracle Linux 6.x is installed" test_ref="oval:org.mitre.oval:tst:80772" />
   </criteria>
 </definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_24773.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_24773.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:24773" version="17">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:24773" version="18">
   <metadata>
     <title>The operating system installed on the system is CentOS Linux 7.x</title>
     <affected family="unix">
@@ -14,13 +14,15 @@
         <status_change date="2014-07-09T11:48:47.285-04:00">DRAFT</status_change>
         <status_change date="2014-07-28T04:00:27.738-04:00">INTERIM</status_change>
         <status_change date="2014-08-18T04:02:46.796-04:00">ACCEPTED</status_change>
+        <modified comment="EDITED oval:org.mitre.oval:def:15459 - Removed criterion checking for the unix family, as this causes a false-positive when the rpm_test is not applicable." date="2018-01-19T10:23:00.000-05:00">
+          <contributor organization="Joval">David A. Solin</contributor>
+        </modified>
       </dates>
       <status>ACCEPTED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>
   <criteria>
-    <criterion comment="the installed operating system is part of the Unix family" test_ref="oval:org.mitre.oval:tst:4424" />
     <criterion comment="CentOS Linux 7.x is installed" test_ref="oval:org.mitre.oval:tst:115369" />
   </criteria>
 </definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_25183.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_25183.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:25183" version="13">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:25183" version="14">
   <metadata>
     <title>Oracle Linux 7.x</title>
     <affected family="unix">
@@ -14,13 +14,15 @@
         <status_change date="2014-07-23T11:44:52.851-04:00">DRAFT</status_change>
         <status_change date="2014-08-11T04:00:56.441-04:00">INTERIM</status_change>
         <status_change date="2014-09-01T04:03:01.933-04:00">ACCEPTED</status_change>
+        <modified comment="EDITED oval:org.mitre.oval:def:25183 - Removed criterion checking for the unix family, as this causes a false-positive when the rpm_test is not applicable." date="2018-01-19T10:23:00.000-05:00">
+          <contributor organization="Joval">David A. Solin</contributor>
+        </modified>
       </dates>
       <status>ACCEPTED</status>
       <min_schema_version>5.3</min_schema_version>
     </oval_repository>
   </metadata>
   <criteria>
-    <criterion comment="the installed operating system is part of the Unix family" test_ref="oval:org.mitre.oval:tst:4424" />
     <criterion comment="Oracle Linux 7.x is installed" test_ref="oval:org.mitre.oval:tst:115464" />
   </criteria>
 </definition>


### PR DESCRIPTION
The schema documentation for the ResultEnumeration entry "not applicable" states:

> Another example would be in trying to collect RPM information on a linux system that does not have the RPM packaging system installed.

With this in mind, six inventory definitions for CentOS and Oracle Linux return false-positives on Linux machines without RPM (e.g., Ubuntu).  By removing the unnecessary criterion for family_test==unix, these definitions can return a "not applicable" result instead of a "true" result.