### PR TITLE
CVE-2018-8589

### DIFF
--- a/repository/definitions/vulnerability/oval_org.xorcism_def_20188589.xml
+++ b/repository/definitions/vulnerability/oval_org.xorcism_def_20188589.xml
@@ -1,0 +1,39 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.xorcism:def:20188589" version="0">
+	<oval-def:metadata>
+		<oval-def:title>Windows Win32k Elevation of Privilege Vulnerability This affects Windows Server 2008, Windows 7, Windows Server 2008 R2 - CVE-2018-8589</oval-def:title>
+		<oval-def:affected family="windows">
+			<oval-def:platform>Microsoft Windows 7</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+			<oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+		</oval-def:affected>
+		<oval-def:reference ref_id="CVE-2018-8589" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8589" source="CVE" />
+		<oval-def:description>An elevation of privilege vulnerability exists when Windows improperly handles calls to Win32k.sys, aka "Windows Win32k Elevation of Privilege Vulnerability." This affects Windows Server 2008, Windows 7, Windows Server 2008 R2.</oval-def:description>
+		<oval-def:oval_repository>
+			<oval-def:dates>
+				<oval-def:submitted date="2018-11-14T19:47:46+03:00">
+					<oval-def:contributor organization="FRHACK">Jerome Athias</oval-def:contributor>
+				</oval-def:submitted>
+			</oval-def:dates>
+			<oval-def:status>INITIAL SUBMISSION</oval-def:status>
+		</oval-def:oval_repository>
+	</oval-def:metadata>
+	<oval-def:criteria comment="Check for installation of vulnerable Windows OS + vulnerable file version" operator="OR">
+		<oval-def:criteria comment="Windows Server 2008 R2/Windows Server 2008 R2 SP1/Windows 7 is installed + file version" operator="AND">
+			<oval-def:criteria comment="Windows Server 2008 R2/Windows Server 2008 R2 SP1/Windows 7 is installed" operator="OR">
+				<oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:6438" />
+				<oval-def:extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition is installed" definition_ref="oval:org.mitre.oval:def:5954" />
+				<oval-def:extend_definition comment="Microsoft Windows 7 (32-bit) is installed" definition_ref="oval:org.mitre.oval:def:6165" />
+				<oval-def:extend_definition comment="Microsoft Windows 7 x64 Edition is installed" definition_ref="oval:org.mitre.oval:def:5950" />
+			</oval-def:criteria>
+			<oval-def:criterion comment="Check if win32k.sys version is less than 6.1.7601.24288" test_ref="oval:org.xorcism:tst:1875" />
+		</oval-def:criteria>
+		<oval-def:criteria comment="Windows Server 2008/Windows Server 2008 SP2 is installed + file version" operator="AND">
+			<oval-def:criteria comment="Windows Server 2008/Windows Server 2008 SP2 is installed" operator="OR">
+				<oval-def:extend_definition comment="Microsoft Windows Server 2008 is installed" definition_ref="oval:org.mitre.oval:def:12824" />
+				<oval-def:extend_definition comment="Microsoft Windows Server 2008 x64 Edition Service Pack 2 is installed" definition_ref="oval:org.mitre.oval:def:6216" />
+				<oval-def:extend_definition comment="Microsoft Windows Server 2008 (ia-64) is installed" definition_ref="oval:org.mitre.oval:def:5667" />
+			</oval-def:criteria>
+			<oval-def:criterion comment="Check if win32k.sys version is less than 6.0.6002.24520" test_ref="oval:org.xorcism:tst:1876" />
+		</oval-def:criteria>
+	</oval-def:criteria>
+</oval-def:definition>

--- a/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1851.xml
+++ b/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1851.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 6.1.7601.24288" id="oval:org.xorcism:ste:1851" version="0">
+	<version datatype="version" operation="less than">6.1.7601.24288</version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1852.xml
+++ b/repository/states/windows/file_state/1000/oval_org.xorcism_ste_1852.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 6.0.6002.24520" id="oval:org.xorcism:ste:1852" version="0">
+	<version datatype="version" operation="less than">6.0.6002.24520</version>
+</file_state>

--- a/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1875.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1875.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if win32k.sys version is less than 6.1.7601.24288" id="oval:org.xorcism:tst:1875" version="0">
+	<object object_ref="oval:org.mitre.oval:obj:570" />
+	<state state_ref="oval:org.xorcism:ste:1851" />
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1876.xml
+++ b/repository/tests/windows/file_test/1000/oval_org.xorcism_tst_1876.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if win32k.sys version is less than 6.0.6002.24520" id="oval:org.xorcism:tst:1876" version="0">
+	<object object_ref="oval:org.mitre.oval:obj:570" />
+	<state state_ref="oval:org.xorcism:ste:1852" />
+</file_test>


### PR DESCRIPTION
CVE-2018-8589
Missing windows server 2008 r2 x64 service pack 1 (not Release candidate), 20181027 win32k.sys 6.1.7601.24288