### PR TITLE
Fix criteria for vulnerability definitions: oval_org.cisecurity_def 4977 to 4983

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4977.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4977.xml
@@ -38,7 +38,7 @@
         </criteria>
         <criteria comment="Check for vulnerable versions" operator="OR">
           <criterion comment="Check if VBScript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6776" />
-          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.17453" test_ref="oval:org.cisecurity:tst:6774" />
+          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6774" />
         </criteria>
       </criteria>
     </criteria>
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4978.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4978.xml
@@ -38,7 +38,7 @@
         </criteria>
         <criteria comment="Check for vulnerable versions" operator="OR">
           <criterion comment="Check if VBScript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6776" />
-          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.17453" test_ref="oval:org.cisecurity:tst:6774" />
+          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6774" />
         </criteria>
       </criteria>
     </criteria>
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4979.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4979.xml
@@ -38,7 +38,7 @@
         </criteria>
         <criteria comment="Check for vulnerable versions" operator="OR">
           <criterion comment="Check if VBScript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6776" />
-          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.17453" test_ref="oval:org.cisecurity:tst:6774" />
+          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6774" />
         </criteria>
       </criteria>
     </criteria>
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4980.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4980.xml
@@ -38,7 +38,7 @@
         </criteria>
         <criteria comment="Check for vulnerable versions" operator="OR">
           <criterion comment="Check if VBScript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6776" />
-          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.17453" test_ref="oval:org.cisecurity:tst:6774" />
+          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6774" />
         </criteria>
       </criteria>
     </criteria>
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4981.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4981.xml
@@ -38,7 +38,7 @@
         </criteria>
         <criteria comment="Check for vulnerable versions" operator="OR">
           <criterion comment="Check if VBScript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6776" />
-          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.17453" test_ref="oval:org.cisecurity:tst:6774" />
+          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6774" />
         </criteria>
       </criteria>
     </criteria>
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4982.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4982.xml
@@ -38,7 +38,7 @@
         </criteria>
         <criteria comment="Check for vulnerable versions" operator="OR">
           <criterion comment="Check if VBScript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6776" />
-          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.17453" test_ref="oval:org.cisecurity:tst:6774" />
+          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6774" />
         </criteria>
       </criteria>
     </criteria>
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4983.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4983.xml
@@ -38,7 +38,7 @@
         </criteria>
         <criteria comment="Check for vulnerable versions" operator="OR">
           <criterion comment="Check if VBScript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6776" />
-          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.17453" test_ref="oval:org.cisecurity:tst:6774" />
+          <criterion comment="Check if Jscript.dll version is less than 5.8.7601.21176" test_ref="oval:org.cisecurity:tst:6774" />
         </criteria>
       </criteria>
     </criteria>
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />


### PR DESCRIPTION
For vulnerability definitions `oval_org.cisecurity_def` 4977 to 4983:
* criterion `oval:org.cisecurity:tst:6774` is correct but has wrong comment (makes it confusing when reading)
* The Win10 criteria check should be using the definition for the Win10 Gold/base version, not the definition for all Win10 instances.