### PR TITLE
 Update to oval:org.cisecurity:var:478

### DIFF
--- a/repository/variables/oval_org.cisecurity_var_478.xml
+++ b/repository/variables/oval_org.cisecurity_var_478.xml
@@ -1,9 +1,7 @@
-<local_variable xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Full key path of uninstall registry key under HKEY_USERS" datatype="string" id="oval:org.cisecurity:var:478" version="1">
+<local_variable xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Full key path of uninstall registry key under HKEY_USERS" datatype="string" id="oval:org.cisecurity:var:478" version="2">
   <concat>
     <literal_component>^</literal_component>
-    <escape_regex>
-      <object_component item_field="key" object_ref="oval:org.mitre.oval:obj:23331" />
-    </escape_regex>
+    <object_component item_field="key" object_ref="oval:org.mitre.oval:obj:23331" />
     <literal_component>\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\.*$</literal_component>
   </concat>
 </local_variable>


### PR DESCRIPTION
Removes the escape_regex from the object_component for registry_object [@id=oval:org.mitre.oval:obj:23331]/key. This registry object is supposed to list the sub-keys of the hive HKEY_USERS. However, it may also include the hive HKEY_USERS itself, whose value for 'key' would be null (or xsi:nil="true"). This could lead to the generation of an error within the escape_regex function.