### PR TITLE
Kemanik fixes4

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3928.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3928.xml
@@ -14,7 +14,7 @@
       <product>Microsoft .NET Framework 4.0</product>
       <product>Microsoft .NET Framework 4.5</product>
     </affected>
-    <reference ref_id="VE-2018-0786" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0786" source="CVE" />
+    <reference ref_id="CVE-2018-0786" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0786" source="CVE" />
     <description>Microsoft .NET Framework 1.1, 2.0, 3.0, 3.5, 3.5.1, 4, 4.5, 4.5.1, 4.5.2, 4.6, 4.6.1, 4.6.2, and 4.7 and .NET Core 1.0 and 2.0 allow a security feature bypass vulnerability due to the way certificates are validated, aka ".NET Security Feature Bypass Vulnerability".</description>
     <oval_repository>
       <dates>

--- a/repository/tests/ios/version55_test/3000/oval_org.cisecurity_tst_3362.xml
+++ b/repository/tests/ios/version55_test/3000/oval_org.cisecurity_tst_3362.xml
@@ -1,4 +1,4 @@
 <version55_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#ios" check="at least one" check_existence="at_least_one_exists" comment="IOS version 15.2(2)e3" id="oval:org.cisecurity:tst:3362" version="2">
   <object object_ref="oval:org.mitre.oval:obj:6804" />
-  <state state_ref="oval:org.mitre.oval:ste:4" />
+  <state state_ref="oval:org.cisecurity:ste:2494" />
 </version55_test>


### PR DESCRIPTION
In oval_org.cisecurity_def_3928.xml letter 'C' was added in reference.
In oval_org.cisecurity_tst_3362.xml missing state was replaced with existed