### PR TITLE
Update oval_org.mitre.oval_def_18828.xml

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_18828.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_18828.xml
@@ -4,7 +4,7 @@
     <oval-def:affected family="unix">
       <oval-def:platform>IBM AIX 7.1</oval-def:platform>
     </oval-def:affected>
-    <oval-def:reference ref_id="cpe:/o:ibm:aix:7.1" source="CVE" />
+    <oval-def:reference ref_id="cpe:/o:ibm:aix:7.1" source="CPE" />
     <oval-def:description>The operating system installed on the system is IBM AIX 7.1.</oval-def:description>
     <oval-def:oval_repository>
       <oval-def:dates>


### PR DESCRIPTION
source="CPE" was replaced with CVE by mistake