### PR TITLE
Deprecated definitions

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5115.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5115.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5115" version="4">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5115" version="4" deprecated="true">
   <metadata>
     <title>HPESBUX03817 rev.2 - HP-UX CIFS Server, Local and Remote Vulnerabilities</title>
     <affected family="unix">
@@ -13,8 +13,9 @@
         </submitted>
         <status_change date="2018-06-08T13:18:01.158-05:00">DRAFT</status_change>
         <status_change date="2018-06-22T04:00:08.269-05:00">INTERIM</status_change>
+        <status_change date="2018-06-25T08:00:00.000-05:00">DEPRECATED</status_change>
       </dates>
-      <status>INTERIM</status>
+      <status>DEPRECATED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5117.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5117.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5117" version="4">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5117" version="4" deprecated="true">
   <metadata>
     <title>HPESBUX03817 rev.2 - HP-UX CIFS Server, Local and Remote Vulnerabilities</title>
     <affected family="unix">
@@ -13,8 +13,9 @@
         </submitted>
         <status_change date="2018-06-08T13:18:01.158-05:00">DRAFT</status_change>
         <status_change date="2018-06-22T04:00:08.269-05:00">INTERIM</status_change>
+        <status_change date="2018-06-25T08:00:00.000-05:00">DEPRECATED</status_change>
       </dates>
-      <status>INTERIM</status>
+      <status>DEPRECATED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5118.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5118.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5118" version="4">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5118" version="4" deprecated="true">
   <metadata>
     <title>HPESBUX03817 rev.2 - HP-UX CIFS Server, Local and Remote Vulnerabilities</title>
     <affected family="unix">
@@ -13,8 +13,9 @@
         </submitted>
         <status_change date="2018-06-08T13:18:01.158-05:00">DRAFT</status_change>
         <status_change date="2018-06-22T04:00:08.269-05:00">INTERIM</status_change>
+        <status_change date="2018-06-25T08:00:00.000-05:00">DEPRECATED</status_change>
       </dates>
-      <status>INTERIM</status>
+      <status>DEPRECATED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5119.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5119.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5119" version="4">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5119" version="4" deprecated="true">
   <metadata>
     <title>HPESBUX03817 rev.2 - HP-UX CIFS Server, Local and Remote Vulnerabilities</title>
     <affected family="unix">
@@ -13,8 +13,9 @@
         </submitted>
         <status_change date="2018-06-08T13:18:01.158-05:00">DRAFT</status_change>
         <status_change date="2018-06-22T04:00:08.269-05:00">INTERIM</status_change>
+        <status_change date="2018-06-25T08:00:00.000-05:00">DEPRECATED</status_change>
       </dates>
-      <status>INTERIM</status>
+      <status>DEPRECATED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5120.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5120.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5120" version="4">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5120" version="4" deprecated="true">
   <metadata>
     <title>HPESBUX03817 rev.2 - HP-UX CIFS Server, Local and Remote Vulnerabilities</title>
     <affected family="unix">
@@ -13,8 +13,9 @@
         </submitted>
         <status_change date="2018-06-08T13:18:01.158-05:00">DRAFT</status_change>
         <status_change date="2018-06-22T04:00:08.269-05:00">INTERIM</status_change>
+        <status_change date="2018-06-25T08:00:00.000-05:00">DEPRECATED</status_change>
       </dates>
-      <status>INTERIM</status>
+      <status>DEPRECATED</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>


### PR DESCRIPTION
oval:org.cisecurity:def:5115 deprecated by oval:org.cisecurity:def:5087, 
oval:org.cisecurity:def:5117 deprecated by oval:org.cisecurity:def:5092, 
oval:org.cisecurity:def:5118 deprecated by oval:org.cisecurity:def:5085, 
oval:org.cisecurity:def:5119 deprecated by oval:org.cisecurity:def:5091, 
oval:org.cisecurity:def:5120 deprecated by oval:org.cisecurity:def:5089