### PR TITLE
Update oval_org.mitre.oval_def_28359.xml

### DIFF
--- a/repository/definitions/vulnerability/oval_org.mitre.oval_def_28359.xml
+++ b/repository/definitions/vulnerability/oval_org.mitre.oval_def_28359.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:28359" version="38">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.mitre.oval:def:28359" version="39">
   <metadata>
     <title>A potential security vulnerability has been identified in the HP-UX running PAM using
           libpam_updbe in pam.conf(4). This vulnerability could allow remote users to bypass certain
@@ -22,6 +22,9 @@
         <modified comment="EDITED oval:org.mitre.oval:def:28359 - Corrected repository status" date="2015-04-09T12:56:00.133-04:00">
           <contributor organization="The MITRE Corporation">Mike Cokus</contributor>
         </modified>
+        <modified comment="EDITED oval:org.mitre.oval:def:28359 - Fixed OS applicability " date="2018-10-09T12:54:00.133-04:00">
+          <contributor organization="Rapid7">Adam Bunn</contributor>
+        </modified>
         <status_change date="2015-04-27T04:00:13.455-04:00">ACCEPTED</status_change>
       </dates>
       <status>ACCEPTED</status>
@@ -30,7 +33,7 @@
   </metadata>
   <criteria operator="OR">
     <criteria comment="Criteria meets HP Security Bulletin HPSBUX03166" operator="AND">
-      <criterion comment="HP-UX B.11.31" test_ref="oval:org.mitre.oval:tst:8260" />
+      <criterion comment="HP-UX B.11.11" test_ref="oval:org.mitre.oval:tst:3704" />
       <criteria comment="filesets tests" operator="OR">
         <criterion comment="OS-Core.ADMN-ENG-A-MAN is installed" test_ref="oval:org.mitre.oval:tst:8060" />
         <criterion comment="OS-Core.CORE-ENG-A-MAN is installed" test_ref="oval:org.mitre.oval:tst:113428" />


### PR DESCRIPTION
This definition has a mistake that is leading to incorrect results. Patch `PHCO_43873` is only applicable to `B.11.11`
https://support.hpe.com/hpsc/doc/public/display?docId=emr_na-c04511778&docLocale=en_US