### PR TITLE
Update oval_org.cisecurity_def_5689.xml

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5689.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5689.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:5689" version="2">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" deprecated="true" id="oval:org.cisecurity:def:5689" version="2">
   <metadata>
     <title> Windows Hyper-V Denial of Service Vulnerability - CVE-2018-8436</title>
     <affected family="windows">


### PR DESCRIPTION
oval:org.cisecurity:def:5687 and oval:org.cisecurity:def:5689 are duplicates. oval:org.cisecurity:def:5689 should be deprecated.