### PR TITLE
Office 2016 inventories

### DIFF
--- a/repository/definitions/inventory/oval_org.cisecurity_def_746.xml
+++ b/repository/definitions/inventory/oval_org.cisecurity_def_746.xml
@@ -1,32 +1,32 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.cisecurity:def:746" version="53">
-  <metadata>
-    <title>Microsoft Office 2016 is installed</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="cpe:/a:microsoft:office:2016" source="CPE" />
-    <description>Microsoft Office 2016 is installed on the system</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2016-05-19T19:00:00+08:00">
-          <contributor organization="The Depository Trust and Clearing Corporation">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2016-05-27T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2016-06-13T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2016-07-01T12:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria>
-    <criterion comment="Microsoft Office 2016 is installed on the system" test_ref="oval:org.cisecurity:tst:1206" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" deprecated="true" id="oval:org.cisecurity:def:746" version="53">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office 2016 is installed</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="cpe:/a:microsoft:office:2016" source="CPE" />
+    <oval-def:description>Microsoft Office 2016 is installed on the system</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-05-19T19:00:00+08:00">
+          <oval-def:contributor organization="The Depository Trust and Clearing Corporation">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2016-05-27T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2016-06-13T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2016-07-01T12:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criterion comment="Microsoft Office 2016 is installed on the system" test_ref="oval:org.cisecurity:tst:1206" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1450.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1450.xml
@@ -1,60 +1,60 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:1450" version="9">
-  <metadata>
-    <title>Microsoft Office Memory Corruption Vulnerability – CVE-2016-7245 (MS16-133)</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2016-7245" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7245" source="CVE" />
-    <description>Microsoft Office 2007 SP3, Office 2010 SP2, Office 2013 SP1, Office 2013 RT SP1, and Office 2016 allow remote attackers to execute arbitrary code via a crafted Office document, aka "Microsoft Office Memory Corruption Vulnerability."</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2016-11-25T23:00:00+08:00">
-          <contributor organization="DTCC">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2016-11-25T21:49:32.600-04:00">DRAFT</status_change>
-        <status_change date="2016-12-09T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2016-12-23T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criterion comment="Check if the version of vbe6.dll is less than 6.05.1057" test_ref="oval:org.cisecurity:tst:2110" />
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 SP2" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criterion comment="Check if the version of vbe7.dll is less than 7.00.1640" test_ref="oval:org.cisecurity:tst:2107" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 SP1" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if the version of vbe7.dll is less than 7.01.1056" test_ref="oval:org.cisecurity:tst:2106" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if the version of vbe7.dll is less than 7.01.1056" test_ref="oval:org.cisecurity:tst:2106" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:1450" version="9">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Memory Corruption Vulnerability – CVE-2016-7245 (MS16-133)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-7245" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7245" source="CVE" />
+    <oval-def:description>Microsoft Office 2007 SP3, Office 2010 SP2, Office 2013 SP1, Office 2013 RT SP1, and Office 2016 allow remote attackers to execute arbitrary code via a crafted Office document, aka "Microsoft Office Memory Corruption Vulnerability."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-11-25T23:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2016-11-25T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2016-12-09T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2016-12-23T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criterion comment="Check if the version of vbe6.dll is less than 6.05.1057" test_ref="oval:org.cisecurity:tst:2110" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 SP2" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if the version of vbe7.dll is less than 7.00.1640" test_ref="oval:org.cisecurity:tst:2107" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 SP1" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if the version of vbe7.dll is less than 7.01.1056" test_ref="oval:org.cisecurity:tst:2106" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if the version of vbe7.dll is less than 7.01.1056" test_ref="oval:org.cisecurity:tst:2106" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1638.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1638.xml
@@ -1,49 +1,49 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:1638" version="12">
-  <metadata>
-    <title>Microsoft Office OLE DLL Side Loading Vulnerability – CVE-2016-7275 (MS16-148)</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2016-7275" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7275" source="CVE" />
-    <description>Microsoft Office 2010 SP2, 2013 SP1, 2013 RT SP1, and 2016 mishandles library loading, which allows local users to gain privileges via a crafted application, aka "Microsoft Office OLE DLL Side Loading Vulnerability."</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2016-12-21T15:46:01+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2016-12-23T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-01-06T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-01-20T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      <criterion comment="Check if Mso.dll version is less than 14.0.7177.5000" test_ref="oval:org.cisecurity:tst:2319" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if Mso.dll version is less than 15.0.4885.1000" test_ref="oval:org.cisecurity:tst:2321" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if Mso.dll version is less than 16.0.4471.1000" test_ref="oval:org.cisecurity:tst:2320" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:1638" version="12">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office OLE DLL Side Loading Vulnerability – CVE-2016-7275 (MS16-148)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-7275" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7275" source="CVE" />
+    <oval-def:description>Microsoft Office 2010 SP2, 2013 SP1, 2013 RT SP1, and 2016 mishandles library loading, which allows local users to gain privileges via a crafted application, aka "Microsoft Office OLE DLL Side Loading Vulnerability."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-12-21T15:46:01+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2016-12-23T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-01-06T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-01-20T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 14.0.7177.5000" test_ref="oval:org.cisecurity:tst:2319" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if Mso.dll version is less than 15.0.4885.1000" test_ref="oval:org.cisecurity:tst:2321" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 16.0.4471.1000" test_ref="oval:org.cisecurity:tst:2320" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_1684.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_1684.xml
@@ -1,32 +1,32 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:1684" version="8">
-  <metadata>
-    <title>Microsoft Office Memory Corruption Vulnerability – CVE-2016-7277 (MS16-148)</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2016-7277" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7277" source="CVE" />
-    <description>Microsoft Office 2016 allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted document, aka "Microsoft Office Memory Corruption Vulnerability."</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-01-03T14:37:53+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2017-01-06T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-01-20T12:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-02-03T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-    <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-    <criterion comment="Check if Mso.dll version is less than 16.0.4471.1000" test_ref="oval:org.cisecurity:tst:2402" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:1684" version="8">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Memory Corruption Vulnerability – CVE-2016-7277 (MS16-148)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-7277" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7277" source="CVE" />
+    <oval-def:description>Microsoft Office 2016 allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted document, aka "Microsoft Office Memory Corruption Vulnerability."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-01-03T14:37:53+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-01-06T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-01-20T12:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-02-03T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+    <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+    <oval-def:criterion comment="Check if Mso.dll version is less than 16.0.4471.1000" test_ref="oval:org.cisecurity:tst:2402" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2160.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2160.xml
@@ -1,90 +1,90 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2160" version="12">
-  <metadata>
-    <title>Microsoft Office/WordPad Remote Code Execution Vulnerability w/Windows API – CVE-2017-0199</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-0199" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0199" source="CVE" />
-    <description>Microsoft Office 2007 SP3, Microsoft Office 2010 SP2, Microsoft Office 2013 SP1, Microsoft Office 2016, Microsoft Windows Vista SP2, Windows Server 2008 SP2, Windows 7 SP1, Windows 8.1 allow remote attackers to execute arbitrary code via a crafted document, aka "Microsoft Office/WordPad Remote Code Execution Vulnerability w/Windows API."</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-04-18T00:00:00+08:00">
-          <contributor organization="DTCC">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2017-04-21T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-05-05T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-05-19T12:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="MS OS/Office + vulnerable version" operator="OR">
-    <criteria comment="MS Office + vulnerable version" operator="OR">
-      <criteria comment="MSO 2007 SP3 + vulnerable version" operator="AND">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <criterion comment="Check if the version of mso.dll is less than 12.0.6766.5000" test_ref="oval:org.cisecurity:tst:2957" />
-      </criteria>
-      <criteria comment="MS Office 2010 + vulnerable version" operator="AND">
-        <criteria comment="MSO 2010 SP2" operator="OR">
-          <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-          <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-        </criteria>
-        <criterion comment="Check if the version of mso.dll is less than 14.0.7180.5000" test_ref="oval:org.cisecurity:tst:2955" />
-      </criteria>
-      <criteria comment="MS Office 2013 + vulnerable version" operator="AND">
-        <criteria comment="MSO 2013 SP1" operator="OR">
-          <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-          <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-        </criteria>
-        <criterion comment="Check if the version of mso.dll is less than 15.0.4919.1000" test_ref="oval:org.cisecurity:tst:2959" />
-      </criteria>
-      <criteria comment="MS Office 2016 + vulnerable version" operator="AND">
-        <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-        <criterion comment="Check if the version of msointl30.dll is less than 16.0.4309.1000" test_ref="oval:org.cisecurity:tst:2963" />
-      </criteria>
-    </criteria>
-    <criteria comment="MS OS + vulnerable wordpad version" operator="OR">
-      <criteria comment="Vista/2008 + file version" operator="AND">
-        <criteria comment="Vista/2008" operator="OR">
-          <extend_definition comment="Microsoft Windows Vista (32-bit) Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:6124" />
-          <extend_definition comment="Microsoft Windows Vista x64 Edition Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:5594" />
-          <extend_definition comment="Microsoft Windows Server 2008 (32-bit) Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:5653" />
-          <extend_definition comment="Microsoft Windows Server 2008 x64 Edition Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:6216" />
-          <extend_definition comment="Microsoft Windows Server 2008 Itanium-Based Edition Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:6150" />
-        </criteria>
-        <criteria comment="file version" operator="OR">
-          <criterion comment="Check if the version of Wordpad.exe is less than 6.0.6002.19755" test_ref="oval:org.cisecurity:tst:2961" />
-          <criteria comment="LDR" operator="AND">
-            <criterion comment="Check if the version of Wordpad.exe is less than 6.0.6002.24078" test_ref="oval:org.cisecurity:tst:2960" />
-            <criterion comment="Check if the version of Wordpad.exe is greater than or equal to 6.0.6002.24000" test_ref="oval:org.cisecurity:tst:2962" />
-          </criteria>
-        </criteria>
-      </criteria>
-      <criteria comment="Win7/2008 R2 + file version" operator="AND">
-        <criteria comment="Win7/2008 R2" operator="OR">
-          <extend_definition comment="Microsoft Windows 7 (32-bit) Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:12292" />
-          <extend_definition comment="Microsoft Windows 7 x64 Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:12627" />
-          <extend_definition comment="Microsoft Windows Server 2008 R2 x64 Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:12567" />
-          <extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:12583" />
-        </criteria>
-        <criteria comment="file version">
-          <criterion comment="Check if the version of Wordpad.exe is less than 6.1.7601.23714" test_ref="oval:org.cisecurity:tst:2956" />
-        </criteria>
-      </criteria>
-      <criteria comment="2012 + file version" operator="AND">
-        <extend_definition comment="Microsoft Windows Server 2012 is installed" definition_ref="oval:org.mitre.oval:def:16359" />
-        <criterion comment="Check if the version of Wordpad.exe is less than 6.2.9200.22106" test_ref="oval:org.cisecurity:tst:2958" />
-      </criteria>
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2160" version="12">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office/WordPad Remote Code Execution Vulnerability w/Windows API – CVE-2017-0199</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-0199" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0199" source="CVE" />
+    <oval-def:description>Microsoft Office 2007 SP3, Microsoft Office 2010 SP2, Microsoft Office 2013 SP1, Microsoft Office 2016, Microsoft Windows Vista SP2, Windows Server 2008 SP2, Windows 7 SP1, Windows 8.1 allow remote attackers to execute arbitrary code via a crafted document, aka "Microsoft Office/WordPad Remote Code Execution Vulnerability w/Windows API."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-04-18T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-04-21T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-05-05T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-05-19T12:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="MS OS/Office + vulnerable version" operator="OR">
+    <oval-def:criteria comment="MS Office + vulnerable version" operator="OR">
+      <oval-def:criteria comment="MSO 2007 SP3 + vulnerable version" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:criterion comment="Check if the version of mso.dll is less than 12.0.6766.5000" test_ref="oval:org.cisecurity:tst:2957" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="MS Office 2010 + vulnerable version" operator="AND">
+        <oval-def:criteria comment="MSO 2010 SP2" operator="OR">
+          <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+          <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+        </oval-def:criteria>
+        <oval-def:criterion comment="Check if the version of mso.dll is less than 14.0.7180.5000" test_ref="oval:org.cisecurity:tst:2955" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="MS Office 2013 + vulnerable version" operator="AND">
+        <oval-def:criteria comment="MSO 2013 SP1" operator="OR">
+          <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+          <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+        </oval-def:criteria>
+        <oval-def:criterion comment="Check if the version of mso.dll is less than 15.0.4919.1000" test_ref="oval:org.cisecurity:tst:2959" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="MS Office 2016 + vulnerable version" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+        <oval-def:criterion comment="Check if the version of msointl30.dll is less than 16.0.4309.1000" test_ref="oval:org.cisecurity:tst:2963" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="MS OS + vulnerable wordpad version" operator="OR">
+      <oval-def:criteria comment="Vista/2008 + file version" operator="AND">
+        <oval-def:criteria comment="Vista/2008" operator="OR">
+          <oval-def:extend_definition comment="Microsoft Windows Vista (32-bit) Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:6124" />
+          <oval-def:extend_definition comment="Microsoft Windows Vista x64 Edition Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:5594" />
+          <oval-def:extend_definition comment="Microsoft Windows Server 2008 (32-bit) Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:5653" />
+          <oval-def:extend_definition comment="Microsoft Windows Server 2008 x64 Edition Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:6216" />
+          <oval-def:extend_definition comment="Microsoft Windows Server 2008 Itanium-Based Edition Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:6150" />
+        </oval-def:criteria>
+        <oval-def:criteria comment="file version" operator="OR">
+          <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.0.6002.19755" test_ref="oval:org.cisecurity:tst:2961" />
+          <oval-def:criteria comment="LDR" operator="AND">
+            <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.0.6002.24078" test_ref="oval:org.cisecurity:tst:2960" />
+            <oval-def:criterion comment="Check if the version of Wordpad.exe is greater than or equal to 6.0.6002.24000" test_ref="oval:org.cisecurity:tst:2962" />
+          </oval-def:criteria>
+        </oval-def:criteria>
+      </oval-def:criteria>
+      <oval-def:criteria comment="Win7/2008 R2 + file version" operator="AND">
+        <oval-def:criteria comment="Win7/2008 R2" operator="OR">
+          <oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:12292" />
+          <oval-def:extend_definition comment="Microsoft Windows 7 x64 Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:12627" />
+          <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 x64 Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:12567" />
+          <oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition Service Pack 1 is installed" definition_ref="oval:org.mitre.oval:def:12583" />
+        </oval-def:criteria>
+        <oval-def:criteria comment="file version">
+          <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.1.7601.23714" test_ref="oval:org.cisecurity:tst:2956" />
+        </oval-def:criteria>
+      </oval-def:criteria>
+      <oval-def:criteria comment="2012 + file version" operator="AND">
+        <oval-def:extend_definition comment="Microsoft Windows Server 2012 is installed" definition_ref="oval:org.mitre.oval:def:16359" />
+        <oval-def:criterion comment="Check if the version of Wordpad.exe is less than 6.2.9200.22106" test_ref="oval:org.cisecurity:tst:2958" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2332.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2332.xml
@@ -1,62 +1,62 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2332" version="9">
-  <metadata>
-    <title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-0262</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-0262" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0262" source="CVE" />
-    <description>Microsoft Office 2010 SP2, Office 2013 SP1, and Office 2016 allow a remote code execution vulnerability when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-0261 and CVE-2017-0281.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-05-15T18:43:59+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2017-05-19T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-06-02T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-06-16T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2010.1400.0000.0000" test_ref="oval:org.cisecurity:tst:1256" />
-        <criterion comment="Check if epsimp32.flt version is less than 2010.1400.7181.5002" test_ref="oval:org.cisecurity:tst:3132" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1500.0000.0000" test_ref="oval:org.cisecurity:tst:1257" />
-        <criterion comment="Check if epsimp32.flt version is less than 2012.1500.4927.1002" test_ref="oval:org.cisecurity:tst:3130" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1600.0000.0000" test_ref="oval:org.cisecurity:tst:1251" />
-        <criterion comment="Check if epsimp32.flt version is less than 2012.1600.4534.1002" test_ref="oval:org.cisecurity:tst:3131" />
-      </criteria>
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2332" version="9">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-0262</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-0262" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0262" source="CVE" />
+    <oval-def:description>Microsoft Office 2010 SP2, Office 2013 SP1, and Office 2016 allow a remote code execution vulnerability when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-0261 and CVE-2017-0281.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-05-15T18:43:59+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-05-19T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-06-02T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-06-16T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2010.1400.0000.0000" test_ref="oval:org.cisecurity:tst:1256" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2010.1400.7181.5002" test_ref="oval:org.cisecurity:tst:3132" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1500.0000.0000" test_ref="oval:org.cisecurity:tst:1257" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2012.1500.4927.1002" test_ref="oval:org.cisecurity:tst:3130" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1600.0000.0000" test_ref="oval:org.cisecurity:tst:1251" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2012.1600.4534.1002" test_ref="oval:org.cisecurity:tst:3131" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2333.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2333.xml
@@ -1,62 +1,62 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2333" version="9">
-  <metadata>
-    <title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-0261</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-0261" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0261" source="CVE" />
-    <description>Microsoft Office 2010 SP2, Office 2013 SP1, and Office 2016 allow a remote code execution vulnerability when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-0262 and CVE-2017-0281.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-05-15T18:43:59+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2017-05-19T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-06-02T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-06-16T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2010.1400.0000.0000" test_ref="oval:org.cisecurity:tst:1256" />
-        <criterion comment="Check if epsimp32.flt version is less than 2010.1400.7181.5002" test_ref="oval:org.cisecurity:tst:3132" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1500.0000.0000" test_ref="oval:org.cisecurity:tst:1257" />
-        <criterion comment="Check if epsimp32.flt version is less than 2012.1500.4927.1002" test_ref="oval:org.cisecurity:tst:3130" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1600.0000.0000" test_ref="oval:org.cisecurity:tst:1251" />
-        <criterion comment="Check if epsimp32.flt version is less than 2012.1600.4534.1002" test_ref="oval:org.cisecurity:tst:3131" />
-      </criteria>
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2333" version="9">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-0261</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-0261" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0261" source="CVE" />
+    <oval-def:description>Microsoft Office 2010 SP2, Office 2013 SP1, and Office 2016 allow a remote code execution vulnerability when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-0262 and CVE-2017-0281.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-05-15T18:43:59+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-05-19T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-06-02T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-06-16T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2010.1400.0000.0000" test_ref="oval:org.cisecurity:tst:1256" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2010.1400.7181.5002" test_ref="oval:org.cisecurity:tst:3132" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1500.0000.0000" test_ref="oval:org.cisecurity:tst:1257" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2012.1500.4927.1002" test_ref="oval:org.cisecurity:tst:3130" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1600.0000.0000" test_ref="oval:org.cisecurity:tst:1251" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2012.1600.4534.1002" test_ref="oval:org.cisecurity:tst:3131" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2394.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2394.xml
@@ -1,93 +1,93 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2394" version="8">
-  <metadata>
-    <title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-0281</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Online Server 2016</product>
-      <product>Microsoft Office Web Apps 2010</product>
-      <product>Microsoft Office Web Apps 2013</product>
-      <product>Microsoft Project Server 2013</product>
-      <product>Microsoft SharePoint Enterprise Server 2013</product>
-      <product>Microsoft SharePoint Enterprise Server 2016</product>
-      <product>Microsoft SharePoint Server 2010</product>
-      <product>Microsoft Word 2016</product>
-      <product>Skype for Business 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-0281" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0281" source="CVE" />
-    <description>Microsoft Office 2007 SP3, Office 2010 SP2, Office 2013 SP1, Office 2016, Office Online Server 2016, Office Web Apps 2010 SP2,Office Web Apps 2013 SP1, Project Server 2013 SP1, SharePoint Enterprise Server 2013 SP1, SharePoint Enterprise Server 2016, SharePoint Foundation 2013 SP1, Sharepoint Server 2010 SP2, Word 2016, and Skype for Business 2016 allow a remote code execution vulnerability when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-0261 and CVE-2017-0262.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-05-24T09:18:06+00:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2017-05-26T21:49:32.600-04:00">DRAFT</status_change>
-        <status_change date="2017-06-09T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-06-23T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if Mso.dll version is less than 12.0.6768.5000" test_ref="oval:org.cisecurity:tst:3267" />
-        <criterion comment="Check if riched20.dll version is less than 12.0.6768.5000" test_ref="oval:org.cisecurity:tst:3265" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      <criterion comment="Check if Mso.dll version is less than 14.0.7181.5000" test_ref="oval:org.cisecurity:tst:3266" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if Mso.dll version is less than 15.0.4927.1000" test_ref="oval:org.cisecurity:tst:3270" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if Mso.dll version is less than 16.0.4534.1000" test_ref="oval:org.cisecurity:tst:3268" />
-        <criterion comment="Check if mso99lres.dll version is less than 16.0.4519.1000" test_ref="oval:org.cisecurity:tst:3271" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Web Apps 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Web Apps 2010 Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:19186" />
-      <criterion comment="Check if msoserver.dll version is less than 14.0.7181.5000" test_ref="oval:org.cisecurity:tst:3257" />
-    </criteria>
-    <criteria comment="Microsoft Office Web Apps 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Web Apps Server 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24530" />
-      <criterion comment="Check if msoserver.dll version is less than 15.0.4927.1000" test_ref="oval:org.cisecurity:tst:3248" />
-    </criteria>
-    <criteria comment="Microsoft Project Server 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Project Server 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24784" />
-      <criterion comment="Check if microsoft.office.project.server.pwa.applicationpages.dll version is less than 15.0.4919.1000" test_ref="oval:org.cisecurity:tst:3272" />
-    </criteria>
-    <criteria comment="Microsoft Sharepoint Server 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft SharePoint Server 2010 Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:18921" />
-      <criterion comment="Check if sword.dll version is less than 14.0.7181.5000" test_ref="oval:org.cisecurity:tst:3246" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4534.1000" test_ref="oval:org.cisecurity:tst:3239" />
-    </criteria>
-    <criteria comment="Skype for Business 2016 + file version" operator="AND">
-      <extend_definition comment="Skype for Business 2016 is installed" definition_ref="oval:org.cisecurity:def:488" />
-      <criterion comment="Check if lynchtmlconv.exe version is less than 16.0.4366.1000" test_ref="oval:org.cisecurity:tst:3269" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2394" version="8">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-0281</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Online Server 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Web Apps 2010</oval-def:product>
+      <oval-def:product>Microsoft Office Web Apps 2013</oval-def:product>
+      <oval-def:product>Microsoft Project Server 2013</oval-def:product>
+      <oval-def:product>Microsoft SharePoint Enterprise Server 2013</oval-def:product>
+      <oval-def:product>Microsoft SharePoint Enterprise Server 2016</oval-def:product>
+      <oval-def:product>Microsoft SharePoint Server 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+      <oval-def:product>Skype for Business 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-0281" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0281" source="CVE" />
+    <oval-def:description>Microsoft Office 2007 SP3, Office 2010 SP2, Office 2013 SP1, Office 2016, Office Online Server 2016, Office Web Apps 2010 SP2,Office Web Apps 2013 SP1, Project Server 2013 SP1, SharePoint Enterprise Server 2013 SP1, SharePoint Enterprise Server 2016, SharePoint Foundation 2013 SP1, Sharepoint Server 2010 SP2, Word 2016, and Skype for Business 2016 allow a remote code execution vulnerability when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-0261 and CVE-2017-0262.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-05-24T09:18:06+00:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-05-26T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-06-09T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-06-23T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if Mso.dll version is less than 12.0.6768.5000" test_ref="oval:org.cisecurity:tst:3267" />
+        <oval-def:criterion comment="Check if riched20.dll version is less than 12.0.6768.5000" test_ref="oval:org.cisecurity:tst:3265" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 14.0.7181.5000" test_ref="oval:org.cisecurity:tst:3266" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if Mso.dll version is less than 15.0.4927.1000" test_ref="oval:org.cisecurity:tst:3270" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if Mso.dll version is less than 16.0.4534.1000" test_ref="oval:org.cisecurity:tst:3268" />
+        <oval-def:criterion comment="Check if mso99lres.dll version is less than 16.0.4519.1000" test_ref="oval:org.cisecurity:tst:3271" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Web Apps 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Web Apps 2010 Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:19186" />
+      <oval-def:criterion comment="Check if msoserver.dll version is less than 14.0.7181.5000" test_ref="oval:org.cisecurity:tst:3257" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Web Apps 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Web Apps Server 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24530" />
+      <oval-def:criterion comment="Check if msoserver.dll version is less than 15.0.4927.1000" test_ref="oval:org.cisecurity:tst:3248" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Project Server 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Project Server 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24784" />
+      <oval-def:criterion comment="Check if microsoft.office.project.server.pwa.applicationpages.dll version is less than 15.0.4919.1000" test_ref="oval:org.cisecurity:tst:3272" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Sharepoint Server 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SharePoint Server 2010 Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:18921" />
+      <oval-def:criterion comment="Check if sword.dll version is less than 14.0.7181.5000" test_ref="oval:org.cisecurity:tst:3246" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4534.1000" test_ref="oval:org.cisecurity:tst:3239" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Skype for Business 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Skype for Business 2016 is installed" definition_ref="oval:org.cisecurity:def:488" />
+      <oval-def:criterion comment="Check if lynchtmlconv.exe version is less than 16.0.4366.1000" test_ref="oval:org.cisecurity:tst:3269" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2729.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2729.xml
@@ -1,61 +1,61 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2729" version="6">
-  <metadata>
-    <title>Office Remote Code Execution Vulnerability - CVE-2017-8510</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-8510" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8510" source="CVE" />
-    <description>A remote code execution vulnerability exists in Microsoft Office when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-8509, CVE-2017-8511, CVE-2017-8512, CVE-2017-0260, and CVE-2017-8506.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-07-05T22:45:38+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criterion comment="Check if Pictim32.flt version is less than 2006.1200.6769.5000" test_ref="oval:org.cisecurity:tst:3631" />
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2010.1400.4740.1000" test_ref="oval:org.cisecurity:tst:3635" />
-        <criterion comment="Check if epsimp32.flt version is less than 2010.1400.7182.5000" test_ref="oval:org.cisecurity:tst:3632" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if epsimp32.flt version is less than 2012.1500.4454.1000" test_ref="oval:org.cisecurity:tst:3634" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if epsimp32.flt version is less than 2012.1600.8201.1003" test_ref="oval:org.cisecurity:tst:3633" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2729" version="6">
+  <oval-def:metadata>
+    <oval-def:title>Office Remote Code Execution Vulnerability - CVE-2017-8510</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-8510" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8510" source="CVE" />
+    <oval-def:description>A remote code execution vulnerability exists in Microsoft Office when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-8509, CVE-2017-8511, CVE-2017-8512, CVE-2017-0260, and CVE-2017-8506.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-07-05T22:45:38+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criterion comment="Check if Pictim32.flt version is less than 2006.1200.6769.5000" test_ref="oval:org.cisecurity:tst:3631" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2010.1400.4740.1000" test_ref="oval:org.cisecurity:tst:3635" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2010.1400.7182.5000" test_ref="oval:org.cisecurity:tst:3632" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if epsimp32.flt version is less than 2012.1500.4454.1000" test_ref="oval:org.cisecurity:tst:3634" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if epsimp32.flt version is less than 2012.1600.8201.1003" test_ref="oval:org.cisecurity:tst:3633" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2730.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2730.xml
@@ -1,53 +1,53 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2730" version="7">
-  <metadata>
-    <title>Office Remote Code Execution Vulnerability - CVE-2017-8506</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-8506" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8506" source="CVE" />
-    <description>A remote code execution vulnerability exists in Microsoft Office when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-8509, CVE-2017-8510, CVE-2017-8511, CVE-2017-8512, and CVE-2017-0260.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-07-14T23:09:27+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criterion comment="Check if outlook.exe version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:3637" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if outlook.exe version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:3638" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if outlook.exe version is less than 16.0.4549.1002" test_ref="oval:org.cisecurity:tst:3636" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2730" version="7">
+  <oval-def:metadata>
+    <oval-def:title>Office Remote Code Execution Vulnerability - CVE-2017-8506</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-8506" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8506" source="CVE" />
+    <oval-def:description>A remote code execution vulnerability exists in Microsoft Office when the software fails to properly handle objects in memory, aka "Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-8509, CVE-2017-8510, CVE-2017-8511, CVE-2017-8512, and CVE-2017-0260.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-07-14T23:09:27+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if outlook.exe version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:3637" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if outlook.exe version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:3638" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if outlook.exe version is less than 16.0.4549.1002" test_ref="oval:org.cisecurity:tst:3636" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2731.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2731.xml
@@ -1,58 +1,58 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2731" version="7">
-  <metadata>
-    <title>Office Remote Code Execution Vulnerability - CVE-2017-8507</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-8507" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8507" source="CVE" />
-    <description>A remote code execution vulnerability exists in the way Microsoft Office software parses specially crafted email messages, aka "Microsoft Office Memory Corruption Vulnerability". </description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-07-14T23:09:27+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criterion comment="Check if outlook.exe version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:3639" />
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criterion comment="Check if outlook.exe version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:3642" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if outlook.exe version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:3641" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if outlook.exe version is less than 16.0.4549.1002" test_ref="oval:org.cisecurity:tst:3640" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2731" version="7">
+  <oval-def:metadata>
+    <oval-def:title>Office Remote Code Execution Vulnerability - CVE-2017-8507</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-8507" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8507" source="CVE" />
+    <oval-def:description>A remote code execution vulnerability exists in the way Microsoft Office software parses specially crafted email messages, aka "Microsoft Office Memory Corruption Vulnerability". </oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-07-14T23:09:27+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criterion comment="Check if outlook.exe version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:3639" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if outlook.exe version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:3642" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if outlook.exe version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:3641" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if outlook.exe version is less than 16.0.4549.1002" test_ref="oval:org.cisecurity:tst:3640" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2732.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2732.xml
@@ -1,58 +1,58 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2732" version="7">
-  <metadata>
-    <title>Office Remote Code Execution Vulnerability - CVE-2017-8508</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-8508" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8508" source="CVE" />
-    <description>A security feature bypass vulnerability exists in Microsoft Office software when it improperly handles the parsing of file formats, aka "Microsoft Office Security Feature Bypass Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-07-14T23:09:27+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criterion comment="Check if outlook.exe version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:3643" />
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criterion comment="Check if outlook.exe version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:3645" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if outlook.exe version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:3646" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if outlook.exe version is less than 16.0.4549.1002" test_ref="oval:org.cisecurity:tst:3644" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2732" version="7">
+  <oval-def:metadata>
+    <oval-def:title>Office Remote Code Execution Vulnerability - CVE-2017-8508</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-8508" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8508" source="CVE" />
+    <oval-def:description>A security feature bypass vulnerability exists in Microsoft Office software when it improperly handles the parsing of file formats, aka "Microsoft Office Security Feature Bypass Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-07-14T23:09:27+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criterion comment="Check if outlook.exe version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:3643" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if outlook.exe version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:3645" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if outlook.exe version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:3646" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if outlook.exe version is less than 16.0.4549.1002" test_ref="oval:org.cisecurity:tst:3644" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2738.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2738.xml
@@ -1,54 +1,54 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2738" version="6">
-  <metadata>
-    <title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-8570</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-8570" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8570" source="CVE" />
-    <description>Microsoft Office allows a remote code execution vulnerability due to the way that it handles objects in memory, aka "Microsoft Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-0243.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-07-17T20:21:32+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criterion comment="Check if Mso.dll version is less than 12.0.6772.5000" test_ref="oval:org.cisecurity:tst:3655" />
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      <criterion comment="Check if Mso.dll version is less than 14.0.7184.5000" test_ref="oval:org.cisecurity:tst:3652" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if Mso.dll version is less than 15.0.4945.1001" test_ref="oval:org.cisecurity:tst:3653" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if mso30win32client.dll version is less than 16.0.4561.1002" test_ref="oval:org.cisecurity:tst:3654" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2738" version="6">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-8570</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-8570" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8570" source="CVE" />
+    <oval-def:description>Microsoft Office allows a remote code execution vulnerability due to the way that it handles objects in memory, aka "Microsoft Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-0243.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-07-17T20:21:32+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 12.0.6772.5000" test_ref="oval:org.cisecurity:tst:3655" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 14.0.7184.5000" test_ref="oval:org.cisecurity:tst:3652" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if Mso.dll version is less than 15.0.4945.1001" test_ref="oval:org.cisecurity:tst:3653" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if mso30win32client.dll version is less than 16.0.4561.1002" test_ref="oval:org.cisecurity:tst:3654" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_2739.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_2739.xml
@@ -1,54 +1,54 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2739" version="6">
-  <metadata>
-    <title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-0243</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-0243" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0243" source="CVE" />
-    <description>Microsoft Office allows a remote code execution vulnerability due to the way that it handles objects in memory, aka "Microsoft Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-8570.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-07-17T20:21:32+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criterion comment="Check if Mso.dll version is less than 12.0.6772.5000" test_ref="oval:org.cisecurity:tst:3655" />
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      <criterion comment="Check if Mso.dll version is less than 14.0.7184.5000" test_ref="oval:org.cisecurity:tst:3652" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if Mso.dll version is less than 15.0.4945.1001" test_ref="oval:org.cisecurity:tst:3653" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if mso30win32client.dll version is less than 16.0.4561.1002" test_ref="oval:org.cisecurity:tst:3654" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:2739" version="6">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-0243</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-0243" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0243" source="CVE" />
+    <oval-def:description>Microsoft Office allows a remote code execution vulnerability due to the way that it handles objects in memory, aka "Microsoft Office Remote Code Execution Vulnerability". This CVE ID is unique from CVE-2017-8570.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-07-17T20:21:32+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-07-21T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-08-04T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-08-18T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 12.0.6772.5000" test_ref="oval:org.cisecurity:tst:3655" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 14.0.7184.5000" test_ref="oval:org.cisecurity:tst:3652" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if Mso.dll version is less than 15.0.4945.1001" test_ref="oval:org.cisecurity:tst:3653" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if mso30win32client.dll version is less than 16.0.4561.1002" test_ref="oval:org.cisecurity:tst:3654" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3107.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3107.xml
@@ -1,102 +1,102 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3107" version="8">
-  <metadata>
-    <title>Office Remote Code Execution Vulnerability - CVE-2017-8509</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-8509" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8509" source="CVE" />
-    <description>A security feature bypass vulnerability exists in Microsoft Office software when it improperly handles the parsing of file formats, aka "Microsoft Office Security Feature Bypass Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-09-07T22:21:32+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-09-08T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-09-22T12:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-10-06T12:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criterion comment="Check if Mso.dll version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:4195" />
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criterion comment="Check if wwlibcxm.dll version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:4188" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if mso.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4186" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if mso.dll version is less than 16.0.4549.1001" test_ref="oval:org.cisecurity:tst:4192" />
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if Wordcnv.dll version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:4189" />
-    </criteria>
-    <criteria comment="Microsoft Office Web Apps 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Web Apps 2010 Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:19186" />
-      <criterion comment="Check if msoserver.dll version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:4184" />
-    </criteria>
-    <criteria comment="Microsoft Office Web Apps 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Web Apps 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24530" />
-      <criterion comment="Check if msoserver.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4196" />
-    </criteria>
-    <criteria comment="Microsoft Office Web Apps Server 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Web Apps Server 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24530" />
-      <criterion comment="Check if sword.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4193" />
-    </criteria>
-    <criteria comment="Microsoft Sharepoint Server 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft SharePoint Server 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24462" />
-      <criterion comment="Check if sword.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4191" />
-    </criteria>
-    <criteria comment="Microsoft Sharepoint Server 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft SharePoint Server 2016 is installed" definition_ref="oval:org.cisecurity:def:1708" />
-      <criterion comment="Check if sword.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4197" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:4198" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:4190" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if winword.exe version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4185" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4549.1000" test_ref="oval:org.cisecurity:tst:4194" />
-    </criteria>
-    <criteria comment="Microsoft Sharepoint Server 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft SharePoint Server 2010 Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:18921" />
-      <criterion comment="Check if sword.dll version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:4187" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3107" version="8">
+  <oval-def:metadata>
+    <oval-def:title>Office Remote Code Execution Vulnerability - CVE-2017-8509</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-8509" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8509" source="CVE" />
+    <oval-def:description>A security feature bypass vulnerability exists in Microsoft Office software when it improperly handles the parsing of file formats, aka "Microsoft Office Security Feature Bypass Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-09-07T22:21:32+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-09-08T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-09-22T12:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-10-06T12:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Vulnerable Microsoft Office + file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:4195" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if wwlibcxm.dll version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:4188" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if mso.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4186" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if mso.dll version is less than 16.0.4549.1001" test_ref="oval:org.cisecurity:tst:4192" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if Wordcnv.dll version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:4189" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Web Apps 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Web Apps 2010 Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:19186" />
+      <oval-def:criterion comment="Check if msoserver.dll version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:4184" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Web Apps 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Web Apps 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24530" />
+      <oval-def:criterion comment="Check if msoserver.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4196" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Web Apps Server 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Web Apps Server 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24530" />
+      <oval-def:criterion comment="Check if sword.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4193" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Sharepoint Server 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SharePoint Server 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24462" />
+      <oval-def:criterion comment="Check if sword.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4191" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Sharepoint Server 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SharePoint Server 2016 is installed" definition_ref="oval:org.cisecurity:def:1708" />
+      <oval-def:criterion comment="Check if sword.dll version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4197" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6770.5000" test_ref="oval:org.cisecurity:tst:4198" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:4190" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 15.0.4937.1000" test_ref="oval:org.cisecurity:tst:4185" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4549.1000" test_ref="oval:org.cisecurity:tst:4194" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Sharepoint Server 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SharePoint Server 2010 Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:18921" />
+      <oval-def:criterion comment="Check if sword.dll version is less than 14.0.7182.5000" test_ref="oval:org.cisecurity:tst:4187" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3235.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3235.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3235" version="7">
-  <metadata>
-    <title>Microsoft Office Memory Corruption Vulnerability – CVE-2017-8630</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-8630" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8630" source="CVE" />
-    <description>Microsoft Office 2016 allows a remote code execution vulnerability when it fails to properly handle objects in memory, aka "Microsoft Office Memory Corruption Vulnerability". This CVE ID is unique from CVE-2017-8631, CVE-2017-8632, and CVE-2017-8744.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2016-09-20T16:04:02+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2017-09-22T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-10-06T12:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-10-20T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-    <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-    <criterion comment="Check if oart.dll version is less than 16.0.4588.1000" test_ref="oval:org.cisecurity:tst:4336" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3235" version="7">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Memory Corruption Vulnerability – CVE-2017-8630</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-8630" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8630" source="CVE" />
+    <oval-def:description>Microsoft Office 2016 allows a remote code execution vulnerability when it fails to properly handle objects in memory, aka "Microsoft Office Memory Corruption Vulnerability". This CVE ID is unique from CVE-2017-8631, CVE-2017-8632, and CVE-2017-8744.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-09-20T16:04:02+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-09-22T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-10-06T12:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-10-20T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+    <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+    <oval-def:criterion comment="Check if oart.dll version is less than 16.0.4588.1000" test_ref="oval:org.cisecurity:tst:4336" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3394.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3394.xml
@@ -1,38 +1,38 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3394" version="6">
-  <metadata>
-    <title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-11825</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-11825" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11825" source="CVE" />
-    <description>A remote code execution vulnerability exists in Microsoft Office software when it fails to properly handle objects in memory. An attacker who successfully exploited the vulnerability could use a specially crafted file to perform actions in the security context of the current user. For example, the file could then take actions on behalf of the logged-on user with the same permissions as the current user.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-10-12T22:30:00+08:00">
-          <contributor organization="DTCC">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2017-10-13T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-10-27T11:35:13.104-04:00">INTERIM</status_change>
-        <status_change date="2017-11-10T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="MSO 2016 + file version" operator="AND">
-    <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-    <criteria comment="Win OS + vulnerable file version" operator="OR">
-      <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2200 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:4521" />
-      <criterion comment="Check if oart.dll version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2119 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:4516" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3394" version="6">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Remote Code Execution Vulnerability – CVE-2017-11825</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-11825" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11825" source="CVE" />
+    <oval-def:description>A remote code execution vulnerability exists in Microsoft Office software when it fails to properly handle objects in memory. An attacker who successfully exploited the vulnerability could use a specially crafted file to perform actions in the security context of the current user. For example, the file could then take actions on behalf of the logged-on user with the same permissions as the current user.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-10-12T22:30:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-10-13T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-10-27T11:35:13.104-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-11-10T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="MSO 2016 + file version" operator="AND">
+    <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+    <oval-def:criteria comment="Win OS + vulnerable file version" operator="OR">
+      <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2200 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:4521" />
+      <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2119 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:4516" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3705.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3705.xml
@@ -1,50 +1,50 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3705" version="6">
-  <metadata>
-    <title>Microsoft Office Memory Corruption Vulnerability - CVE-2017-11882</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-11882" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11882" source="CVE" />
-    <description>Microsoft Office 2007 Service Pack 3, Microsoft Office 2010 Service Pack 2, Microsoft Office 2013 Service Pack 1, and Microsoft Office 2016 allow an attacker to run arbitrary code in the context of the current user by failing to properly handle objects in memory, aka "Microsoft Office Memory Corruption Vulnerability". This CVE ID is unique from CVE-2017-11884.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-11-23T21:01:42+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-12-01T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-12-15T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-12-29T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria operator="OR">
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe version is less than 2017.8.14.0" test_ref="oval:org.cisecurity:tst:4951" />
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      <criterion comment="Check if eqnedt32.exe version is less than 2017.8.14.0" test_ref="oval:org.cisecurity:tst:4950" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe version is less than 2017.8.14.0" test_ref="oval:org.cisecurity:tst:4949" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3705" version="6">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Memory Corruption Vulnerability - CVE-2017-11882</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-11882" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11882" source="CVE" />
+    <oval-def:description>Microsoft Office 2007 Service Pack 3, Microsoft Office 2010 Service Pack 2, Microsoft Office 2013 Service Pack 1, and Microsoft Office 2016 allow an attacker to run arbitrary code in the context of the current user by failing to properly handle objects in memory, aka "Microsoft Office Memory Corruption Vulnerability". This CVE ID is unique from CVE-2017-11884.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-11-23T21:01:42+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-12-01T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-12-15T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-12-29T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe version is less than 2017.8.14.0" test_ref="oval:org.cisecurity:tst:4951" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      <oval-def:criterion comment="Check if eqnedt32.exe version is less than 2017.8.14.0" test_ref="oval:org.cisecurity:tst:4950" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe version is less than 2017.8.14.0" test_ref="oval:org.cisecurity:tst:4949" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3714.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3714.xml
@@ -1,38 +1,38 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3714" version="7">
-  <metadata>
-    <title>Microsoft Office Memory Corruption Vulnerability - CVE-2017-11884</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-11884" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11884" source="CVE" />
-    <description>Microsoft Excel 2016 Click-to-Run (C2R) allows an attacker to run arbitrary code in the context of the current user by failing to properly handle objects in memory, aka "Microsoft Office Memory Corruption Vulnerability". This CVE ID is unique from CVE-2017-11882.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-11-28T20:57:23+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-12-01T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-12-15T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-12-29T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="MSO 2016 + file version" operator="AND">
-    <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-    <criteria comment="Win OS + vulnerable file version" operator="OR">
-      <criterion comment="Check if excel.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2209 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:4964" />
-      <criterion comment="Check if excel.exe version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2122 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:4965" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3714" version="7">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Memory Corruption Vulnerability - CVE-2017-11884</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-11884" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11884" source="CVE" />
+    <oval-def:description>Microsoft Excel 2016 Click-to-Run (C2R) allows an attacker to run arbitrary code in the context of the current user by failing to properly handle objects in memory, aka "Microsoft Office Memory Corruption Vulnerability". This CVE ID is unique from CVE-2017-11882.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-11-28T20:57:23+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-12-01T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-12-15T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-12-29T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="MSO 2016 + file version" operator="AND">
+    <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+    <oval-def:criteria comment="Win OS + vulnerable file version" operator="OR">
+      <oval-def:criterion comment="Check if excel.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2209 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:4964" />
+      <oval-def:criterion comment="Check if excel.exe version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2122 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:4965" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3805.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3805.xml
@@ -1,38 +1,38 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3805" version="7">
-  <metadata>
-    <title>Microsoft Excel Remote Code Execution Vulnerability - CVE-2017-11935</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-11935" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11935" source="CVE" />
-    <description>Microsoft Office 2016 Click-to-Run (C2R) allows a remote code execution vulnerability due to the way files are handled in memory, aka "Microsoft Excel Remote Code Execution Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-12-19T19:23:03+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-12-22T10:55:58.360-04:00">DRAFT</status_change>
-        <status_change date="2018-01-05T13:32:25.761-04:00">INTERIM</status_change>
-        <status_change date="2018-01-19T12:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="MSO 2016 + file version" operator="AND">
-    <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-    <criteria comment="Win OS + vulnerable file version" operator="OR">
-      <criterion comment="Check if excel.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2213 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5058" />
-      <criterion comment="Check if excel.exe version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2130 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:5059" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3805" version="7">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Excel Remote Code Execution Vulnerability - CVE-2017-11935</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-11935" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11935" source="CVE" />
+    <oval-def:description>Microsoft Office 2016 Click-to-Run (C2R) allows a remote code execution vulnerability due to the way files are handled in memory, aka "Microsoft Excel Remote Code Execution Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-12-19T19:23:03+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-12-22T10:55:58.360-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-01-05T13:32:25.761-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2018-01-19T12:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="MSO 2016 + file version" operator="AND">
+    <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+    <oval-def:criteria comment="Win OS + vulnerable file version" operator="OR">
+      <oval-def:criterion comment="Check if excel.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2213 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5058" />
+      <oval-def:criterion comment="Check if excel.exe version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2130 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:5059" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3806.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3806.xml
@@ -1,37 +1,37 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3806" version="6">
-  <metadata>
-    <title>Microsoft Office Information Disclosure Vulnerability - CVE-2017-11939</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-11939" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11939" source="CVE" />
-    <description>Microsoft Office 2016 Click-to-Run (C2R) allows an information disclosure vulnerability due to the way Microsoft Office enforces DRM copy/paste permissions, aka "Microsoft Office Information Disclosure Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-12-19T19:23:03+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-12-29T10:55:58.360-04:00">DRAFT</status_change>
-        <status_change date="2018-01-12T13:32:25.761-04:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="MSO 2016 + file version" operator="AND">
-    <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-    <criteria comment="Win OS + vulnerable file version" operator="OR">
-      <criterion comment="Check if outlook.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2213 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5061" />
-      <criterion comment="Check if outlook.exe version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2130 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:5060" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3806" version="6">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Information Disclosure Vulnerability - CVE-2017-11939</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-11939" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11939" source="CVE" />
+    <oval-def:description>Microsoft Office 2016 Click-to-Run (C2R) allows an information disclosure vulnerability due to the way Microsoft Office enforces DRM copy/paste permissions, aka "Microsoft Office Information Disclosure Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-12-19T19:23:03+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-12-29T10:55:58.360-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-01-12T13:32:25.761-04:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="MSO 2016 + file version" operator="AND">
+    <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+    <oval-def:criteria comment="Win OS + vulnerable file version" operator="OR">
+      <oval-def:criterion comment="Check if outlook.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2213 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5061" />
+      <oval-def:criterion comment="Check if outlook.exe version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2130 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:5060" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3822.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3822.xml
@@ -1,47 +1,47 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3822" version="5">
-  <metadata>
-    <title>Microsoft PowerPoint Information Disclosure Vulnerability - CVE-2017-11934</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2017-11934" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11934" source="CVE" />
-    <description>Microsoft Office 2013 RT SP1, Microsoft Office 2013 SP1, and Microsoft Office 2016 allow an information disclosure vulnerability due to the way certain functions handle objects in memory, aka "Microsoft Office Information Disclosure Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-12-19T19:23:03+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-12-29T10:55:58.360-04:00">DRAFT</status_change>
-        <status_change date="2018-01-12T13:32:25.761-04:00">INTERIM</status_change>
-      </dates>
-      <status>INTERIM</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria operator="OR">
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if the version of oart.dll is less than 15.0.4989.1000" test_ref="oval:org.cisecurity:tst:5075" />
-    </criteria>
-    <criteria comment="MSO 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if the version of chart.dll is less than 16.0.4627.1000" test_ref="oval:org.cisecurity:tst:5076" />
-    </criteria>
-    <criteria comment="MSO 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if oart.dll version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2130 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:5077" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3822" version="5">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft PowerPoint Information Disclosure Vulnerability - CVE-2017-11934</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-11934" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11934" source="CVE" />
+    <oval-def:description>Microsoft Office 2013 RT SP1, Microsoft Office 2013 SP1, and Microsoft Office 2016 allow an information disclosure vulnerability due to the way certain functions handle objects in memory, aka "Microsoft Office Information Disclosure Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-12-19T19:23:03+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-12-29T10:55:58.360-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-01-12T13:32:25.761-04:00">INTERIM</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>INTERIM</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if the version of oart.dll is less than 15.0.4989.1000" test_ref="oval:org.cisecurity:tst:5075" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="MSO 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if the version of chart.dll is less than 16.0.4627.1000" test_ref="oval:org.cisecurity:tst:5076" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="MSO 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.7766.0000 and less than 16.0.7766.2130 (MSO 2016 Version 1701)" test_ref="oval:org.cisecurity:tst:5077" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3851.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3851.xml
@@ -1,68 +1,68 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3851" version="4">
-  <metadata>
-    <title>Microsoft Outlook Remote Code Execution Vulnerability – CVE-2018-0793</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0793" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0793" source="CVE" />
-    <description>Microsoft Outlook 2007, Microsoft Outlook 2010, Microsoft Outlook 2013, and Microsoft Outlook 2016 allow a remote code execution vulnerability due to the way email messages are parsed, aka "Microsoft Outlook Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0793.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-11T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-12T13:06:02.462-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      <criterion comment="Check if wwlibcxm.dll version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5121" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5116" />
-        <criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5127" />
-        <criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5123" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3851" version="4">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Outlook Remote Code Execution Vulnerability – CVE-2018-0793</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0793" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0793" source="CVE" />
+    <oval-def:description>Microsoft Outlook 2007, Microsoft Outlook 2010, Microsoft Outlook 2013, and Microsoft Outlook 2016 allow a remote code execution vulnerability due to the way email messages are parsed, aka "Microsoft Outlook Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0793.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-11T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-12T13:06:02.462-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      <oval-def:criterion comment="Check if wwlibcxm.dll version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5121" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5116" />
+        <oval-def:criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5127" />
+        <oval-def:criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5123" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3852.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3852.xml
@@ -1,58 +1,58 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3852" version="5">
-  <metadata>
-    <title>Microsoft Outlook Remote Code Execution Vulnerability – CVE-2018-0791</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Outlook 2007</product>
-      <product>Microsoft Outlook 2010</product>
-      <product>Microsoft Outlook 2013</product>
-      <product>Microsoft Outlook 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0791" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0791" source="CVE" />
-    <description>Microsoft Outlook 2007, Microsoft Outlook 2010, Microsoft Outlook 2013, and Microsoft Outlook 2016 allow a remote code execution vulnerability due to the way email messages are parsed, aka "Microsoft Outlook Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0793.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-11T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-12T13:06:02.462-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Outlook + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Outlook 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Outlook 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:18834" />
-      <criterion comment="Check if Outlook.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5128" />
-    </criteria>
-    <criteria comment="Microsoft Outlook 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Outlook 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:18700" />
-      <criterion comment="Check if Outlook.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5119" />
-    </criteria>
-    <criteria comment="Microsoft Outlook 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Outlook 2013 SP1 is installed" definition_ref="oval:org.cisecurity:def:2167" />
-      <criterion comment="Check if Outlook.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5125" />
-    </criteria>
-    <criteria comment="Microsoft Outlook 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Outlook 2016 is installed" definition_ref="oval:org.cisecurity:def:2166" />
-      <criterion comment="Check if Outlook.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5122" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5116" />
-        <criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5127" />
-        <criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5123" />
-      </criteria>
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3852" version="5">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Outlook Remote Code Execution Vulnerability – CVE-2018-0791</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Outlook 2007</oval-def:product>
+      <oval-def:product>Microsoft Outlook 2010</oval-def:product>
+      <oval-def:product>Microsoft Outlook 2013</oval-def:product>
+      <oval-def:product>Microsoft Outlook 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0791" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0791" source="CVE" />
+    <oval-def:description>Microsoft Outlook 2007, Microsoft Outlook 2010, Microsoft Outlook 2013, and Microsoft Outlook 2016 allow a remote code execution vulnerability due to the way email messages are parsed, aka "Microsoft Outlook Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0793.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-11T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-12T13:06:02.462-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Outlook + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Outlook 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Outlook 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:18834" />
+      <oval-def:criterion comment="Check if Outlook.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5128" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Outlook 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Outlook 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:18700" />
+      <oval-def:criterion comment="Check if Outlook.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5119" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Outlook 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Outlook 2013 SP1 is installed" definition_ref="oval:org.cisecurity:def:2167" />
+      <oval-def:criterion comment="Check if Outlook.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5125" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Outlook 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Outlook 2016 is installed" definition_ref="oval:org.cisecurity:def:2166" />
+      <oval-def:criterion comment="Check if Outlook.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5122" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5116" />
+        <oval-def:criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5127" />
+        <oval-def:criterion comment="Check if Outlook.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5123" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3887.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3887.xml
@@ -1,68 +1,68 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3887" version="4">
-  <metadata>
-    <title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0794</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0794" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0794" source="CVE" />
-    <description>Microsoft Word in Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0792.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-12T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-12T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      <criterion comment="Check if wwlibcxm.dll version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5121" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3887" version="4">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0794</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0794" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0794" source="CVE" />
+    <oval-def:description>Microsoft Word in Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0792.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-12T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-12T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      <oval-def:criterion comment="Check if wwlibcxm.dll version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5121" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3888.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3888.xml
@@ -1,49 +1,49 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3888" version="4">
-  <metadata>
-    <title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0792</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Online Server 2016</product>
-      <product>Microsoft Sharepoint Enterprise Server 2016</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0792" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0792" source="CVE" />
-    <description>Microsoft Word 2016 in Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0794.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-12T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-12T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft SharePoint Server 2016 is installed + file version" operator="AND">
-      <extend_definition comment="Microsoft SharePoint Server 2016 is installed" definition_ref="oval:org.cisecurity:def:1708" />
-      <criterion comment="Check if Sword.dll version is less than 16.0.4639.1002" test_ref="oval:org.cisecurity:tst:5114" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3888" version="4">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0792</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Online Server 2016</oval-def:product>
+      <oval-def:product>Microsoft Sharepoint Enterprise Server 2016</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0792" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0792" source="CVE" />
+    <oval-def:description>Microsoft Word 2016 in Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0794.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-12T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-12T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft SharePoint Server 2016 is installed + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SharePoint Server 2016 is installed" definition_ref="oval:org.cisecurity:def:1708" />
+      <oval-def:criterion comment="Check if Sword.dll version is less than 16.0.4639.1002" test_ref="oval:org.cisecurity:tst:5114" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3889.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3889.xml
@@ -1,79 +1,79 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3889" version="2">
-  <metadata>
-    <title>Microsoft Office Remote Code Execution Vulnerability – CVE-2018-0801</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0801" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0801" source="CVE" />
-    <description>Equation Editor in Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Office Remote Code Execution Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-15T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007/2010/2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2007/2010/2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5180" />
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5179" />
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5181" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3889" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Remote Code Execution Vulnerability – CVE-2018-0801</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0801" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0801" source="CVE" />
+    <oval-def:description>Equation Editor in Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Office Remote Code Execution Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-15T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007/2010/2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2007/2010/2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5180" />
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5179" />
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5181" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3890.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3890.xml
@@ -1,84 +1,84 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3890" version="2">
-  <metadata>
-    <title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0806</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0806" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0806" source="CVE" />
-    <description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0804, CVE-2018-0805, and CVE-2018-0807.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-15T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007/2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2007/2010" operator="OR">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3890" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0806</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0806" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0806" source="CVE" />
+    <oval-def:description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0804, CVE-2018-0805, and CVE-2018-0807.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-15T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007/2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2007/2010" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3891.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3891.xml
@@ -1,84 +1,84 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3891" version="2">
-  <metadata>
-    <title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0805</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0805" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0805" source="CVE" />
-    <description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0804, CVE-2018-0806, and CVE-2018-0807.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-15T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007/2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2007/2010" operator="OR">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3891" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0805</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0805" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0805" source="CVE" />
+    <oval-def:description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0804, CVE-2018-0806, and CVE-2018-0807.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-15T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007/2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2007/2010" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3892.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3892.xml
@@ -1,84 +1,84 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3892" version="2">
-  <metadata>
-    <title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0807</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0807" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0807" source="CVE" />
-    <description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0804, CVE-2018-0805, and CVE-2018-0806.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-15T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007/2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2007/2010" operator="OR">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3892" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0807</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0807" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0807" source="CVE" />
+    <oval-def:description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0804, CVE-2018-0805, and CVE-2018-0806.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-15T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007/2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2007/2010" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3893.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3893.xml
@@ -1,79 +1,79 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3893" version="2">
-  <metadata>
-    <title>Microsoft Word Memory Corruption Vulnerability – CVE-2018-0812</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0812" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0812" source="CVE" />
-    <description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Memory Corruption Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-15T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007/2010/2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2007/2010/2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3893" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Word Memory Corruption Vulnerability – CVE-2018-0812</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0812" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0812" source="CVE" />
+    <oval-def:description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Memory Corruption Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-15T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007/2010/2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2007/2010/2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3894.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3894.xml
@@ -1,79 +1,79 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3894" version="2">
-  <metadata>
-    <title>Microsoft Office Memory Corruption Vulnerability – CVE-2018-0802</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0802" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0802" source="CVE" />
-    <description>Equation Editor in Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allow a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Office Memory Corruption Vulnerability". This CVE is unique from CVE-2018-0797 and CVE-2018-0812.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-15T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007/2010/2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2007/2010/2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5180" />
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5179" />
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5181" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3894" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Memory Corruption Vulnerability – CVE-2018-0802</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0802" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0802" source="CVE" />
+    <oval-def:description>Equation Editor in Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allow a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Office Memory Corruption Vulnerability". This CVE is unique from CVE-2018-0797 and CVE-2018-0812.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-15T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007/2010/2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2007/2010/2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5180" />
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5179" />
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5181" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3895.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3895.xml
@@ -1,79 +1,79 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3895" version="2">
-  <metadata>
-    <title>Microsoft Office Memory Corruption Vulnerability – CVE-2018-0798</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0798" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0798" source="CVE" />
-    <description>Equation Editor in Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Office Memory Corruption Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-15T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007/2010/2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2007/2010/2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5180" />
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5179" />
-        <criterion comment="Check if oart.dll version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5181" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3895" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Memory Corruption Vulnerability – CVE-2018-0798</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0798" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0798" source="CVE" />
+    <oval-def:description>Equation Editor in Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Office Memory Corruption Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-15T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007/2010/2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2007/2010/2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5180" />
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5179" />
+        <oval-def:criterion comment="Check if oart.dll version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5181" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3896.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3896.xml
@@ -1,84 +1,84 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3896" version="2">
-  <metadata>
-    <title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0804</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-      <product>Microsoft Office Compatibility Pack</product>
-      <product>Microsoft Word 2007</product>
-      <product>Microsoft Word 2010</product>
-      <product>Microsoft Word 2013</product>
-      <product>Microsoft Word 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0804" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0804" source="CVE" />
-    <description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0805, CVE-2018-0806, and CVE-2018-0807.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-15T21:47:24+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007/2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2007/2010" operator="OR">
-        <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-        <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      </criteria>
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
-        <criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
-      <extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
-      <criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
-    </criteria>
-    <criteria comment="Microsoft Word 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
-      <criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
-    </criteria>
-    <criteria comment="Microsoft Word 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
-      <criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
-    </criteria>
-    <criteria comment="Microsoft Word 2013 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
-      <criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
-    </criteria>
-    <criteria comment="Microsoft Word 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
-      <criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3896" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Word Remote Code Execution Vulnerability – CVE-2018-0804</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+      <oval-def:product>Microsoft Office Compatibility Pack</oval-def:product>
+      <oval-def:product>Microsoft Word 2007</oval-def:product>
+      <oval-def:product>Microsoft Word 2010</oval-def:product>
+      <oval-def:product>Microsoft Word 2013</oval-def:product>
+      <oval-def:product>Microsoft Word 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0804" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0804" source="CVE" />
+    <oval-def:description>Equation Editor in Microsoft Office 2003, Microsoft Office 2007, Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allows a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Word Remote Code Execution Vulnerability". This CVE is unique from CVE-2018-0805, CVE-2018-0806, and CVE-2018-0807.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-15T21:47:24+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007/2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2007/2010" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5178" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if eqnedt32.exe exists" test_ref="oval:org.cisecurity:tst:5182" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5176" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5175" />
+        <oval-def:criterion comment="Check if winword.exe version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5177" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office Compatibility Pack + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office Compatibility Pack SP3 is installed" definition_ref="oval:org.mitre.oval:def:15035" />
+      <oval-def:criterion comment="Check if wordcnv.dll version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5117" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15946" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 12.0.6784.5000" test_ref="oval:org.cisecurity:tst:5118" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17454" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5124" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2013 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2013 SP1 is installed" definition_ref="oval:org.mitre.oval:def:24680" />
+      <oval-def:criterion comment="Check if winword.exe.exe version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5126" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Word 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Word 2016 is installed" definition_ref="oval:org.cisecurity:def:770" />
+      <oval-def:criterion comment="Check if winword.exe version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5120" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3898.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3898.xml
@@ -1,55 +1,55 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3898" version="2">
-  <metadata>
-    <title>Microsoft Office Remote Code Execution Vulnerability – CVE-2018-0795</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2018-0795" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0795" source="CVE" />
-    <description>Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allow a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Office Remote Code Execution Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-16T20:21:32+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
-      <criterion comment="Check if Mso.dll version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5194" />
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if Mso.dll version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5192" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if Mso.dll version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5196" />
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="file version" operator="OR">
-        <criterion comment="Check if Mso.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5198" />
-        <criterion comment="Check if Mso.dll version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5195" />
-        <criterion comment="Check if Mso.dll version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5185" />
-      </criteria>
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3898" version="2">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Remote Code Execution Vulnerability – CVE-2018-0795</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-0795" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0795" source="CVE" />
+    <oval-def:description>Microsoft Office 2010, Microsoft Office 2013, and Microsoft Office 2016 allow a remote code execution vulnerability due to the way objects are handled in memory, aka "Microsoft Office Remote Code Execution Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-16T20:21:32+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-19T21:49:32.600-04:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 14.0.7192.5000" test_ref="oval:org.cisecurity:tst:5194" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if Mso.dll version is less than 15.0.4997.1000" test_ref="oval:org.cisecurity:tst:5192" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if Mso.dll version is less than 16.0.4639.1000" test_ref="oval:org.cisecurity:tst:5196" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="file version" operator="OR">
+        <oval-def:criterion comment="Check if Mso.dll version is greater than or equal to 16.0.8201.0000 and less than 16.0.8201.2217 (MSO 2016 Version 1705)" test_ref="oval:org.cisecurity:tst:5198" />
+        <oval-def:criterion comment="Check if Mso.dll version is greater than or equal to 16.0.8431.0000 and less than 16.0.8431.2153 (MSO 2016 Version 1708)" test_ref="oval:org.cisecurity:tst:5195" />
+        <oval-def:criterion comment="Check if Mso.dll version is greater than or equal to 16.0.8730.0000 and less than 16.0.8730.2175 (MSO 2016 Version 1711)" test_ref="oval:org.cisecurity:tst:5185" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_768.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_768.xml
@@ -1,43 +1,43 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:768" version="17">
-  <metadata>
-    <title>Microsoft Office Memory Corruption Vulnerability - CVE-2016-0126 (MS16-054)</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2016-0126" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0126" source="CVE" />
-    <description>Microsoft Office 2013 SP1, 2013 RT SP1, and 2016 allows remote attackers to execute arbitrary code via a crafted Office document, aka "Microsoft Office Memory Corruption Vulnerability."</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2016-05-24T17:00:00+08:00">
-          <contributor organization="The Depository Trust and Clearing Corporation">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2016-05-27T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2016-06-13T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2016-07-01T12:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="MS Office 2013/2016 + vulnerable version" operator="OR">
-    <criteria comment="MS Office 2013 + vulnerable version" operator="AND">
-      <criteria comment="MS Office 2013" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criterion comment="Check if the version of mso.dll is less than 15.0.4823.1000" test_ref="oval:org.cisecurity:tst:1237" />
-    </criteria>
-    <criteria comment="MS Office 2016 + vulnerable version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criterion comment="Check if the version of mso40uires.dll is less than 16.0.4297.1000" test_ref="oval:org.cisecurity:tst:1238" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:768" version="17">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Memory Corruption Vulnerability - CVE-2016-0126 (MS16-054)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-0126" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0126" source="CVE" />
+    <oval-def:description>Microsoft Office 2013 SP1, 2013 RT SP1, and 2016 allows remote attackers to execute arbitrary code via a crafted Office document, aka "Microsoft Office Memory Corruption Vulnerability."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-05-24T17:00:00+08:00">
+          <oval-def:contributor organization="The Depository Trust and Clearing Corporation">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2016-05-27T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2016-06-13T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2016-07-01T12:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="MS Office 2013/2016 + vulnerable version" operator="OR">
+    <oval-def:criteria comment="MS Office 2013 + vulnerable version" operator="AND">
+      <oval-def:criteria comment="MS Office 2013" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criterion comment="Check if the version of mso.dll is less than 15.0.4823.1000" test_ref="oval:org.cisecurity:tst:1237" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="MS Office 2016 + vulnerable version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criterion comment="Check if the version of mso40uires.dll is less than 16.0.4297.1000" test_ref="oval:org.cisecurity:tst:1238" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_772.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_772.xml
@@ -1,69 +1,69 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:772" version="17">
-  <metadata>
-    <title>Microsoft Office Malformed EPS File Vulnerability - CVE-2015-2545 (MS15-099)</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <product>Microsoft Office 2007</product>
-      <product>Microsoft Office 2010</product>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
-    </affected>
-    <reference ref_id="CVE-2015-2545" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2545" source="CVE" />
-    <description>Microsoft Office 2007 SP3, 2010 SP2, 2013 SP1, and 2013 RT SP1 allows remote attackers to execute arbitrary code via a crafted EPS image, aka "Microsoft Office Malformed EPS File Vulnerability."</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2016-05-31T21:11:47+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2016-06-13T11:40:32.600-04:00">DRAFT</status_change>
-        <status_change date="2016-07-01T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2016-07-15T11:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
-    <criteria comment="Microsoft Office 2007 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2006.1200.0000.0000" test_ref="oval:org.cisecurity:tst:1253" />
-        <criterion comment="Check if epsimp32.flt version is less than 2006.1200.6736.5000" test_ref="oval:org.cisecurity:tst:1252" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2010 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2010 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
-        <extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
-      </criteria>
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2010.1400.0000.0000" test_ref="oval:org.cisecurity:tst:1256" />
-        <criterion comment="Check if epsimp32.flt version is less than 2010.1400.7162.5001" test_ref="oval:org.cisecurity:tst:1255" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2013 + file version" operator="AND">
-      <criteria comment="Microsoft Office 2013 is installed" operator="OR">
-        <extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
-        <extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
-      </criteria>
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1500.0000.0000" test_ref="oval:org.cisecurity:tst:1257" />
-        <criterion comment="Check if epsimp32.flt version is less than 2012.1500.4753.1002" test_ref="oval:org.cisecurity:tst:1250" />
-      </criteria>
-    </criteria>
-    <criteria comment="Microsoft Office 2016 + file version" operator="AND">
-      <extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:746" />
-      <criteria comment="Check for file version" operator="AND">
-        <criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1600.0000.0000" test_ref="oval:org.cisecurity:tst:1251" />
-        <criterion comment="Check if epsimp32.flt version is less than 2012.1600.4288.1000" test_ref="oval:org.cisecurity:tst:1254" />
-      </criteria>
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:772" version="17">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft Office Malformed EPS File Vulnerability - CVE-2015-2545 (MS15-099)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:product>Microsoft Office 2007</oval-def:product>
+      <oval-def:product>Microsoft Office 2010</oval-def:product>
+      <oval-def:product>Microsoft Office 2013</oval-def:product>
+      <oval-def:product>Microsoft Office 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2015-2545" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2545" source="CVE" />
+    <oval-def:description>Microsoft Office 2007 SP3, 2010 SP2, 2013 SP1, and 2013 RT SP1 allows remote attackers to execute arbitrary code via a crafted EPS image, aka "Microsoft Office Malformed EPS File Vulnerability."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-05-31T21:11:47+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2016-06-13T11:40:32.600-04:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2016-07-01T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2016-07-15T11:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation vulnerable Microsoft Office + vulnerable file version" operator="OR">
+    <oval-def:criteria comment="Microsoft Office 2007 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2007 SP3 is installed" definition_ref="oval:org.mitre.oval:def:15704" />
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2006.1200.0000.0000" test_ref="oval:org.cisecurity:tst:1253" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2006.1200.6736.5000" test_ref="oval:org.cisecurity:tst:1252" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2010 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2010 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x86 is installed" definition_ref="oval:org.mitre.oval:def:20860" />
+        <oval-def:extend_definition comment="Microsoft Office 2010 SP2 x64 is installed" definition_ref="oval:org.mitre.oval:def:20917" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2010.1400.0000.0000" test_ref="oval:org.cisecurity:tst:1256" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2010.1400.7162.5001" test_ref="oval:org.cisecurity:tst:1255" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2013 + file version" operator="AND">
+      <oval-def:criteria comment="Microsoft Office 2013 is installed" operator="OR">
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x86 is installed" definition_ref="oval:org.mitre.oval:def:22392" />
+        <oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+      </oval-def:criteria>
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1500.0000.0000" test_ref="oval:org.cisecurity:tst:1257" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2012.1500.4753.1002" test_ref="oval:org.cisecurity:tst:1250" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft Office 2016 + file version" operator="AND">
+      <oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+      <oval-def:criteria comment="Check for file version" operator="AND">
+        <oval-def:criterion comment="Check if epsimp32.flt version is greater than or equal to 2012.1600.0000.0000" test_ref="oval:org.cisecurity:tst:1251" />
+        <oval-def:criterion comment="Check if epsimp32.flt version is less than 2012.1600.4288.1000" test_ref="oval:org.cisecurity:tst:1254" />
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>


### PR DESCRIPTION
oval:org.cisecurity:def:746 and oval:org.cisecurity:def:2618 are duplicates but oval:org.cisecurity:def:2618 is more correct because oval:org.cisecurity:def:746 has false positives