### PR TITLE
Fixed IOS version_string regular expression error

### DIFF
--- a/repository/states/ios/version55_state/6000/oval_org.mitre.oval_ste_6348.xml
+++ b/repository/states/ios/version55_state/6000/oval_org.mitre.oval_ste_6348.xml
@@ -1,4 +1,4 @@
 <version55_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#ios" id="oval:org.mitre.oval:ste:6348" version="1">
-  <version_string operation="pattern match">12\.4\(22\w*\)MD0?$|12\.4\(20\w*\)T(1\w*|[0-1]?|$)|12\.4\(22\w*\)T(\0?|$)|12\.4\(\d+\w*\)XZ(\d.*|$)|12\.4\(\d+\w*\)YA(\d.*|$)|
+  <version_string operation="pattern match">12\.4\(22\w*\)MD0?$|12\.4\(20\w*\)T(1\w*|[0-1]?|$)|12\.4\(22\w*\)T(0?|$)|12\.4\(\d+\w*\)XZ(\d.*|$)|12\.4\(\d+\w*\)YA(\d.*|$)|
 12\.4\((\d|1\d|2[0-2])\[a-z|A-Z]*\)YD0?$|12\.4\((\d|1\d|2[0-2])[a-z|A-Z]*\)YE0?$|12\.2\(\d+\w*\)XN[A-D](\d.*|$)</version_string>
 </version55_state>


### PR DESCRIPTION
The regular expression included `\0`. `0` is not a special character and should not be escaped.