### PR TITLE
kemanik_fixes_070918

### DIFF
--- a/repository/definitions/inventory/oval_org.cisecurity_def_3929.xml
+++ b/repository/definitions/inventory/oval_org.cisecurity_def_3929.xml
@@ -1,37 +1,38 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.cisecurity:def:3929" version="23">
-  <metadata>
-    <title>Microsoft .NET Framework 4.7.1 is installed</title>
-    <affected family="windows">
-      <platform>Microsoft Windows Vista</platform>
-      <platform>Microsoft Windows 7</platform>
-      <platform>Microsoft Windows 8</platform>
-      <platform>Microsoft Windows 8.1</platform>
-      <platform>Microsoft Windows 10</platform>
-      <platform>Microsoft Windows Server 2008</platform>
-      <platform>Microsoft Windows Server 2008 R2</platform>
-      <platform>Microsoft Windows Server 2012</platform>
-      <platform>Microsoft Windows Server 2012 R2</platform>
-      <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft .NET Framework 4.7.1</product>
-    </affected>
-    <description>Microsoft .NET Framework 4.7.1 is installed.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2018-01-10T18:08:35+08:00">
-          <contributor organization="DTCC">Jose Israel Padilla</contributor>
-        </submitted>
-        <status_change date="2018-01-26T12:00:00.000-05:00">DRAFT</status_change>
-        <status_change date="2018-02-09T14:00:00.000-05:00">INTERIM</status_change>
-        <status_change date="2018-02-23T14:00:00.000-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.10</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria operator="OR">
-    <criterion comment="Check if the release of .Net framework 4.7.1 (full) is equal to 461308" test_ref="oval:org.cisecurity:tst:5316" />
-    <criterion comment="Check if the release of .Net framework 4.7.1 (client) is equal to 461308" test_ref="oval:org.cisecurity:tst:5315" />
-    <criterion comment="Check if the release of .Net framework 4.7.1 (full) is equal to 461310" test_ref="oval:org.cisecurity:tst:8161" />
-    <criterion comment="Check if the release of .Net framework 4.7.1 (client) is equal to 461310" test_ref="oval:org.cisecurity:tst:8162" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.cisecurity:def:3929" version="23">
+  <oval-def:metadata>
+    <oval-def:title>Microsoft .NET Framework 4.7.1 is installed</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>Microsoft .NET Framework 4.7.1</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="cpe:/a:microsoft:.net_framework:4.7.1" source="CPE" />
+    <oval-def:description>Microsoft .NET Framework 4.7.1 is installed.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2018-01-10T18:08:35+08:00">
+          <oval-def:contributor organization="DTCC">Jose Israel Padilla</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2018-01-26T12:00:00.000-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2018-02-09T14:00:00.000-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2018-02-23T14:00:00.000-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criterion comment="Check if the release of .Net framework 4.7.1 (full) is equal to 461308" test_ref="oval:org.cisecurity:tst:5316" />
+    <oval-def:criterion comment="Check if the release of .Net framework 4.7.1 (client) is equal to 461308" test_ref="oval:org.cisecurity:tst:5315" />
+    <oval-def:criterion comment="Check if the release of .Net framework 4.7.1 (full) is equal to 461310" test_ref="oval:org.cisecurity:tst:8161" />
+    <oval-def:criterion comment="Check if the release of .Net framework 4.7.1 (client) is equal to 461310" test_ref="oval:org.cisecurity:tst:8162" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_org.mitre.oval_def_21707.xml
+++ b/repository/definitions/patch/oval_org.mitre.oval_def_21707.xml
@@ -1,61 +1,61 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:org.mitre.oval:def:21707" version="68">
-  <metadata>
-    <title>RHSA-2014:0133: thunderbird security update (Important)</title>
-    <affected family="unix">
-      <platform>Red Hat Enterprise Linux 5</platform>
-      <platform>Red Hat Enterprise Linux 6</platform>
-      <platform>CentOS Linux 5</platform>
-      <platform>CentOS Linux 6</platform>
-      <product>thunderbird</product>
-    </affected>
-    <reference ref_id="RHSA-2014:0133-00" ref_url="https://rhn.redhat.com/errata/RHSA-2014-0133.html" source="VENDOR" />
-    <reference ref_id="CESA-2014:0133" source="CESA" />
-    <reference ref_id="CVE-2014-1477" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1477.html" source="CVE" />
-    <reference ref_id="CVE-2014-1479" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1479.html" source="CVE" />
-    <reference ref_id="CVE-2014-1481" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1481.html" source="CVE" />
-    <reference ref_id="CVE-2014-1482" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1482.html" source="CVE" />
-    <reference ref_id="CVE-2014-1486" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1486.html" source="CVE" />
-    <reference ref_id="CVE-2014-1487" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1487.html" source="CVE" />
-    <description>The Web workers implementation in Mozilla Firefox before 27.0, Firefox ESR 24.x before 24.3, Thunderbird before 24.3, and SeaMonkey before 2.24 allows remote attackers to bypass the Same Origin Policy and obtain sensitive authentication information via vectors involving error messages.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2014-02-14T11:55:48">
-          <contributor organization="ALTX-SOFT">Sergey Artykhov</contributor>
-        </submitted>
-        <status_change date="2014-02-19T08:08:15.974-05:00">DRAFT</status_change>
-        <status_change date="2014-03-10T04:00:35.023-04:00">INTERIM</status_change>
-        <status_change date="2014-03-31T04:00:11.697-04:00">ACCEPTED</status_change>
-        <modified comment="EDITED oval:org.mitre.oval:def:21707 - CentOS was added to RedHat vulnerabilities and products were added were nessesary." date="2014-04-23T10:34:00.988-04:00">
-          <contributor organization="ALTX-SOFT">Maria Mikhno</contributor>
-        </modified>
-        <status_change date="2014-04-23T10:36:15.711-04:00">INTERIM</status_change>
-        <status_change date="2014-05-12T04:00:09.096-04:00">ACCEPTED</status_change>
-        <modified comment="EDITED oval:org.mitre.oval:def:21707 - RHEL/CentOS  patches with added CESA ids" date="2014-06-20T11:49:00.014-04:00">
-          <contributor organization="ALTX-SOFT">Maria Mikhno</contributor>
-        </modified>
-        <status_change date="2014-06-20T11:51:39.703-04:00">INTERIM</status_change>
-        <status_change date="2014-07-07T04:00:52.145-04:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.3</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria operator="OR">
-    <criteria comment="Operation system section">
-      <extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 5" definition_ref="oval:org.mitre.oval:def:11414" />
-      <criterion comment="thunderbird is earlier than 0:24.3.0-2.el5_10" test_ref="oval:org.mitre.oval:tst:100278" />
-    </criteria>
-    <criteria comment="Operation system section">
-      <criterion comment="thunderbird is earlier than 0:24.3.0-2.el6_5" test_ref="oval:org.mitre.oval:tst:100038" />
-      <extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 6" definition_ref="oval:org.mitre.oval:def:20273" />
-    </criteria>
-    <criteria comment="Centos 5 section" operator="AND">
-      <extend_definition comment="The operating system installed on the system is CentOS Linux 5.x" definition_ref="oval:org.mitre.oval:def:15802" />
-      <criterion comment="libvirt-devel is earlier than 0:0.10.2-29.el6_5.3" test_ref="oval:org.mitre.oval:tst:113897" />
-    </criteria>
-    <criteria comment="Centos 6 section" operator="AND">
-      <criterion comment="libvirt-lock-sanlock is earlier than 0:0.10.2-29.el6_5.3" test_ref="oval:org.mitre.oval:tst:113478" />
-      <extend_definition comment="The operating system installed on the system is CentOS Linux 6.x" definition_ref="oval:org.mitre.oval:def:16337" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:org.mitre.oval:def:21707" version="68">
+  <oval-def:metadata>
+    <oval-def:title>RHSA-2014:0133: thunderbird security update (Important)</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>Red Hat Enterprise Linux 5</oval-def:platform>
+      <oval-def:platform>Red Hat Enterprise Linux 6</oval-def:platform>
+      <oval-def:platform>CentOS Linux 5</oval-def:platform>
+      <oval-def:platform>CentOS Linux 6</oval-def:platform>
+      <oval-def:product>thunderbird</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="RHSA-2014:0133-00" ref_url="https://rhn.redhat.com/errata/RHSA-2014-0133.html" source="VENDOR" />
+    <oval-def:reference ref_id="CESA-2014:0133" source="CESA" />
+    <oval-def:reference ref_id="CVE-2014-1477" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1477.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1479" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1479.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1481" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1481.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1482" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1482.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1486" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1486.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1487" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1487.html" source="CVE" />
+    <oval-def:description>The Web workers implementation in Mozilla Firefox before 27.0, Firefox ESR 24.x before 24.3, Thunderbird before 24.3, and SeaMonkey before 2.24 allows remote attackers to bypass the Same Origin Policy and obtain sensitive authentication information via vectors involving error messages.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2014-02-14T11:55:48">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2014-02-19T08:08:15.974-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2014-03-10T04:00:35.023-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2014-03-31T04:00:11.697-04:00">ACCEPTED</oval-def:status_change>
+        <oval-def:modified comment="EDITED oval:org.mitre.oval:def:21707 - CentOS was added to RedHat vulnerabilities and products were added were nessesary." date="2014-04-23T10:34:00.988-04:00">
+          <oval-def:contributor organization="ALTX-SOFT">Maria Mikhno</oval-def:contributor>
+        </oval-def:modified>
+        <oval-def:status_change date="2014-04-23T10:36:15.711-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2014-05-12T04:00:09.096-04:00">ACCEPTED</oval-def:status_change>
+        <oval-def:modified comment="EDITED oval:org.mitre.oval:def:21707 - RHEL/CentOS  patches with added CESA ids" date="2014-06-20T11:49:00.014-04:00">
+          <oval-def:contributor organization="ALTX-SOFT">Maria Mikhno</oval-def:contributor>
+        </oval-def:modified>
+        <oval-def:status_change date="2014-06-20T11:51:39.703-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2014-07-07T04:00:52.145-04:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criteria comment="Operation system section">
+      <oval-def:extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 5" definition_ref="oval:org.mitre.oval:def:11414" />
+      <oval-def:criterion comment="thunderbird is earlier than 0:24.3.0-2.el5_10" test_ref="oval:org.mitre.oval:tst:100278" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Operation system section">
+      <oval-def:criterion comment="thunderbird is earlier than 0:24.3.0-2.el6_5" test_ref="oval:org.mitre.oval:tst:100038" />
+      <oval-def:extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 6" definition_ref="oval:org.mitre.oval:def:20273" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Centos 5 section" operator="AND">
+      <oval-def:extend_definition comment="The operating system installed on the system is CentOS Linux 5.x" definition_ref="oval:org.mitre.oval:def:15802" />
+      <oval-def:criterion comment="thunderbird is earlier than 0:24.3.0-2.el5.centos" test_ref="oval:org.mitre.oval:tst:113897" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Centos 6 section" operator="AND">
+      <oval-def:criterion comment="thunderbird is earlier than 0:24.3.0-2.el6.centos" test_ref="oval:org.mitre.oval:tst:113478" />
+      <oval-def:extend_definition comment="The operating system installed on the system is CentOS Linux 6.x" definition_ref="oval:org.mitre.oval:def:16337" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/patch/oval_org.mitre.oval_def_22534.xml
+++ b/repository/definitions/patch/oval_org.mitre.oval_def_22534.xml
@@ -1,61 +1,61 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:org.mitre.oval:def:22534" version="67">
-  <metadata>
-    <title>RHSA-2014:0132: firefox security update (Critical)</title>
-    <affected family="unix">
-      <platform>Red Hat Enterprise Linux 6</platform>
-      <platform>Red Hat Enterprise Linux 5</platform>
-      <platform>CentOS Linux 5</platform>
-      <platform>CentOS Linux 6</platform>
-      <product>firefox</product>
-    </affected>
-    <reference ref_id="RHSA-2014:0132-00" ref_url="https://rhn.redhat.com/errata/RHSA-2014-0132.html" source="VENDOR" />
-    <reference ref_id="CESA-2014:0132" source="CESA" />
-    <reference ref_id="CVE-2014-1477" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1477.html" source="CVE" />
-    <reference ref_id="CVE-2014-1479" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1479.html" source="CVE" />
-    <reference ref_id="CVE-2014-1481" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1481.html" source="CVE" />
-    <reference ref_id="CVE-2014-1482" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1482.html" source="CVE" />
-    <reference ref_id="CVE-2014-1486" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1486.html" source="CVE" />
-    <reference ref_id="CVE-2014-1487" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1487.html" source="CVE" />
-    <description>The Web workers implementation in Mozilla Firefox before 27.0, Firefox ESR 24.x before 24.3, Thunderbird before 24.3, and SeaMonkey before 2.24 allows remote attackers to bypass the Same Origin Policy and obtain sensitive authentication information via vectors involving error messages.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2014-02-14T11:55:48">
-          <contributor organization="ALTX-SOFT">Sergey Artykhov</contributor>
-        </submitted>
-        <status_change date="2014-02-19T08:08:16.817-05:00">DRAFT</status_change>
-        <status_change date="2014-03-10T04:00:47.912-04:00">INTERIM</status_change>
-        <status_change date="2014-03-31T04:00:31.335-04:00">ACCEPTED</status_change>
-        <modified comment="EDITED oval:org.mitre.oval:def:22534 - CentOS was added to RedHat vulnerabilities and products were added were nessesary." date="2014-04-23T10:34:00.988-04:00">
-          <contributor organization="ALTX-SOFT">Maria Mikhno</contributor>
-        </modified>
-        <status_change date="2014-04-23T10:36:14.930-04:00">INTERIM</status_change>
-        <status_change date="2014-05-12T04:00:20.704-04:00">ACCEPTED</status_change>
-        <modified comment="EDITED oval:org.mitre.oval:def:22534 - RHEL/CentOS  patches with added CESA ids" date="2014-06-20T11:49:00.014-04:00">
-          <contributor organization="ALTX-SOFT">Maria Mikhno</contributor>
-        </modified>
-        <status_change date="2014-06-20T11:51:33.437-04:00">INTERIM</status_change>
-        <status_change date="2014-07-07T04:00:56.902-04:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.3</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria operator="OR">
-    <criteria comment="Operation system section">
-      <extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 5" definition_ref="oval:org.mitre.oval:def:11414" />
-      <criterion comment="firefox is earlier than 0:24.3.0-2.el5_10" test_ref="oval:org.mitre.oval:tst:100310" />
-    </criteria>
-    <criteria comment="Operation system section">
-      <criterion comment="firefox is earlier than 0:24.3.0-2.el6_5" test_ref="oval:org.mitre.oval:tst:100086" />
-      <extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 6" definition_ref="oval:org.mitre.oval:def:20273" />
-    </criteria>
-    <criteria comment="Centos 5 section" operator="AND">
-      <extend_definition comment="The operating system installed on the system is CentOS Linux 5.x" definition_ref="oval:org.mitre.oval:def:15802" />
-      <criterion comment="libvirt-client is earlier than 0:0.10.2-29.el6_5.3" test_ref="oval:org.mitre.oval:tst:113809" />
-    </criteria>
-    <criteria comment="Centos 6 section" operator="AND">
-      <criterion comment="libvirt-python is earlier than 0:0.10.2-29.el6_5.3" test_ref="oval:org.mitre.oval:tst:113156" />
-      <extend_definition comment="The operating system installed on the system is CentOS Linux 6.x" definition_ref="oval:org.mitre.oval:def:16337" />
-    </criteria>
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="patch" id="oval:org.mitre.oval:def:22534" version="67">
+  <oval-def:metadata>
+    <oval-def:title>RHSA-2014:0132: firefox security update (Critical)</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>Red Hat Enterprise Linux 6</oval-def:platform>
+      <oval-def:platform>Red Hat Enterprise Linux 5</oval-def:platform>
+      <oval-def:platform>CentOS Linux 5</oval-def:platform>
+      <oval-def:platform>CentOS Linux 6</oval-def:platform>
+      <oval-def:product>firefox</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="RHSA-2014:0132-00" ref_url="https://rhn.redhat.com/errata/RHSA-2014-0132.html" source="VENDOR" />
+    <oval-def:reference ref_id="CESA-2014:0132" source="CESA" />
+    <oval-def:reference ref_id="CVE-2014-1477" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1477.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1479" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1479.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1481" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1481.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1482" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1482.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1486" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1486.html" source="CVE" />
+    <oval-def:reference ref_id="CVE-2014-1487" ref_url="https://www.redhat.com/security/data/cve/CVE-2014-1487.html" source="CVE" />
+    <oval-def:description>The Web workers implementation in Mozilla Firefox before 27.0, Firefox ESR 24.x before 24.3, Thunderbird before 24.3, and SeaMonkey before 2.24 allows remote attackers to bypass the Same Origin Policy and obtain sensitive authentication information via vectors involving error messages.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2014-02-14T11:55:48">
+          <oval-def:contributor organization="ALTX-SOFT">Sergey Artykhov</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2014-02-19T08:08:16.817-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2014-03-10T04:00:47.912-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2014-03-31T04:00:31.335-04:00">ACCEPTED</oval-def:status_change>
+        <oval-def:modified comment="EDITED oval:org.mitre.oval:def:22534 - CentOS was added to RedHat vulnerabilities and products were added were nessesary." date="2014-04-23T10:34:00.988-04:00">
+          <oval-def:contributor organization="ALTX-SOFT">Maria Mikhno</oval-def:contributor>
+        </oval-def:modified>
+        <oval-def:status_change date="2014-04-23T10:36:14.930-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2014-05-12T04:00:20.704-04:00">ACCEPTED</oval-def:status_change>
+        <oval-def:modified comment="EDITED oval:org.mitre.oval:def:22534 - RHEL/CentOS  patches with added CESA ids" date="2014-06-20T11:49:00.014-04:00">
+          <oval-def:contributor organization="ALTX-SOFT">Maria Mikhno</oval-def:contributor>
+        </oval-def:modified>
+        <oval-def:status_change date="2014-06-20T11:51:33.437-04:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2014-07-07T04:00:56.902-04:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criteria comment="Operation system section">
+      <oval-def:extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 5" definition_ref="oval:org.mitre.oval:def:11414" />
+      <oval-def:criterion comment="firefox is earlier than 0:24.3.0-2.el5_10" test_ref="oval:org.mitre.oval:tst:100310" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Operation system section">
+      <oval-def:criterion comment="firefox is earlier than 0:24.3.0-2.el6_5" test_ref="oval:org.mitre.oval:tst:100086" />
+      <oval-def:extend_definition comment="The operating system installed on the system is Red Hat Enterprise Linux 6" definition_ref="oval:org.mitre.oval:def:20273" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Centos 5 section" operator="AND">
+      <oval-def:extend_definition comment="The operating system installed on the system is CentOS Linux 5.x" definition_ref="oval:org.mitre.oval:def:15802" />
+      <oval-def:criterion comment="firefox is earlier than 0:24.3.0-2.el5.centos" test_ref="oval:org.mitre.oval:tst:113809" />
+    </oval-def:criteria>
+    <oval-def:criteria comment="Centos 6 section" operator="AND">
+      <oval-def:criterion comment="firefox is earlier than 0:24.3.0-2.el6.centos" test_ref="oval:org.mitre.oval:tst:113156" />
+      <oval-def:extend_definition comment="The operating system installed on the system is CentOS Linux 6.x" definition_ref="oval:org.mitre.oval:def:16337" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/states/linux/rpminfo_state/0000/oval_ru.altx-soft.nix_ste_1.xml
+++ b/repository/states/linux/rpminfo_state/0000/oval_ru.altx-soft.nix_ste_1.xml
@@ -1,0 +1,3 @@
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:ru.altx-soft.nix:ste:1" version="0">
+  <evr datatype="evr_string" operation="less than">0:24.3.0-2.el6.centos</evr>
+</rpminfo_state>

