### PR TITLE
Source fix in oval:org.mitre.oval:def:18828

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_18828.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_18828.xml
@@ -4,7 +4,7 @@
     <affected family="unix">
       <platform>IBM AIX 7.1</platform>
     </affected>
-    <reference ref_id="cpe:/o:ibm:aix:7.1" source="CVE" />
+    <reference ref_id="cpe:/o:ibm:aix:7.1" source="CPE" />
     <description>The operating system installed on the system is IBM AIX 7.1.</description>
     <oval_repository>
       <dates>


### PR DESCRIPTION
source="CPE" was replaced with CVE by mistake