### PR TITLE
Fix Win10 criteria for vuln def: oval:org.cisecurity:def:5030

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5030.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5030.xml
@@ -60,8 +60,8 @@
     </criteria>
     <criteria comment="Win10 + file version" operator="AND">
       <criteria comment="Win10" operator="OR">
-        <extend_definition comment="Microsoft Windows 10 (x86) is installed" definition_ref="oval:org.mitre.oval:def:29471" />
-        <extend_definition comment="Microsoft Windows 10 (x64) is installed" definition_ref="oval:org.mitre.oval:def:29117" />
+        <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
+        <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
       </criteria>
       <criteria comment="file version">
         <criterion comment="Check if the version of comsvcs.dll is less than 2001.12.10941.16506" test_ref="oval:org.cisecurity:tst:7263" />


### PR DESCRIPTION
For vulnerability definition `oval:org.cisecurity:def:5030`, the Win10 criteria check should be using the definition for the Win10 Gold/base version, not the definition for all Win10 instances.

This fixes #1489 (that issue mentions two CVEs but the other one has already been fixed).