### PR TITLE
CVE-2018-8501 incomplete

### DIFF
--- a/repository/definitions/vulnerability/oval_org.xorcism_def_20188501.xml
+++ b/repository/definitions/vulnerability/oval_org.xorcism_def_20188501.xml
@@ -1,0 +1,63 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.xorcism:def:20188501" version="0">
+	<oval-def:metadata>
+		<oval-def:title>Vulnerability - CVE-2018-8501</oval-def:title>
+		<oval-def:affected family="windows">
+			<oval-def:platform>Microsoft Windows 10</oval-def:platform>
+			<oval-def:platform>Microsoft Windows 2000</oval-def:platform>
+			<oval-def:platform>Microsoft Windows 7</oval-def:platform>
+			<oval-def:platform>Microsoft Windows 8</oval-def:platform>
+			<oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+			<oval-def:platform>Microsoft Windows XP</oval-def:platform>
+			<oval-def:product>Office 2010</oval-def:product>
+			<oval-def:product>Office 2013</oval-def:product>
+			<oval-def:product>Office 2016</oval-def:product>
+			<oval-def:product>Powerpoint 2010</oval-def:product>
+			<oval-def:product>Powerpoint 2013</oval-def:product>
+			<oval-def:product>Powerpoint 2016</oval-def:product>
+			<oval-def:product>Powerpoint Viewer 2010</oval-def:product>
+		</oval-def:affected>
+		<oval-def:reference ref_id="CVE-2018-8501" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8501" source="CVE" />
+		<oval-def:description>CVE-2018-8501 | Microsoft PowerPoint Remote Code Execution Vulnerability</oval-def:description>
+		<oval-def:oval_repository>
+			<oval-def:dates>
+				<oval-def:submitted date="2018-10-31T21:18:10+03:00">
+					<oval-def:contributor organization="FRHACK">Jerome Athias</oval-def:contributor>
+				</oval-def:submitted>
+			</oval-def:dates>
+			<oval-def:status>INITIAL SUBMISSION</oval-def:status>
+		</oval-def:oval_repository>
+	</oval-def:metadata>
+	<oval-def:criteria operator="OR">
+		<oval-def:criteria comment="Office 2010 Service Pack 2 + file version" operator="AND">
+			<oval-def:extend_definition comment="Microsoft Office 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17121" />
+			<oval-def:criterion comment="Check if mso.dll version is less than 14.0.7214.5000" test_ref="oval:org.xorcism:tst:1639" />
+		</oval-def:criteria>
+		<oval-def:criteria comment="Office 2013 Service Pack 1 + file version" operator="AND">
+			<oval-def:extend_definition comment="Microsoft Office 2013 SP1 x64 is installed" definition_ref="oval:org.mitre.oval:def:21966" />
+			<oval-def:criterion comment="Check if mso.dll version is less than 15.0.5075.1001" test_ref="oval:org.xorcism:tst:1634" />
+		</oval-def:criteria>
+		<oval-def:criteria comment="Office 2016 + file version" operator="AND">
+			<oval-def:extend_definition comment="Microsoft Office 2016 is installed" definition_ref="oval:org.cisecurity:def:2618" />
+			<oval-def:criterion comment="Check if mso.dll version is less than 16.0.4756.1000" test_ref="oval:org.xorcism:tst:1635" />
+		</oval-def:criteria>
+		<oval-def:criteria comment="Powerpoint 2010 Service Pack 2 + file version" operator="AND">
+			<oval-def:extend_definition comment="Microsoft PowerPoint 2010 SP2 is installed" definition_ref="oval:org.mitre.oval:def:17767" />
+			<oval-def:criterion comment="Check if ppcore.dll version is less than 14.0.7214.5000" test_ref="oval:org.xorcism:tst:1653" />
+		</oval-def:criteria>
+		<oval-def:criteria comment="Powerpoint 2016 + file version" operator="AND">
+			<oval-def:extend_definition comment="Microsoft PowerPoint 2016 is installed" definition_ref="oval:org.cisecurity:def:3225" />
+			<oval-def:criterion comment="Check if ppcore.dll version is less than 16.0.4756.1000" test_ref="oval:org.xorcism:tst:1655" />
+		</oval-def:criteria>
+		<oval-def:criteria comment="Powerpoint Viewer 2010 + file version" operator="AND">
+			<oval-def:extend_definition comment="Microsoft PowerPoint Viewer 2010 is installed" definition_ref="oval:org.mitre.oval:def:12520" />
+			<oval-def:criterion comment="Check if pptview.exe version is less than 14.0.7214.5000" test_ref="oval:org.xorcism:tst:1730" />
+		</oval-def:criteria>
+	</oval-def:criteria>
+</oval-def:definition>

