### PR TITLE
Fixed several bugs

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1316.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1316.xml
@@ -6,7 +6,7 @@
       <oval-def:platform>Microsoft Windows 2000</oval-def:platform>
       <oval-def:platform>Microsoft Windows XP</oval-def:platform>
       <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
-      <oval-def:product>Microsoft Outlook</oval-def:product>
+      <oval-def:product>Microsoft Exchange Server 5.0</oval-def:product>
     </oval-def:affected>
     <oval-def:reference ref_id="CVE-2006-0002" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2006-0002" source="CVE" />
     <oval-def:description>Unspecified vulnerability in Microsoft Outlook 2000 through 2003, Exchange 5.0 Server SP2 and 5.5 SP4, Exchange 2000 SP3, and Office allows remote attackers to execute arbitrary code via an e-mail message with a crafted Transport Neutral Encapsulation Format (TNEF) MIME attachment, related to message length validation.</oval-def:description>
@@ -24,6 +24,7 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria comment="Software section" operator="AND">
+    <oval-def:criterion comment="Exchange Services registry key exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Exchange\Setup\Services)" negate="false" test_ref="oval:com.g2-inc.dev.oval:tst:1000" />
     <oval-def:criterion comment="the version of Mdbmsg.dll greater than or equal 5.0.1460.9 (Exchange Server 5.0,SP2 is installed)." negate="false" test_ref="oval:org.mitre.oval:tst:990" />
     <oval-def:criterion comment="the version of Mdbmsg.dll is less than 5.0.1462.22" negate="false" test_ref="oval:org.mitre.oval:tst:989" />
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1402.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1402.xml
@@ -34,6 +34,7 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria comment="Software section" operator="AND">
+    <oval-def:extend_definition definition_ref="oval:org.mitre.oval:def:6897" comment="Winamp is installed"></oval-def:extend_definition>
     <oval-def:criterion comment="the version of winamp is less than or equal 5.12" test_ref="oval:org.mitre.oval:tst:970" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_1570.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_1570.xml
@@ -23,6 +23,7 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria comment="Software section" operator="AND">
+    <oval-def:extend_definition definition_ref="oval:org.mitre.oval:def:439" comment="Microsoft Excel Viewer 2003 is installed" />
     <oval-def:criterion comment="Xlview.exe is installed with a version less than 11.0.8012.0" negate="false" test_ref="oval:org.mitre.oval:tst:881" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_188.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_188.xml
@@ -55,7 +55,7 @@
       <oval-def:criterion comment="the version of Winword.exe is less than 10.0.5522.0" test_ref="oval:org.mitre.oval:tst:7679" />
     </oval-def:criteria>
     <oval-def:criteria operator="AND">
-      <oval-def:criterion comment="Word 97 registry key exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Word\InstallRoot!Path)" test_ref="oval:com.g2-inc.dev.oval:tst:1002" />
+      <oval-def:criterion comment="Registry key for Word exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Word\InstallRoot!Path)" test_ref="oval:com.g2-inc.dev.oval:tst:1002" />
       <oval-def:criterion comment="the version of winword.exe is less than 8.0.0.9125" test_ref="oval:org.mitre.oval:tst:7738" />
     </oval-def:criteria>
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_188.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_188.xml
@@ -55,7 +55,7 @@
       <oval-def:criterion comment="the version of Winword.exe is less than 10.0.5522.0" test_ref="oval:org.mitre.oval:tst:7679" />
     </oval-def:criteria>
     <oval-def:criteria operator="AND">
-      <oval-def:criterion comment="Word 97 is installed" test_ref="oval:org.mitre.oval:tst:2531" />
+      <oval-def:criterion comment="Word 97 registry key exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Word\InstallRoot!Path)" test_ref="oval:com.g2-inc.dev.oval:tst:1002" />
       <oval-def:criterion comment="the version of winword.exe is less than 8.0.0.9125" test_ref="oval:org.mitre.oval:tst:7738" />
     </oval-def:criteria>
   </oval-def:criteria>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_585.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_585.xml
@@ -40,7 +40,7 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Word 97 is installed" test_ref="oval:org.mitre.oval:tst:2531" />
+    <oval-def:criterion comment="Registry key for Word exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Word\InstallRoot!Path)" test_ref="oval:com.g2-inc.dev.oval:tst:1002" />
     <oval-def:criterion comment="the version of winword.exe is less than 8.0.0.9315" test_ref="oval:org.mitre.oval:tst:2530" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_586.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_586.xml
@@ -34,7 +34,7 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Word 98 is installed" test_ref="oval:org.mitre.oval:tst:2529" />
+    <oval-def:criterion comment="Registry key for Word exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Word\InstallRoot!Path)" test_ref="oval:com.g2-inc.dev.oval:tst:1002" />
     <oval-def:criterion comment="the version of winword.exe is less than 8.0.0.9716" test_ref="oval:org.mitre.oval:tst:2528" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_675.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_675.xml
@@ -37,7 +37,7 @@
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria operator="AND">
-    <oval-def:criterion comment="Excel 97 is installed" test_ref="oval:org.mitre.oval:tst:2435" />
+    <oval-def:criterion comment="Excel 97 registry key exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Excel\InstallRoot!Path)" test_ref="oval:com.g2-inc.dev.oval:tst:1001" />
     <oval-def:criterion comment="the version of excel.exe is less than 8.00.01.9904" test_ref="oval:org.mitre.oval:tst:2434" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/objects/windows/file_object/1000/oval_com.g2-inc.dev.oval_obj_1000.xml
