### PR TITLE
Fix test missing oval id

### DIFF
--- a/repository/tests/windows/registry_test/9000/oval_org.cisecurity_tst_9236.xml
+++ b/repository/tests/windows/registry_test/9000/oval_org.cisecurity_tst_9236.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows ReleaseId is 1809" version="4">
+<registry_test id="oval:org.cisecurity:tst:9236" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Windows ReleaseId is 1809" version="4">
   <object object_ref="oval:org.cisecurity:obj:131" />
   <state state_ref="oval:org.cisecurity:ste:7082" />
 </registry_test>


### PR DESCRIPTION
This PR fixes a mistake introduced by our last PR. It appears that we accidentally removed an OVAL id from a this test. Logs show that we validated the content before submitting, so we will have to investigate why this happened. In the meantime, this PR fixes the issue!