### PR TITLE
Some coding style and problem of running on Windows

### DIFF
--- a/scripts/build_all_oval_definitions.py
+++ b/scripts/build_all_oval_definitions.py
@@ -24,7 +24,7 @@ def main():
     args = vars(parser.parse_args())
 
     # get indexes
-    definitions_index = lib_search.DefinitionsIndex(message)
+    # definitions_index = lib_search.DefinitionsIndex(message)
     elements_index = lib_search.ElementsIndex(message)
 
     # create generator, build in memory b/c smallish files

--- a/scripts/build_all_oval_definitions.py
+++ b/scripts/build_all_oval_definitions.py
@@ -13,6 +13,9 @@ TODO:
 import argparse, sys, time, cProfile
 import lib_repo, lib_xml, lib_search
 
+###
+# Get a temp directory rather than /tmp/ hardcoding
+import tempfile
 
 def main():
     """ parse command line options and generate file """
@@ -31,6 +34,7 @@ def main():
     OvalGenerator = lib_xml.OvalGenerator(message)
     OvalGenerator.use_file_queues = False
 
+    print("Storing data in temp directory: {}".format(tempfile.gettempdir()))
     i_file = 0
     i_limit = args['limit']
     for defpath in lib_repo.get_definition_paths_iterator():
@@ -52,7 +56,7 @@ def main():
             OvalGenerator.queue_element_file(element_type, file_path)
 
         # write output file
-        outfile = './tmp/gen.{0}'.format(lib_repo.oval_id_to_path(def_id))
+        outfile = '{1}/gen.{0}'.format(lib_repo.oval_id_to_path(def_id), tempfile.gettempdir())
         OvalGenerator.to_file(outfile)
 
     seconds_elapsed = time.time() - start_time

--- a/scripts/lib_search.py
+++ b/scripts/lib_search.py
@@ -356,10 +356,10 @@ class SearchIndex:
 
         # if not a text field, escape spaces
         if (field and field not in self.text_fields):
-            s = re.sub('\s+','_', s)
+            s = re.sub(r'\s+','_', s)
 
         # escape _:[]
-        s = re.sub('[_:\[\]]+','_', s)
+        s = re.sub(r'[_:\[\]]+','_', s)
 
         return s
 

--- a/scripts/lib_xml.py
+++ b/scripts/lib_xml.py
@@ -70,14 +70,14 @@ def get_definition_metadata(filepath):
                 "type": revision_type, 
                 "status": revision.text,
                 "date": revision_datetime
-            });
+            })
         elif revision_type in ['created','submitted','modified']:
             if len(revision) == 0:
                 revisions.append({
                     "type": revision_type, 
                     "comment": revision.get('comment'),
                     "date": revision_datetime
-                });
+                })
             else:
                 for contributor in revision:
                     revisions.append({
@@ -86,7 +86,7 @@ def get_definition_metadata(filepath):
                         "date": revision_datetime,
                         "contributor": contributor.text,
                         "organization": contributor.get('organization')
-                    });
+                    })
         else:
             raise InvalidRevisionXml(filepath, 'Unexpected revision type:  {0}'.format(revision_type))
 


### PR DESCRIPTION
I have made some correction to Python coding style (lack of 'r', use of ;, etc) patch

As well as there is a reference in the code to /tmp/ which on Linux wouldn't exist (unless you made it) and on Windows wouldn't work as well, so I suggest we transition to tempfile.gettempdir() which will return the temporary directory set in Linux and Windows

We can further move to asking the user to pass a TMP folder - other python scripts appear to ask for it

Let me know what you think