+++ b/repository/objects/windows/file_object/1000/oval_com.g2-inc.dev.oval_obj_1000.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the details of ppcore.dll (Powerpoint 2016)" id="oval:com.g2-inc.dev.oval:obj:1000" version="1">
+  <path var_check="at least one" var_ref="oval:com.g2-inc.dev.oval:var:1000" />
+  <filename>ppcore.dll</filename>
+</file_object>

--- a/repository/tests/independent/unknown_test/2000/oval_org.mitre.oval_tst_2435.xml
+++ b/repository/tests/independent/unknown_test/2000/oval_org.mitre.oval_tst_2435.xml
@@ -1,3 +1,4 @@
 <ns0:unknown_test xmlns:ns0="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="Excel 97 is installed" id="oval:org.mitre.oval:tst:2435" version="1" />
 
+
 		

--- a/repository/tests/windows/file_test/4000/oval_org.cisecurity_tst_4326.xml
+++ b/repository/tests/windows/file_test/4000/oval_org.cisecurity_tst_4326.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if the version of ppcore.dll is less than 16.0.4588.1000" id="oval:org.cisecurity:tst:4326" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:44001" />
+  <object object_ref="oval:com.g2-inc.dev.oval:obj:1000" />
   <state state_ref="oval:org.cisecurity:ste:3155" />
 </file_test>

--- a/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1000.xml
+++ b/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1000.xml
@@ -1,3 +1,3 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Outlook 2000 is installed" id="oval:com.g2-inc.dev.oval:tst:1000" version="0">
-  <object object_ref="oval:org.mitre.oval:obj:329" />
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Exchange Services registry key exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Exchange\Setup\Services)" id="oval:com.g2-inc.dev.oval:tst:1000" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:329"/>
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1000.xml
+++ b/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1000.xml
@@ -1,0 +1,3 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Outlook 2000 is installed" id="oval:com.g2-inc.dev.oval:tst:1000" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:329" />
+</registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1001.xml
+++ b/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1001.xml
@@ -1,0 +1,3 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Excel 97 registry key exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Excel\InstallRoot!Path)" id="oval:com.g2-inc.dev.oval:tst:1001" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:23838" />
+</registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1002.xml
+++ b/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1002.xml
@@ -1,3 +1,3 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Word 97 registry key exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Word\InstallRoot!Path)" id="oval:com.g2-inc.dev.oval:tst:1002" version="0">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Registry key for Word exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Word\InstallRoot!Path)" id="oval:com.g2-inc.dev.oval:tst:1002" version="0">
   <object object_ref="oval:org.mitre.oval:obj:23762" />
 </registry_test>

--- a/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1002.xml
+++ b/repository/tests/windows/registry_test/1000/oval_com.g2-inc.dev.oval_tst_1002.xml
@@ -1,0 +1,3 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Word 97 registry key exists (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Office\8.0\Word\InstallRoot!Path)" id="oval:com.g2-inc.dev.oval:tst:1002" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:23762" />
+</registry_test>

--- a/repository/variables/oval_com.g2-inc.dev.oval_var_1000.xml
+++ b/repository/variables/oval_com.g2-inc.dev.oval_var_1000.xml
@@ -1,0 +1,3 @@
+<oval-def:local_variable xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Powerpoint 2016 Install folder" datatype="string" id="oval:com.g2-inc.dev.oval:var:1000" version="1">
+  <oval-def:object_component item_field="value" object_ref="oval:org.cisecurity:obj:841" />
+</oval-def:local_variable>

--- a/repository/variables/oval_org.cisecurity_var_65.xml
+++ b/repository/variables/oval_org.cisecurity_var_65.xml
@@ -4,6 +4,6 @@
     <escape_regex>
       <object_component item_field="value" object_ref="oval:org.cisecurity:obj:524" />
     </escape_regex>
-    <literal_component>\root\vfs\ProgramFilesCommonx*.$\Microsoft Shared\OFFICE16\1033</literal_component>
+    <literal_component>\\[Rr][Oo][Oo][Tt]\\[Vv][Ff][Ss]\\[Pp][Rr][Oo][Gg][Rr][Aa][Mm][Ff][Ii][Ll][Ee][Ss][Cc][Oo][Mm][Mm][Oo][Nn][Xx]\d{2}\\[Mm][Ii][Cc][Rr][Oo][Ss][Oo][Ff][Tt]\s+[Ss][Hh][Aa][Rr][Ee][Dd]\\[Oo][Ff][Ff][Ii][Cc][Ee]16\\1033</literal_component>
   </concat>
 </local_variable>


### PR DESCRIPTION
Change log

Updated oval:org.mitre.oval:def:1316 and oval:org.mitre.oval:def:1402 to prevent a runtime error.
Added inventory definition for Excel Viewer to oval:org.mitre.oval:def:1570 to prevent a runtime error.
Updated definition oval:org.mitre.oval:def:675 to prevent a runtime error.
Updated oval:org.cisecurity:tst:4326 to use the correct object for ppcore.dll (PowerPoint 2016)
Updated oval:org.mitre.oval:def:188 to prevent an error when Word 97 is not installed.
Updated oval:org.mitre.oval:def:585 to prevent an error when Word 97 is not installed.
Updated oval:org.mitre.oval:def:586 to prevent an error when Word 97 is not installed.
Corrected the regex used by variable oval:org.cisecurity:var:65
