### PR TITLE
Fixed path to file Microsoft.sharepoint.publishing.dll for SharePoint 2010

### DIFF
--- a/repository/objects/windows/file_object/23000/oval_ru.test.win_obj_23976.xml
+++ b/repository/objects/windows/file_object/23000/oval_ru.test.win_obj_23976.xml
@@ -1,0 +1,4 @@
+<file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds the path to Microsoft.sharepoint.publishing.dll (SharePoint 2010)" id="oval:ru.test.win:obj:23976" version="0">
+  <path var_check="all" var_ref="oval:org.mitre.oval:var:1138" />
+  <filename>Microsoft.sharepoint.publishing.dll</filename>
+</file_object>

--- a/repository/tests/windows/file_test/6000/oval_org.cisecurity_tst_6783.xml
+++ b/repository/tests/windows/file_test/6000/oval_org.cisecurity_tst_6783.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Microsoft.sharepoint.publishing.dll version is less than 14.0.7197.5000" id="oval:org.cisecurity:tst:6783" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:23976" />
+  <object object_ref="oval:ru.test.win:obj:23976" />
   <state state_ref="oval:org.cisecurity:ste:5036" />
 </file_test>

--- a/repository/tests/windows/file_test/8000/oval_org.cisecurity_tst_8659.xml
+++ b/repository/tests/windows/file_test/8000/oval_org.cisecurity_tst_8659.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Microsoft.sharepoint.publishing.dll version is less than 14.0.7213.5000" id="oval:org.cisecurity:tst:8659" version="2">
-  <object object_ref="oval:org.mitre.oval:obj:23976" />
+  <object object_ref="oval:ru.test.win:obj:23976" />
   <state state_ref="oval:org.cisecurity:ste:6536" />
 </file_test>


### PR DESCRIPTION
Before this fix path {install_path}12.0\BIN was checked when Microsoft.sharepoint.publishing.dll for SharePoint 2010 was finding. But it should be checked in {install_path}14.0\BIN folder