### PR TITLE
Update oval_org.cisecurity_def_7498.xml

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_7498.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_7498.xml
@@ -1,4 +1,4 @@
-<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:7498" version="6">
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:org.cisecurity:def:7498" version="6" deprecated="true">
   <metadata>
     <title>The libtremor library has the same flaw as CVE-2018-5146.</title>
     <affected family="windows">


### PR DESCRIPTION
This vulnerability is applied "on Android and ARM platforms" so it should be deprecated.