### PR TITLE
13 Firefox and Thunderbird CVEs

### DIFF
--- a/repository/definitions/vulnerability/oval_com.gfi_def_1358.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1358.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1358" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in code shared between Firefox and Thunderbird.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-29976" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29976" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in code shared between Firefox and Thunderbird. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Thunderbird &lt; 78.12, Firefox ESR &lt; 78.12, and Firefox &lt; 90.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-01T01:36:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.12" test_ref="oval:com.gfi:tst:1359"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.12" test_ref="oval:com.gfi:tst:1361"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 90.0" test_ref="oval:com.gfi:tst:1363"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1365.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1365.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1365" version="0" class="vulnerability">
+  <metadata>
+    <title>Through a series of DOM manipulations, a message, over which the attacker had control of the text but not HTML or formatting, could be overlaid on top of another domain (with the new domain correctly shown in the address bar) resulting in possible user confusion.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-29975" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29975" source="CVE"/>
+    <description>Through a series of DOM manipulations, a message, over which the attacker had control of the text but not HTML or formatting, could be overlaid on top of another domain (with the new domain correctly shown in the address bar) resulting in possible user confusion. This vulnerability affects Firefox &lt; 90.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-01T03:19:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 90.0" test_ref="oval:com.gfi:tst:1366"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1368.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1368.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1368" version="0" class="vulnerability">
+  <metadata>
+    <title>When network partitioning was enabled, e.g. as a result of Enhanced Tracking Protection settings, a TLS error page would allow the user to override an error on a domain which had specified HTTP Strict Transport Security (which implies that the error should not be override-able.)</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-29974" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29974" source="CVE"/>
+    <description>When network partitioning was enabled, e.g. as a result of Enhanced Tracking Protection settings, a TLS error page would allow the user to override an error on a domain which had specified HTTP Strict Transport Security (which implies that the error should not be override-able.) This issue did not affect the network connections, and they were correctly upgraded to HTTPS automatically. This vulnerability affects Firefox &lt; 90.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-01T04:38:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 90.0" test_ref="oval:com.gfi:tst:1369"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1374.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1374.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1374" version="0" class="vulnerability">
+  <metadata>
+    <title>A use-after-free vulnerability was found via testing, and traced to an out-of-date Cairo library.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-29972" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29972" source="CVE"/>
+    <description>A use-after-free vulnerability was found via testing, and traced to an out-of-date Cairo library. Updating the library resolved the issue, and may have remediated other, unknown security vulnerabilities as well. This vulnerability affects Firefox &lt; 90.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-01T06:10:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 90.0" test_ref="oval:com.gfi:tst:1375"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1377.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1377.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1377" version="0" class="vulnerability">
+  <metadata>
+    <title>A malicious webpage could have triggered a use-after-free, memory corruption, and a potentially exploitable crash.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-29970" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29970" source="CVE"/>
+    <description>A malicious webpage could have triggered a use-after-free, memory corruption, and a potentially exploitable crash. *This bug could only be triggered when accessibility was enabled.*. This vulnerability affects Thunderbird &lt; 78.12, Firefox ESR &lt; 78.12, and Firefox &lt; 90.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-01T07:50:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.12" test_ref="oval:com.gfi:tst:1378"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.12" test_ref="oval:com.gfi:tst:1380"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 90.0" test_ref="oval:com.gfi:tst:1382"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1384.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1384.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1384" version="0" class="vulnerability">
+  <metadata>
+    <title>By utilizing 3D CSS in conjunction with Javascript, content could have been rendered outside the webpage's viewport, resulting in a spoofing attack that could have been used for phishing or other attacks on a user.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-23996" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23996" source="CVE"/>
+    <description>By utilizing 3D CSS in conjunction with Javascript, content could have been rendered outside the webpage's viewport, resulting in a spoofing attack that could have been used for phishing or other attacks on a user. This vulnerability affects Firefox &lt; 88.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-01T09:28:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 88.0" test_ref="oval:com.gfi:tst:1385"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1387.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1387.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1387" version="0" class="vulnerability">
+  <metadata>
+    <title>When Responsive Design Mode was enabled, it used references to objects that were previously freed.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-23995" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23995" source="CVE"/>
+    <description>When Responsive Design Mode was enabled, it used references to objects that were previously freed. We presume that with enough effort this could have been exploited to run arbitrary code. This vulnerability affects Firefox ESR &lt; 78.10, Thunderbird &lt; 78.10, and Firefox &lt; 88.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-01T12:39:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.10" test_ref="oval:com.gfi:tst:1388"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.10" test_ref="oval:com.gfi:tst:1390"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 88.0" test_ref="oval:com.gfi:tst:1392"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1394.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1394.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1394" version="0" class="vulnerability">
+  <metadata>
+    <title>A WebGL framebuffer was not initialized early enough, resulting in memory corruption and an out of bound write.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-23994" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23994" source="CVE"/>
+    <description>A WebGL framebuffer was not initialized early enough, resulting in memory corruption and an out of bound write. This vulnerability affects Firefox ESR &lt; 78.10, Thunderbird &lt; 78.10, and Firefox &lt; 88.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-01T13:46:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.10" test_ref="oval:com.gfi:tst:1395"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.10" test_ref="oval:com.gfi:tst:1397"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 88.0" test_ref="oval:com.gfi:tst:1399"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1401.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1401.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1401" version="0" class="vulnerability">
+  <metadata>
+    <title>A malicious extension with the 'search' permission could have installed a new search engine whose favicon referenced a cross-origin URL.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-23986" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23986" source="CVE"/>
+    <description>A malicious extension with the 'search' permission could have installed a new search engine whose favicon referenced a cross-origin URL. The response to this cross-origin request could have been read by the extension, allowing a same-origin policy bypass by the extension, which should not have cross-origin permissions. This cross-origin request was made without cookies, so the sensitive information disclosed by the violation was limited to local-network resources or resources that perform IP-based authentication. This vulnerability affects Firefox &lt; 87.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-02T10:05:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 87.0" test_ref="oval:com.gfi:tst:1402"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1404.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1404.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1404" version="0" class="vulnerability">
+  <metadata>
+    <title>If an attacker is able to alter specific about:config values (for example malware running on the user's computer), the Devtools remote debugging feature could have been enabled in a way that was unnoticable to the user.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-23985" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23985" source="CVE"/>
+    <description>If an attacker is able to alter specific about:config values (for example malware running on the user's computer), the Devtools remote debugging feature could have been enabled in a way that was unnoticable to the user. This would have allowed a remote attacker (able to make a direct network connection to the victim) to monitor the user's browsing activity and (plaintext) network traffic. This was addressed by providing a visual cue when Devtools has an open network socket. This vulnerability affects Firefox &lt; 87.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-02T10:54:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 87.0" test_ref="oval:com.gfi:tst:1405"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1407.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1407.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1407" version="0" class="vulnerability">
+  <metadata>
+    <title>A malicious extension could have opened a popup window lacking an address bar.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+    </affected>
+    <reference ref_id="CVE-2021-23984" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23984" source="CVE"/>
+    <description>A malicious extension could have opened a popup window lacking an address bar. The title of the popup lacking an address bar should not be fully controllable, but in this situation was. This could have been used to spoof a website and attempt to trick the user into providing credentials. This vulnerability affects Firefox ESR &lt; 78.9, Firefox &lt; 87, and Thunderbird &lt; 78.9.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-02T11:19:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.9" test_ref="oval:com.gfi:tst:1408"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 87.0" test_ref="oval:com.gfi:tst:1410"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.9" test_ref="oval:com.gfi:tst:1412"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1414.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1414.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1414" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in Firefox 92 and Firefox ESR 91.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+    </affected>
+    <reference ref_id="CVE-2021-38501" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38501" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in Firefox 92 and Firefox ESR 91.1. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Firefox &lt; 93, Thunderbird &lt; 91.2, and Firefox ESR &lt; 91.2.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-03T04:16:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 93.0" test_ref="oval:com.gfi:tst:1415"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 91.2" test_ref="oval:com.gfi:tst:1417"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 91.2" test_ref="oval:com.gfi:tst:1419"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1421.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1421.xml
@@ -1,0 +1,53 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1421" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in Firefox 92 and Firefox ESR 91.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-38500" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38500" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in Firefox 92 and Firefox ESR 91.1. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Thunderbird &lt; 78.15, Thunderbird &lt; 91.2, Firefox ESR &lt; 91.2, Firefox ESR &lt; 78.15, and Firefox &lt; 93.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-03T08:00:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.15" test_ref="oval:com.gfi:tst:1422"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 91.2" test_ref="oval:com.gfi:tst:1424"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 91.2" test_ref="oval:com.gfi:tst:1426"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.15" test_ref="oval:com.gfi:tst:1428"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 93.0" test_ref="oval:com.gfi:tst:1430"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1360.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1360.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.12" id="oval:com.gfi:ste:1360" version="0">
+  <product_version datatype="version" operation="less than">78.12</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1362.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1362.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.12" id="oval:com.gfi:ste:1362" version="0">
+  <product_version datatype="version" operation="less than">78.12</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1364.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1364.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 90.0" id="oval:com.gfi:ste:1364" version="0">
+  <product_version datatype="version" operation="less than">90.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1367.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1367.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 90.0" id="oval:com.gfi:ste:1367" version="0">
+  <product_version datatype="version" operation="less than">90.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1370.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1370.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 90.0" id="oval:com.gfi:ste:1370" version="0">
+  <product_version datatype="version" operation="less than">90.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1376.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1376.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 90.0" id="oval:com.gfi:ste:1376" version="0">
+  <product_version datatype="version" operation="less than">90.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1379.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1379.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.12" id="oval:com.gfi:ste:1379" version="0">
+  <product_version datatype="version" operation="less than">78.12</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1381.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1381.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.12" id="oval:com.gfi:ste:1381" version="0">
+  <product_version datatype="version" operation="less than">78.12</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1383.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1383.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 90.0" id="oval:com.gfi:ste:1383" version="0">
+  <product_version datatype="version" operation="less than">90.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1386.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1386.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 88.0" id="oval:com.gfi:ste:1386" version="0">
+  <product_version datatype="version" operation="less than">88.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1389.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1389.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.10" id="oval:com.gfi:ste:1389" version="0">
+  <product_version datatype="version" operation="less than">78.10</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1391.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1391.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.10" id="oval:com.gfi:ste:1391" version="0">
+  <product_version datatype="version" operation="less than">78.10</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1393.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1393.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 88.0" id="oval:com.gfi:ste:1393" version="0">
+  <product_version datatype="version" operation="less than">88.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1396.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1396.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.10" id="oval:com.gfi:ste:1396" version="0">
+  <product_version datatype="version" operation="less than">78.10</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1398.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1398.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.10" id="oval:com.gfi:ste:1398" version="0">
+  <product_version datatype="version" operation="less than">78.10</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1400.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1400.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 88.0" id="oval:com.gfi:ste:1400" version="0">
+  <product_version datatype="version" operation="less than">88.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1403.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1403.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 87.0" id="oval:com.gfi:ste:1403" version="0">
+  <product_version datatype="version" operation="less than">87.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1406.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1406.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 87.0" id="oval:com.gfi:ste:1406" version="0">
+  <product_version datatype="version" operation="less than">87.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1409.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1409.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.9" id="oval:com.gfi:ste:1409" version="0">
+  <product_version datatype="version" operation="less than">78.9</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1411.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1411.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 87.0" id="oval:com.gfi:ste:1411" version="0">
+  <product_version datatype="version" operation="less than">87.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1413.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1413.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.9" id="oval:com.gfi:ste:1413" version="0">
+  <product_version datatype="version" operation="less than">78.9</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1416.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1416.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 93.0" id="oval:com.gfi:ste:1416" version="0">
+  <product_version datatype="version" operation="less than">93.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1418.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1418.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1418" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1420.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1420.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1420" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1423.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1423.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.15" id="oval:com.gfi:ste:1423" version="0">
+  <product_version datatype="version" operation="less than">78.15</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1425.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1425.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1425" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1427.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1427.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1427" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1429.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1429.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.15" id="oval:com.gfi:ste:1429" version="0">
+  <product_version datatype="version" operation="less than">78.15</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1431.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1431.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 93.0" id="oval:com.gfi:ste:1431" version="0">
+  <product_version datatype="version" operation="less than">93.0</product_version>
+</file_state>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1359.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1359.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.12" id="oval:com.gfi:tst:1359" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1360"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1361.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1361.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.12" id="oval:com.gfi:tst:1361" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1362"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1363.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1363.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 90.0" id="oval:com.gfi:tst:1363" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1364"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1366.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1366.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 90.0" id="oval:com.gfi:tst:1366" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1367"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1369.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1369.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 90.0" id="oval:com.gfi:tst:1369" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1370"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1375.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1375.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 90.0" id="oval:com.gfi:tst:1375" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1376"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1378.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1378.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.12" id="oval:com.gfi:tst:1378" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1379"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1380.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1380.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.12" id="oval:com.gfi:tst:1380" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1381"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1382.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1382.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 90.0" id="oval:com.gfi:tst:1382" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1383"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1385.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1385.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 88.0" id="oval:com.gfi:tst:1385" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1386"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1388.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1388.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.10" id="oval:com.gfi:tst:1388" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1389"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1390.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1390.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.10" id="oval:com.gfi:tst:1390" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1391"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1392.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1392.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 88.0" id="oval:com.gfi:tst:1392" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1393"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1395.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1395.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.10" id="oval:com.gfi:tst:1395" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1396"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1397.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1397.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.10" id="oval:com.gfi:tst:1397" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1398"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1399.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1399.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 88.0" id="oval:com.gfi:tst:1399" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1400"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1402.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1402.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 87.0" id="oval:com.gfi:tst:1402" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1403"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1405.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1405.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 87.0" id="oval:com.gfi:tst:1405" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1406"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1408.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1408.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.9" id="oval:com.gfi:tst:1408" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1409"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1410.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1410.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 87.0" id="oval:com.gfi:tst:1410" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1411"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1412.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1412.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.9" id="oval:com.gfi:tst:1412" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1413"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1415.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1415.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 93.0" id="oval:com.gfi:tst:1415" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1416"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1417.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1417.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 91.2" id="oval:com.gfi:tst:1417" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1418"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1419.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1419.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 91.2" id="oval:com.gfi:tst:1419" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1420"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1422.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1422.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.15" id="oval:com.gfi:tst:1422" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1423"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1424.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1424.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 91.2" id="oval:com.gfi:tst:1424" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1425"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1426.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1426.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 91.2" id="oval:com.gfi:tst:1426" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1427"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1428.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1428.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.15" id="oval:com.gfi:tst:1428" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1429"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1430.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1430.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 93.0" id="oval:com.gfi:tst:1430" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1431"/>
+</file_test>


### PR DESCRIPTION
Includes CVE-2021-38500, CVE-2021-38501, CVE-2021-23984, CVE-2021-23985, CVE-2021-23986, CVE-2021-23985, CVE-2021-23995, CVE-2021-23996, CVE-2021-29970, CVE-2021-29972, CVE-2021-29974, CVE-2021-29975, and CVE-2021-29976.