--- a/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1612.xml
+++ b/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1612.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 15.0.5075.1001" id="oval:org.xorcism:ste:1612" version="0">
+	<version datatype="version" operation="less than">15.0.5075.1001</version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1613.xml
+++ b/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1613.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 16.0.4756.1000" id="oval:org.xorcism:ste:1613" version="0">
+	<version datatype="version" operation="less than">16.0.4756.1000</version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1617.xml
+++ b/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1617.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 14.0.7214.5000" id="oval:org.xorcism:ste:1617" version="0">
+	<version datatype="version" operation="less than">14.0.7214.5000</version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1631.xml
+++ b/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1631.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 14.0.7214.5000" id="oval:org.xorcism:ste:1631" version="0">
+	<version datatype="version" operation="less than">14.0.7214.5000</version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1633.xml
+++ b/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1633.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 16.0.4756.1000" id="oval:org.xorcism:ste:1633" version="0">
+	<version datatype="version" operation="less than">16.0.4756.1000</version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1707.xml
+++ b/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1707.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 14.0.7214.5000" id="oval:org.xorcism:ste:1707" version="0">
+	<version datatype="version" operation="less than">14.0.7214.5000</version>
+</file_state>

--- a/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1634.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1634.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if mso.dll version is less than 15.0.5075.1001" id="oval:org.xorcism:tst:1634" version="0">
+	<object object_ref="oval:org.cisecurity:obj:323" />
+	<state state_ref="oval:org.xorcism:ste:1612" />
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1635.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1635.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if mso.dll version is less than 16.0.4756.1000" id="oval:org.xorcism:tst:1635" version="0">
+	<object object_ref="oval:org.cisecurity:obj:351" />
+	<state state_ref="oval:org.xorcism:ste:1613" />
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1639.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1639.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if mso.dll version is less than 14.0.7214.5000" id="oval:org.xorcism:tst:1639" version="0">
+	<object object_ref="oval:org.mitre.oval:obj:24248" />
+	<state state_ref="oval:org.xorcism:ste:1617" />
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1653.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1653.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if ppcore.dll version is less than 14.0.7214.5000" id="oval:org.xorcism:tst:1653" version="0">
+	<object object_ref="oval:org.mitre.oval:obj:16004" />
+	<state state_ref="oval:org.xorcism:ste:1631" />
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1655.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1655.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if ppcore.dll version is less than 16.0.4756.1000" id="oval:org.xorcism:tst:1655" version="0">
+	<object object_ref="oval:org.cisecurity:obj:1168" />
+	<state state_ref="oval:org.xorcism:ste:1633" />
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1730.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1730.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if pptview.exe version is less than 14.0.7214.5000" id="oval:org.xorcism:tst:1730" version="0">
+	<object object_ref="oval:org.mitre.oval:obj:16025" />
+	<state state_ref="oval:org.xorcism:ste:1707" />
+</file_test>


### PR DESCRIPTION
NOTE: Missing criteria for Powerpoint 2013 Service Pack 1 (cause no inventory -
 TODO)

		<oval-def:criteria comment="Powerpoint 2013 Service Pack 1 + file version" operator="AND">
			<oval-def:extend_definition comment="" definition_ref="" />
			<oval-def:criterion comment="Check if powerpnt.exe version is less than 15.0.5075.1000" test_ref="oval:org.xorcism:tst:1654" />
		</oval-def:criteria>