--- a/repository/states/linux/rpminfo_state/0000/oval_ru.altx-soft.nix_ste_2.xml
+++ b/repository/states/linux/rpminfo_state/0000/oval_ru.altx-soft.nix_ste_2.xml
@@ -1,0 +1,3 @@
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:ru.altx-soft.nix:ste:2" version="0">
+  <evr datatype="evr_string" operation="less than">0:24.3.0-2.el5.centos</evr>
+</rpminfo_state>

--- a/repository/tests/linux/rpminfo_test/113000/oval_org.mitre.oval_tst_113156.xml
+++ b/repository/tests/linux/rpminfo_test/113000/oval_org.mitre.oval_tst_113156.xml
@@ -1,4 +1,4 @@
-<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="libvirt-python is earlier than 0:0.10.2-29.el6_5.3" id="oval:org.mitre.oval:tst:113156" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:15191" />
-  <state state_ref="oval:org.mitre.oval:ste:30795" />
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="firefox is earlier than 0:24.3.0-2.el6.centos" id="oval:org.mitre.oval:tst:113156" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:13805" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:1" />
 </rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/113000/oval_org.mitre.oval_tst_113478.xml
+++ b/repository/tests/linux/rpminfo_test/113000/oval_org.mitre.oval_tst_113478.xml
@@ -1,4 +1,4 @@
-<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="libvirt-lock-sanlock is earlier than 0:0.10.2-29.el6_5.3" id="oval:org.mitre.oval:tst:113478" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:28971" />
-  <state state_ref="oval:org.mitre.oval:ste:30795" />
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="thunderbird is earlier than 0:24.3.0-2.el6.centos" id="oval:org.mitre.oval:tst:113478" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:14449" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:1" />
 </rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/113000/oval_org.mitre.oval_tst_113809.xml
