### PR TITLE
Improve performance of lib_oval.py 's getElementById method

### DIFF
--- a/scripts/lib_oval.py
+++ b/scripts/lib_oval.py
@@ -150,8 +150,14 @@ class OvalDocument(object):
             gen.setSchemaVersion("5.10.1")
             root.append(gen.get_element())
             return        
-        
+
         self.tree = tree
+        self.id_to_definition = { el.getId(): el for el in self.getDefinitions()} if self.getDefinitions() else {}
+        self.id_to_test = {el.getId(): el for el in self.getTests()} if self.getTests() else {}
+        self.id_to_object = {el.getId(): el for el in self.getObjects()} if self.getObjects() else {}
+        self.id_to_state = {el.getId(): el for el in self.getStates()} if self.getStates() else {}
+        self.id_to_variable = {el.getId(): el for el in self.getVariables()} if self.getVariables() else {}
+
         
         
     def parseFromFile(self, filename):
@@ -428,28 +434,17 @@ class OvalDocument(object):
             return None
         
         if oval_type == OvalDefinition.DEFINITION:
-            elist = self.getDefinitions()
+            return self.id_to_definition[ovalid]
         elif oval_type == OvalDefinition.TEST:
-            elist = self.getTests()
+            return self.id_to_test[ovalid]
         elif oval_type == OvalDefinition.OBJECT:
-            elist = self.getObjects()
+            return self.id_to_object[ovalid]
         elif oval_type == OvalDefinition.STATE:
-            elist = self.getStates()
+            return self.id_to_state[ovalid]
         elif oval_type == OvalDefinition.VARIABLE:
-            elist = self.getVariables()
+            return self.id_to_variable[ovalid]
         else:
             return None
-            
-        if not elist:
-            return None
-        
-        for element in elist:
-            defid = element.getId()
-            if defid and defid == ovalid:
-                return element
-            
-                    
-        
     
     def addElement(self, element, replace=True):
         """
@@ -502,6 +497,7 @@ class OvalDocument(object):
                 root.append(parent)
                 
             parent.append(element.getElement())
+            self.id_to_definition[ovalid] = element
             return True
         
         elif oval_type == OvalDefinition.TEST:
@@ -511,6 +507,7 @@ class OvalDocument(object):
                 root.append(parent)
                 
             parent.append(element.getElement())
+            self.id_to_test[ovalid] = element
             return True
         
         elif oval_type == OvalDefinition.OBJECT:
@@ -520,6 +517,7 @@ class OvalDocument(object):
                 root.append(parent)
                 
             parent.append(element.getElement())
+            self.id_to_object[ovalid] = element
             return True
         
         elif oval_type == OvalDefinition.STATE:
@@ -529,6 +527,7 @@ class OvalDocument(object):
                 root.append(parent)
                 
             parent.append(element.getElement())
+            self.id_to_state[ovalid] = element
             return True
         
         elif oval_type == OvalDefinition.VARIABLE:
@@ -536,7 +535,8 @@ class OvalDocument(object):
             if parent is None:
                 parent = Element("{" + OvalDocument.NS_DEFAULT.get("def") + "}variables")
                 root.append(parent)
-                
+            
+            self.id_to_variable[ovalid] = element
             parent.append(element.getElement())
             return True
         


### PR DESCRIPTION
This came up at https://github.com/nexB/vulnerablecode/pull/179 as we wanted to make parser for OVAL documents to obtain mappings of vulnerabilities and packages. 

I have used  https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2 which is about 40 MB to obtain these below stats
Before performance tweaks :  
```

...: p = pstats.Stats('perf.txt') 
   ...: p.sort_stats('cumulative').print_stats(10)                                                                           
Sat May 16 15:19:18 2020    perf.txt

         769968949 function calls (769934359 primitive calls) in 383.945 seconds

   Ordered by: cumulative time
   List reduced from 469 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     27/1    0.000    0.000  383.945  383.945 {built-in method builtins.exec}
        1    0.000    0.000  383.945  383.945 profiler.py:1(<module>)
        1    0.434    0.434  382.571  382.571 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/oval_parser.py:22(get_data)
    84661   12.240    0.000  205.191    0.002 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/lib_oval.py:408(getElementByID)
    33373    9.235    0.000  195.203    0.006 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/oval_parser.py:115(get_object_state_of_test)
    15267   59.637    0.004  162.846    0.011 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/oval_parser.py:95(get_tests_of_definition)
289921428   75.677    0.000  123.842    0.000 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/lib_oval.py:734(getId)
    33373    2.101    0.000  112.006    0.003 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/lib_oval.py:356(getStates)
    33373   52.569    0.002  109.479    0.003 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/lib_oval.py:377(<listcomp>)
110130900   56.909    0.000   56.909    0.000 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/lib_oval.py:1358(__init__)
```
As you can see the old getElementById method was the culprit.
The new getElementById method(the one included in the PR)  gives these stats 

```
Sat May 16 17:18:32 2020    perf3.txt

         4094392 function calls (4059802 primitive calls) in 5.144 seconds

   Ordered by: cumulative time
   List reduced from 476 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     27/1    0.000    0.000    5.144    5.144 {built-in method builtins.exec}
        1    0.000    0.000    5.144    5.144 profiler.py:1(<module>)
        1    0.140    0.140    3.727    3.727 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/oval_parser.py:60(get_data)
    33373    0.072    0.000    1.665    0.000 /home/shivam/coding/opensource/oriv/vulnerablecode/vulnerabilities/scraper/oval_parser.py:173(get_versionsrngs_from_state)
    33371    0.110    0.000    1.581    0.000 /home/shivam/coding/opensource/oriv/vulnerablecode/venv/lib/python3.8/site-packages/dephell_specifier/range_specifier.py:20(__init__)
        1    0.000    0.000    1.325    1.325 /usr/lib/python3.8/xml/etree/ElementTree.py:1192(parse)
        1    0.000    0.000    1.325    1.325 /usr/lib/python3.8/xml/etree/ElementTree.py:571(parse)
        1    1.325    1.325    1.325    1.325 {method '_parse_whole' of 'xml.etree.ElementTree.XMLParser' objects}
    33371    0.107    0.000    1.300    0.000 /home/shivam/coding/opensource/oriv/vulnerablecode/venv/lib/python3.8/site-packages/dephell_specifier/range_specifier.py:44(_parse)
    33382    0.152    0.000    0.808    0.000 /home/shivam/coding/opensource/oriv/vulnerablecode/venv/lib/python3.8/site-packages/dephell_specifier/specifier.py:51(__init__)
```
As you can see the new `getElementById` doesn't even make to top 10 time consuming function. 

**How this is acheived** 
The old `getElementById ` works something as , take an OVAL id, check every element for it's id ,if this matches to the requested id, return this element. **Old time complexity O(N)**.

The new `getElementById` instead, maintains  a dictionary [id->element]  and uses it. **New time complexity O(1)**.
Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>