### PR TITLE
SLED 12 and SLES 12 inventories modification

### DIFF
--- a/repository/definitions/inventory/oval_org.mitre.oval_def_28148.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_28148.xml
@@ -16,10 +16,10 @@
         <oval-def:status_change date="2014-12-22T04:00:10.428-05:00">ACCEPTED</oval-def:status_change>
       </oval-def:dates>
       <oval-def:status>ACCEPTED</oval-def:status>
-      <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
-  <oval-def:criteria>
+  <oval-def:criteria operator="OR">
     <oval-def:criterion comment="SUSE Linux Enterprise Desktop 12 is installed" test_ref="oval:org.mitre.oval:tst:135250" />
+    <oval-def:criterion comment="SUSE Linux Enterprise Desktop 12 is installed (os-release)" test_ref="oval:ru.test.nix:tst:1" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/inventory/oval_org.mitre.oval_def_28211.xml
+++ b/repository/definitions/inventory/oval_org.mitre.oval_def_28211.xml
@@ -1,25 +1,26 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:28211" version="5">
-  <metadata>
-    <title>SUSE Linux Enterprise Server 12 is installed</title>
-    <affected family="unix">
-      <platform>SUSE Linux Enterprise Server 12</platform>
-    </affected>
-    <reference ref_id="cpe:/o:novell:suse_linux:12::server" source="CPE" />
-    <description>SUSE Linux Enterprise Server 12 is installed.</description>
-    <oval_repository>
-      <dates>
-        <submitted date="2014-11-07T16:31:26.748+04:00">
-          <contributor organization="ALTX-SOFT">Maria Mikhno</contributor>
-        </submitted>
-        <status_change date="2014-11-13T08:35:45.726-05:00">DRAFT</status_change>
-        <status_change date="2014-12-01T04:01:06.230-05:00">INTERIM</status_change>
-        <status_change date="2014-12-22T04:00:11.008-05:00">ACCEPTED</status_change>
-      </dates>
-      <status>ACCEPTED</status>
-      <min_schema_version>5.3</min_schema_version>
-    </oval_repository>
-  </metadata>
-  <criteria>
-    <criterion comment="SUSE Linux Enterprise Server 12 is installed" test_ref="oval:org.mitre.oval:tst:135323" />
-  </criteria>
-</definition>
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:28211" version="5">
+  <oval-def:metadata>
+    <oval-def:title>SUSE Linux Enterprise Server 12 is installed</oval-def:title>
+    <oval-def:affected family="unix">
+      <oval-def:platform>SUSE Linux Enterprise Server 12</oval-def:platform>
+    </oval-def:affected>
+    <oval-def:reference ref_id="cpe:/o:novell:suse_linux:12::server" source="CPE" />
+    <oval-def:description>SUSE Linux Enterprise Server 12 is installed.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2014-11-07T16:31:26.748+04:00">
+          <oval-def:contributor organization="ALTX-SOFT">Maria Mikhno</oval-def:contributor>
+        </oval-def:submitted>
+        <oval-def:status_change date="2014-11-13T08:35:45.726-05:00">DRAFT</oval-def:status_change>
+        <oval-def:status_change date="2014-12-01T04:01:06.230-05:00">INTERIM</oval-def:status_change>
+        <oval-def:status_change date="2014-12-22T04:00:11.008-05:00">ACCEPTED</oval-def:status_change>
+      </oval-def:dates>
+      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:min_schema_version>5.3</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria operator="OR">
+    <oval-def:criterion comment="SUSE Linux Enterprise Server 12 is installed" test_ref="oval:org.mitre.oval:tst:135323" />
+    <oval-def:criterion comment="SUSE Linux Enterprise Server 12 is installed (os-release)" test_ref="oval:ru.test.nix:tst:171405" />
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/objects/independent/textfilecontent54_object/0000/oval_ru.altx-soft.nix_obj_1.xml
+++ b/repository/objects/independent/textfilecontent54_object/0000/oval_ru.altx-soft.nix_obj_1.xml
@@ -1,0 +1,6 @@
+<textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="Object holds SLED version" id="oval:ru.altx-soft.nix:obj:1" version="0">
+  <path>/etc</path>
+  <filename>os-release</filename>
+  <pattern operation="pattern match">^.*SUSE Linux Enterprise Desktop (\d+).*$</pattern>
+  <instance datatype="int">1</instance>
+</textfilecontent54_object>

--- a/repository/objects/independent/textfilecontent54_object/32000/oval_ru.altx-soft.nix_obj_32616.xml
+++ b/repository/objects/independent/textfilecontent54_object/32000/oval_ru.altx-soft.nix_obj_32616.xml
@@ -1,0 +1,6 @@
+<textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="Object holds SLES version" id="oval:ru.altx-soft.nix:obj:32616" version="0">
+  <path>/etc</path>
+  <filename>os-release</filename>
+  <pattern operation="pattern match">^.*SUSE Linux Enterprise Server (\d+).*$</pattern>
+  <instance datatype="int">1</instance>
+</textfilecontent54_object>

--- a/repository/states/independent/textfilecontent54_state/0000/oval_ru.altx-soft.nix_ste_1.xml
+++ b/repository/states/independent/textfilecontent54_state/0000/oval_ru.altx-soft.nix_ste_1.xml
@@ -1,0 +1,3 @@
+<textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="version is equal to 12" id="oval:ru.altx-soft.nix:ste:1" version="0">
+  <subexpression>12</subexpression>
+</textfilecontent54_state>

--- a/repository/states/independent/textfilecontent54_state/48000/oval_ru.altx-soft.nix_ste_48585.xml
+++ b/repository/states/independent/textfilecontent54_state/48000/oval_ru.altx-soft.nix_ste_48585.xml
@@ -1,0 +1,3 @@
+<textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="version is equal to 12" id="oval:ru.altx-soft.nix:ste:48585" version="0">
+  <subexpression>12</subexpression>
+</textfilecontent54_state>

--- a/repository/tests/independent/textfilecontent54_test/0000/oval_ru.test.nix_tst_1.xml
+++ b/repository/tests/independent/textfilecontent54_test/0000/oval_ru.test.nix_tst_1.xml
@@ -1,0 +1,4 @@
+<textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="SUSE Linux Enterprise Desktop 12 is installed (os-release)" id="oval:ru.test.nix:tst:1" version="0">
+  <object object_ref="oval:ru.altx-soft.nix:obj:1" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:1" />
+</textfilecontent54_test>

--- a/repository/tests/independent/textfilecontent54_test/171000/oval_ru.test.nix_tst_171405.xml
+++ b/repository/tests/independent/textfilecontent54_test/171000/oval_ru.test.nix_tst_171405.xml
@@ -1,0 +1,4 @@
+<textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="SUSE Linux Enterprise Server 12 is installed (os-release)" id="oval:ru.test.nix:tst:171405" version="0">
+  <object object_ref="oval:ru.altx-soft.nix:obj:32616" />
+  <state state_ref="oval:ru.altx-soft.nix:ste:48585" />
+</textfilecontent54_test>


### PR DESCRIPTION
There are a few versions of SLES 12 without sled-release rpm package. That's why second check of os-release file was added.