### PR TITLE
Cve 2018 8124a

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4927.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4927.xml
@@ -43,8 +43,8 @@
       </criteria>
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of Mshtml.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6724" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4928.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4928.xml
@@ -50,8 +50,8 @@
         </criteria>
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="file version">
             <criterion comment="Check if the version of Mshtml.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6724" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4929.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4929.xml
@@ -43,8 +43,8 @@
       </criteria>
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of Mshtml.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6724" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4930.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4930.xml
@@ -57,8 +57,8 @@
         </criteria>
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="file version">
             <criterion comment="Check if the version of Mshtml.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6724" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4931.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4931.xml
@@ -43,8 +43,8 @@
       </criteria>
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of Mshtml.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6724" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4966.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4966.xml
@@ -26,8 +26,8 @@
     <criteria comment="vulnerable os and file version" operator="OR">
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of chakra.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6763" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4967.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4967.xml
@@ -26,8 +26,8 @@
     <criteria comment="vulnerable os and file version" operator="OR">
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of chakra.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6763" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4968.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4968.xml
@@ -26,8 +26,8 @@
     <criteria comment="vulnerable os and file version" operator="OR">
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of chakra.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6763" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4969.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4969.xml
@@ -26,8 +26,8 @@
     <criteria comment="vulnerable os and file version" operator="OR">
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of chakra.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6763" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4972.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4972.xml
@@ -26,8 +26,8 @@
     <criteria comment="vulnerable os and file version" operator="OR">
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of chakra.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6763" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4976.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4976.xml
@@ -26,8 +26,8 @@
     <criteria comment="vulnerable os and file version" operator="OR">
       <criteria comment="Win10 + file version" operator="AND">
         <criteria comment="Win10" operator="OR">
-          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+          <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+          <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
         </criteria>
         <criteria comment="file version">
           <criterion comment="Check if the version of chakra.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6763" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4977.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4977.xml
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4978.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4978.xml
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4979.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4979.xml
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4981.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4981.xml
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4982.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4982.xml
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4983.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4983.xml
@@ -57,8 +57,8 @@
       <criteria comment="vulnerable windows OS + vulnerable file version" operator="OR">
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="Check for file version" operator="OR">
             <criterion comment="Check if VBScript.dll version is less than 5.812.10240.17831" test_ref="oval:org.cisecurity:tst:6770" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4988.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4988.xml
@@ -49,8 +49,8 @@
         </criteria>
         <criteria comment="Win10 + file version" operator="AND">
           <criteria comment="Win10" operator="OR">
-            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+            <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+            <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
           </criteria>
           <criteria comment="file version">
             <criterion comment="Check if the version of Mshtml.dll is less than 11.0.10240.17831" test_ref="oval:org.cisecurity:tst:6724" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5015.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5015.xml
@@ -60,8 +60,8 @@
     </criteria>
     <criteria comment="Win10 + file version" operator="AND">
       <criteria comment="Win10" operator="OR">
-        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
       </criteria>
       <criteria comment="file version">
         <criterion comment="Check if Win32kfull.sys version is less than 10.0.10240.17861" test_ref="oval:org.cisecurity:tst:6840" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5017.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5017.xml
@@ -60,8 +60,8 @@
     </criteria>
     <criteria comment="Win10 + file version" operator="AND">
       <criteria comment="Win10" operator="OR">
-        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
       </criteria>
       <criteria comment="file version">
         <criterion comment="Check if Win32kfull.sys version is less than 10.0.10240.17861" test_ref="oval:org.cisecurity:tst:6840" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5019.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5019.xml
@@ -60,8 +60,8 @@
     </criteria>
     <criteria comment="Win10 + file version" operator="AND">
       <criteria comment="Win10" operator="OR">
-        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
       </criteria>
       <criteria comment="file version">
         <criterion comment="Check if Win32kfull.sys version is less than 10.0.10240.17861" test_ref="oval:org.cisecurity:tst:6840" />

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5049.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5049.xml
@@ -60,8 +60,8 @@
     </criteria>
     <criteria comment="Win10 + file version" operator="AND">
       <criteria comment="Win10" operator="OR">
-        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.cisecurity:def:380" />
+        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.cisecurity:def:377" />
       </criteria>
       <criteria comment="file version">
         <criterion comment="Check if the version of Clfs.sys is less than 10.0.10240.17861" test_ref="oval:org.cisecurity:tst:7288" />


### PR DESCRIPTION
Updated windows 10 definitions
replaced definitions, oval:org.mitre.oval:def:29471, and oval:org.mitre.oval:def:29117, with oval:org.cisecurity:def:377, and oval:org.cisecurity:def:380