### PR TITLE
Deprecated definitions

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3712.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3712.xml
@@ -1,36 +1,36 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3712" version="8">
-  <metadata>
-    <title>.NET CORE Denial Of Service Vulnerability - CVE-2017-11770</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft .NET Core 1.0</product>
-      <product>Microsoft .NET Core 1.1</product>
-      <product>Microsoft .NET Core 2.0</product>
-    </affected>
-    <reference ref_id="CVE-2017-11770" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11770" source="CVE" />
-    <description>.NET Core 1.0, 1.1, and 2.0 allow an unauthenticated attacker to remotely cause a denial of service attack against a .NET Core web application by improperly parsing certificate data. A denial of service vulnerability exists when .NET Core improperly handles parsing certificate data, aka ".NET CORE Denial Of Service Vulnerability".</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-11-29T00:00:00+08:00">
-          <contributor organization="DTCC">Jeff Albert</contributor>
-        </submitted>
-        <status_change date="2017-12-01T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-12-15T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-12-29T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Affected Win App + vulnerable file version" operator="OR">
-    <criterion comment="Check if the version of .Net Core 1.0 is less than 1.0.8" test_ref="oval:org.cisecurity:tst:4956" />
-    <criterion comment="Check if the version of .Net Core 1.1 is less than 1.1.5" test_ref="oval:org.cisecurity:tst:4954" />
-    <criterion comment="Check if the version of .Net Core 2.0 is less than 2.0.3" test_ref="oval:org.cisecurity:tst:4955" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3712" version="8">
+  <oval-def:metadata>
+    <oval-def:title>.NET CORE Denial Of Service Vulnerability - CVE-2017-11770</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft .NET Core 1.0</oval-def:product>
+      <oval-def:product>Microsoft .NET Core 1.1</oval-def:product>
+      <oval-def:product>Microsoft .NET Core 2.0</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-11770" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11770" source="CVE" />
+    <oval-def:description>.NET Core 1.0, 1.1, and 2.0 allow an unauthenticated attacker to remotely cause a denial of service attack against a .NET Core web application by improperly parsing certificate data. A denial of service vulnerability exists when .NET Core improperly handles parsing certificate data, aka ".NET CORE Denial Of Service Vulnerability".</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-11-29T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-12-01T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-12-15T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-12-29T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Affected Win App + vulnerable file version" operator="OR">
+    <oval-def:criterion comment="Check if the version of .Net Core 1.0 is less than 1.0.8" test_ref="oval:org.cisecurity:tst:4956" />
+    <oval-def:criterion comment="Check if the version of .Net Core 1.1 is less than 1.1.5" test_ref="oval:org.cisecurity:tst:4954" />
+    <oval-def:criterion comment="Check if the version of .Net Core 2.0 is less than 2.0.3" test_ref="oval:org.cisecurity:tst:4955" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4020.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4020.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:4020" version="8">
-  <metadata>
-    <title>Privilege Escalation in PageState - CVE-2017-15402</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-15402" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15402" source="CVE" />
-    <description>Privilege escalation in PageState.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-31T17:03:39+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2018-02-09T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2018-02-23T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2018-03-09T04:00:40.204-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 62.0.3202.74" test_ref="oval:org.cisecurity:tst:5372" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:4020" version="8">
+  <oval-def:metadata>
+    <oval-def:title>Privilege Escalation in PageState - CVE-2017-15402</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-15402" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15402" source="CVE" />
+    <oval-def:description>Privilege escalation in PageState.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-31T17:03:39+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-02-09T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-02-23T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2018-03-09T04:00:40.204-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 62.0.3202.74" test_ref="oval:org.cisecurity:tst:5372" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4021.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4021.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:4021" version="8">
-  <metadata>
-    <title>Out of Bounds Memory Access in V8 - CVE-2017-15401</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-15401" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15401" source="CVE" />
-    <description>Out of bounds memory access in V8.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-31T17:03:39+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2018-02-09T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2018-02-23T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2018-03-09T04:00:40.204-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 62.0.3202.74" test_ref="oval:org.cisecurity:tst:5372" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:4021" version="8">
+  <oval-def:metadata>
+    <oval-def:title>Out of Bounds Memory Access in V8 - CVE-2017-15401</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-15401" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15401" source="CVE" />
+    <oval-def:description>Out of bounds memory access in V8.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-31T17:03:39+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-02-09T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-02-23T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2018-03-09T04:00:40.204-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 62.0.3202.74" test_ref="oval:org.cisecurity:tst:5372" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4022.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4022.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:4022" version="8">
-  <metadata>
-    <title>Use of Plaintext Network Protocols in ChromeVox - CVE-2017-15397</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-15397" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15397" source="CVE" />
-    <description>Use of plaintext network protocols in ChromeVox.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-02-05T12:46:10+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2018-02-09T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2018-02-23T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2018-03-09T04:00:40.204-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 62.0.3202.74" test_ref="oval:org.cisecurity:tst:5372" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:4022" version="8">
+  <oval-def:metadata>
+    <oval-def:title>Use of Plaintext Network Protocols in ChromeVox - CVE-2017-15397</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-15397" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15397" source="CVE" />
+    <oval-def:description>Use of plaintext network protocols in ChromeVox.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-02-05T12:46:10+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-02-09T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-02-23T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2018-03-09T04:00:40.204-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 62.0.3202.74" test_ref="oval:org.cisecurity:tst:5372" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4023.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4023.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:4023" version="8">
-  <metadata>
-    <title>CRLF and Code Injection in Printer Zeroconfig - CVE-2017-15400</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Google Chrome</product>
-    </affected>
-    <reference ref_id="CVE-2017-15400" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15400" source="CVE" />
-    <description>CRLF and code injection in printer zeroconfig.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-02-05T12:46:10+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2018-02-09T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2018-02-23T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2018-03-09T04:00:40.204-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Google Chrome is installed + version" operator="AND">
-    <extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
-    <criterion comment="Check if Google Chrome version less than 62.0.3202.74" test_ref="oval:org.cisecurity:tst:5372" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:4023" version="8">
+  <oval-def:metadata>
+    <oval-def:title>CRLF and Code Injection in Printer Zeroconfig - CVE-2017-15400</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Google Chrome</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-15400" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15400" source="CVE" />
+    <oval-def:description>CRLF and code injection in printer zeroconfig.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-02-05T12:46:10+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-02-09T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-02-23T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2018-03-09T04:00:40.204-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Google Chrome is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Google Chrome is installed" definition_ref="oval:org.mitre.oval:def:11914" />
+    <oval-def:criterion comment="Check if Google Chrome version less than 62.0.3202.74" test_ref="oval:org.cisecurity:tst:5372" />
+  </oval-def:criteria>
+</oval-def:definition>


### PR DESCRIPTION
Definitions 4020-4023 should be deprecated because they applied to [Chrome OS](https://chromereleases.googleblog.com/2017/10/stable-channel-update-for-chrome-os_27.html). 

Definition 3712 should be deprecated because it applied to [Linux/MacOS](https://github.com/dotnet/announcements/issues/44)