### PR TITLE
Modified products on CVE-2018-11235

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_5114.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_5114.xml
@@ -10,8 +10,7 @@
       <platform>Microsoft Windows Server 2012 R2</platform>
       <platform>Microsoft Windows 10</platform>
       <platform>Microsoft Windows Server 2016</platform>
-      <product>Microsoft Office 2013</product>
-      <product>Microsoft Office 2016</product>
+		  <product>Git</product>
     </affected>
     <reference ref_id="CVE-2018-11235" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235" source="CVE" />
     <description>In Git before 2.13.7, 2.14.x before 2.14.4, 2.15.x before 2.15.2, 2.16.x before 2.16.4, and 2.17.x before 2.17.1, remote code execution can occur. With a crafted .gitmodules file, a malicious project can execute an arbitrary script on a machine that runs "git clone --recurse-submodules" because submodule "names" are obtained from this file, and then appended to $GIT_DIR/modules, leading to directory traversal with "../" in a name. Finally, post-checkout hooks from a submodule are executed, bypassing the intended design in which hooks are not obtained from a remote server.</description>
@@ -23,8 +22,12 @@
         <status_change date="2018-06-08T13:18:01.158-05:00">DRAFT</status_change>
         <status_change date="2018-06-22T04:00:08.269-05:00">INTERIM</status_change>
         <status_change date="2018-07-06T12:30:00.000-05:00">ACCEPTED</status_change>
+        <modified comment="Changed product to Git" date="2018-11-06T12:33:56.231-04:00">
+          <contributor organization="RootSecure">Brendan Reekie</contributor>
+        </modified>
+        <status_change date="2018-11-06T12:33:56.231-04:00">INTERIM</status_change>
       </dates>
-      <status>ACCEPTED</status>
+      <status>INTERIM</status>
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>


### PR DESCRIPTION
Removed the Microsoft Office products and replaced with the correct Git product.