### PR TITLE
Corrected the following tests: tst:3636, tst:3640, and tst:3644

### DIFF
--- a/repository/tests/windows/file_test/3000/oval_org.cisecurity_tst_3636.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.cisecurity_tst_3636.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if outlook.exe version is less than 16.0.4549.1002" id="oval:org.cisecurity:tst:3636" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:1070" />
+  <object object_ref="oval:org.cisecurity:obj:638" />
   <state state_ref="oval:org.cisecurity:ste:2707" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.cisecurity_tst_3640.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.cisecurity_tst_3640.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if outlook.exe version is less than 16.0.4549.1002" id="oval:org.cisecurity:tst:3640" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:1070" />
+  <object object_ref="oval:org.cisecurity:obj:638" />
   <state state_ref="oval:org.cisecurity:ste:2713" />
 </file_test>

--- a/repository/tests/windows/file_test/3000/oval_org.cisecurity_tst_3644.xml
+++ b/repository/tests/windows/file_test/3000/oval_org.cisecurity_tst_3644.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if outlook.exe version is less than 16.0.4549.1002" id="oval:org.cisecurity:tst:3644" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:1070" />
+  <object object_ref="oval:org.cisecurity:obj:638" />
   <state state_ref="oval:org.cisecurity:ste:2716" />
 </file_test>


### PR DESCRIPTION
Corrected the following tests: oval_org.cisecurity_tst_3636.xml, oval_org.cisecurity_tst_3640.xml, and oval_org.cisecurity_tst_3644.xml to use the correct object for Outlook 2016.