+++ b/repository/tests/linux/rpminfo_test/113000/oval_org.mitre.oval_tst_113809.xml
@@ -1,4 +1,4 @@
-<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="libvirt-client is earlier than 0:0.10.2-29.el6_5.3" id="oval:org.mitre.oval:tst:113809" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:29031" />
-  <state state_ref="oval:org.mitre.oval:ste:30795" />
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="firefox is earlier than 0:24.3.0-2.el5.centos" id="oval:org.mitre.oval:tst:113809" version="2">
+  <object object_ref="oval:org.mitre.oval:obj:13805" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:2" />
 </rpminfo_test>

--- a/repository/tests/linux/rpminfo_test/113000/oval_org.mitre.oval_tst_113897.xml
+++ b/repository/tests/linux/rpminfo_test/113000/oval_org.mitre.oval_tst_113897.xml
@@ -1,4 +1,4 @@
-<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="libvirt-devel is earlier than 0:0.10.2-29.el6_5.3" id="oval:org.mitre.oval:tst:113897" version="3">
-  <object object_ref="oval:org.mitre.oval:obj:14880" />
-  <state state_ref="oval:org.mitre.oval:ste:30795" />
+<rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="at least one" check_existence="at_least_one_exists" comment="thunderbird is earlier than 0:24.3.0-2.el5.centos" id="oval:org.mitre.oval:tst:113897" version="3">
+  <object object_ref="oval:org.mitre.oval:obj:14449" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:2" />
 </rpminfo_test>


### PR DESCRIPTION
CPE was added to Microsoft .NET Framework 4.7.1 inventory.
In patches oval:org.mitre.oval:def:21707 and oval:org.mitre.oval:def:22534 were wrong checks.