### PR TITLE
kemanik_deprecated_vulns

### DIFF
--- a/repository/definitions/inventory/oval_org.cisecurity_def_5113.xml
+++ b/repository/definitions/inventory/oval_org.cisecurity_def_5113.xml
@@ -1,0 +1,37 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.cisecurity:def:5113" version="8">
+  <oval-def:metadata>
+    <oval-def:title>Git is installed</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Git</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="cpe:/a:git_project:git" source="CPE" />
+    <oval-def:description>Git is installed.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-06-05T11:02:21+00:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-06-08T13:18:01.158-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-06-22T04:00:08.269-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2018-07-06T12:30:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:criterion comment="Check if Git is installed" test_ref="oval:org.cisecurity:tst:7363" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3045.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3045.xml
@@ -1,40 +1,40 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3045" version="9">
-  <metadata>
-    <title>Vulnerability in the MySQL Server - CVE-2017-3732</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>MySQL Server</product>
-    </affected>
-    <reference ref_id="CVE-2017-3732" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3732" source="CVE" />
-    <description>Vulnerability in the MySQL Server. Supported versions that are affected are 5.6.35 and earlier and 5.7.17 and earlier.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-08-22T19:36:07+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-08-25T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-09-08T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-09-22T12:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of MySQL Server + vulnerable version " operator="OR">
-    <criteria comment="Check for installation of MySQL Server 5.6 + vulnerable version" operator="AND">
-      <extend_definition comment="MySQL 5.6 is installed" definition_ref="oval:org.mitre.oval:def:26414" />
-      <criterion comment="Check if MySQL Server 5.6 version is less than or equal 5.6.35" test_ref="oval:org.cisecurity:tst:4133" />
-    </criteria>
-    <criteria comment="Check for installaion of MySQL Server 5.7 + vulnerable version" operator="AND">
-      <extend_definition comment="MySQL 5.7 is installed" definition_ref="oval:org.cisecurity:def:726" />
-      <criterion comment="Check if MySQL Server 5.7 version is less than or equal 5.7.17" test_ref="oval:org.cisecurity:tst:4132" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3045" version="9">
+  <oval-def:metadata>
+    <oval-def:title>Vulnerability in the MySQL Server - CVE-2017-3732</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>MySQL Server</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-3732" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3732" source="CVE" />
+    <oval-def:description>Vulnerability in the MySQL Server. Supported versions that are affected are 5.6.35 and earlier and 5.7.17 and earlier.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-08-22T19:36:07+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-08-25T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-09-08T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-09-22T12:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of MySQL Server + vulnerable version " operator="OR">
+    <oval-def:criteria comment="Check for installation of MySQL Server 5.6 + vulnerable version" operator="AND">
+      <oval-def:extend_definition comment="MySQL 5.6 is installed" definition_ref="oval:org.mitre.oval:def:26414" />
+      <oval-def:criterion comment="Check if MySQL Server 5.6 version is less than or equal 5.6.35" test_ref="oval:org.cisecurity:tst:4133" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Check for installaion of MySQL Server 5.7 + vulnerable version" operator="AND">
+      <oval-def:extend_definition comment="MySQL 5.7 is installed" definition_ref="oval:org.cisecurity:def:726" />
+      <oval-def:criterion comment="Check if MySQL Server 5.7 version is less than or equal 5.7.17" test_ref="oval:org.cisecurity:tst:4132" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_3051.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_3051.xml
@@ -1,35 +1,35 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:3051" version="6">
-  <metadata>
-    <title>WBXML dissector infinite loop - CVE-2017-7702</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 2000</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2003</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows XP</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <product>Wireshark</product>
-    </affected>
-    <reference ref_id="CVE-2017-7702" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7702" source="CVE" />
-    <description>In Wireshark 2.2.0 to 2.2.7 and 2.0.0 to 2.0.13, the WBXML dissector could go into an infinite loop, triggered by packet injection or a malformed capture file. This was addressed in epan/dissectors/packet-wbxml.c by adding length validation.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2017-08-04T16:46:08+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2017-08-25T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2017-09-08T11:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2017-09-22T12:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria>
-    <extend_definition comment="Wireshark is installed on the system." definition_ref="oval:org.mitre.oval:def:6589" />
-    <criterion comment="Version of Wireshark is 2.0.0 thorugh 2.0.13 or 2.2.0 through 2.2.7" test_ref="oval:org.cisecurity:tst:4162" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:3051" version="6">
+  <oval-def:metadata>
+    <oval-def:title>WBXML dissector infinite loop - CVE-2017-7702</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 2000</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:product>Wireshark</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2017-7702" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7702" source="CVE" />
+    <oval-def:description>In Wireshark 2.2.0 to 2.2.7 and 2.0.0 to 2.0.13, the WBXML dissector could go into an infinite loop, triggered by packet injection or a malformed capture file. This was addressed in epan/dissectors/packet-wbxml.c by adding length validation.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2017-08-04T16:46:08+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2017-08-25T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2017-09-08T11:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2017-09-22T12:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="Wireshark is installed on the system." definition_ref="oval:org.mitre.oval:def:6589" />
+    <oval-def:criterion comment="Version of Wireshark is 2.0.0 thorugh 2.0.13 or 2.2.0 through 2.2.7" test_ref="oval:org.cisecurity:tst:4162" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4098.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4098.xml
@@ -1,34 +1,34 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:4098" version="6">
-  <metadata>
-    <title>Background network requests can open HTTP authentication in unrelated foreground tabs - CVE-2018-5115</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Mozilla Firefox</product>
-    </affected>
-    <reference ref_id="CVE-2018-5115" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5115" source="CVE" />
-    <description>If an HTTP authentication prompt is triggered by a background network request from a page or extension, it is displayed over the currently loaded foreground page. Although the prompt contains the real domain making the request, this can result in user confusion about the originating site of the authentication request and may cause users to mistakenly send private credential information to a third party site.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-02-14T21:43:10+08:00">
-          <contributor organization="DTCC">Alexander Chua</contributor>
-        </submitted>
-        <status_change date="2018-02-16T16:08:16.678-05:00">DRAFT</status_change>
-        <status_change date="2018-03-02T04:00:10.385-05:00">INTERIM</status_change>
-        <status_change date="2018-03-16T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
-    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259" />
-    <criterion comment="Check if Mozilla Firefox Mainline version less than 58.0.0" test_ref="oval:org.cisecurity:tst:5412" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:4098" version="6">
+  <oval-def:metadata>
+    <oval-def:title>Background network requests can open HTTP authentication in unrelated foreground tabs - CVE-2018-5115</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Mozilla Firefox</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2018-5115" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5115" source="CVE" />
+    <oval-def:description>If an HTTP authentication prompt is triggered by a background network request from a page or extension, it is displayed over the currently loaded foreground page. Although the prompt contains the real domain making the request, this can result in user confusion about the originating site of the authentication request and may cause users to mistakenly send private credential information to a third party site.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-02-14T21:43:10+08:00">
+          <oval-def:contributor organization="DTCC">Alexander Chua</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-02-16T16:08:16.678-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-03-02T04:00:10.385-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2018-03-16T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <oval-def:extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259" />
+    <oval-def:criterion comment="Check if Mozilla Firefox Mainline version less than 58.0.0" test_ref="oval:org.cisecurity:tst:5412" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5287.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5287.xml
@@ -1,37 +1,37 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5287" version="2">
-  <metadata>
-    <title>CRLF injection vulnerability - CVE-2016-5699</title>
-    <affected family="windows">
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Python</product>
-    </affected>
-    <reference ref_id="CVE-2016-5699" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5699" source="CVE" />
-    <description>CRLF injection vulnerability in the HTTPConnection.putheader function in urllib2 and urllib in CPython (aka Python) before 2.7.10 and 3.x before 3.4.4 allows remote attackers to inject arbitrary HTTP headers via CRLF sequences in a URL.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-06-20T10:31:28+00:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2018-07-27T12:00:00.000-05:00">DRAFT</status_change>
-      </dates>
-      <status>DRAFT</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria comment="Check for installation of Python + vulnerable version" operator="AND">
-    <extend_definition comment="Python is installed" definition_ref="oval:org.mitre.oval:def:11791" />
-    <criteria comment="Check for vulnerable version" operator="OR">
-      <criterion comment="Check if Python version is less than 2.7.10 (Single User)" test_ref="oval:org.cisecurity:tst:7980" />
-      <criterion comment="Check if Python version is greater than or equal 3.0.0 and less than 3.4.4 (Single User)" test_ref="oval:org.cisecurity:tst:7977" />
-      <criterion comment="Check if Python version is less than 2.7.10 (All Users)" test_ref="oval:org.cisecurity:tst:7981" />
-      <criterion comment="Check if Python version is greater than or equal 3.0.0 and less than 3.4.4 (All Users)" test_ref="oval:org.cisecurity:tst:7979" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:5287" version="2">
+  <oval-def:metadata>
+    <oval-def:title>CRLF injection vulnerability - CVE-2016-5699</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Python</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-5699" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5699" source="CVE" />
+    <oval-def:description>CRLF injection vulnerability in the HTTPConnection.putheader function in urllib2 and urllib in CPython (aka Python) before 2.7.10 and 3.x before 3.4.4 allows remote attackers to inject arbitrary HTTP headers via CRLF sequences in a URL.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-06-20T10:31:28+00:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-07-27T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>DRAFT</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="Check for installation of Python + vulnerable version" operator="AND">
+    <oval-def:extend_definition comment="Python is installed" definition_ref="oval:org.mitre.oval:def:11791" />
+    <oval-def:criteria comment="Check for vulnerable version" operator="OR">
+      <oval-def:criterion comment="Check if Python version is less than 2.7.10 (Single User)" test_ref="oval:org.cisecurity:tst:7980" />
+      <oval-def:criterion comment="Check if Python version is greater than or equal 3.0.0 and less than 3.4.4 (Single User)" test_ref="oval:org.cisecurity:tst:7977" />
+      <oval-def:criterion comment="Check if Python version is less than 2.7.10 (All Users)" test_ref="oval:org.cisecurity:tst:7981" />
+      <oval-def:criterion comment="Check if Python version is greater than or equal 3.0.0 and less than 3.4.4 (All Users)" test_ref="oval:org.cisecurity:tst:7979" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>


### PR DESCRIPTION
Duplicate vulnerabilities were deprecated. The class in one vulnerability def_5113 which was used as an inventory was changed on inventory. 
Will def_5113 be automatically removed from vulnerabilities?