### PR TITLE
15 Firefox and Thunderbird CVEs

### DIFF
--- a/repository/definitions/vulnerability/oval_com.gfi_def_1432.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1432.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1432" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in Firefox 92.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-38499" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38499" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in Firefox 92. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Firefox &lt; 93.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-04T14:33:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 93.0" test_ref="oval:com.gfi:tst:1433"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1435.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1435.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1435" version="0" class="vulnerability">
+  <metadata>
+    <title>During process shutdown, a document could have caused a use-after-free of a languages service object, leading to memory corruption and a potentially exploitable crash.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+    </affected>
+    <reference ref_id="CVE-2021-38498" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38498" source="CVE"/>
+    <description>During process shutdown, a document could have caused a use-after-free of a languages service object, leading to memory corruption and a potentially exploitable crash. This vulnerability affects Firefox &lt; 93, Thunderbird &lt; 91.2, and Firefox ESR &lt; 91.2.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-05T02:41:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 93.0" test_ref="oval:com.gfi:tst:1436"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 91.2" test_ref="oval:com.gfi:tst:1438"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 91.2" test_ref="oval:com.gfi:tst:1440"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1442.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1442.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1442" version="0" class="vulnerability">
+  <metadata>
+    <title>Through use of reportValidity() and window.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+    </affected>
+    <reference ref_id="CVE-2021-38497" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38497" source="CVE"/>
+    <description>Through use of reportValidity() and window.open(), a plain-text validation message could have been overlaid on another origin, leading to possible user confusion and spoofing attacks. This vulnerability affects Firefox &lt; 93, Thunderbird &lt; 91.2, and Firefox ESR &lt; 91.2.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T01:52:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 93.0" test_ref="oval:com.gfi:tst:1443"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 91.2" test_ref="oval:com.gfi:tst:1445"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 91.2" test_ref="oval:com.gfi:tst:1447"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1449.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1449.xml
@@ -1,0 +1,53 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1449" version="0" class="vulnerability">
+  <metadata>
+    <title>During operations on MessageTasks, a task may have been removed while it was still scheduled, resulting in memory corruption and a potentially exploitable crash.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-38496" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38496" source="CVE"/>
+    <description>During operations on MessageTasks, a task may have been removed while it was still scheduled, resulting in memory corruption and a potentially exploitable crash. This vulnerability affects Thunderbird &lt; 78.15, Thunderbird &lt; 91.2, Firefox ESR &lt; 91.2, Firefox ESR &lt; 78.15, and Firefox &lt; 93.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T02:41:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.15" test_ref="oval:com.gfi:tst:1450"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 91.2" test_ref="oval:com.gfi:tst:1452"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 91.2" test_ref="oval:com.gfi:tst:1454"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.15" test_ref="oval:com.gfi:tst:1456"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 93.0" test_ref="oval:com.gfi:tst:1458"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1460.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1460.xml
@@ -1,0 +1,40 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1460" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in Thunderbird 78.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+    </affected>
+    <reference ref_id="CVE-2021-38495" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38495" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in Thunderbird 78.13.0. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Thunderbird &lt; 91.1 and Firefox ESR &lt; 91.1.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T04:25:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 91.1" test_ref="oval:com.gfi:tst:1461"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 91.1" test_ref="oval:com.gfi:tst:1463"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1465.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1465.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1465" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in Firefox 91.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-38494" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38494" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in Firefox 91. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Firefox &lt; 92.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T05:19:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 92.0" test_ref="oval:com.gfi:tst:1466"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1468.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1468.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1468" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in Firefox 91 and Firefox ESR 78.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-38493" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38493" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in Firefox 91 and Firefox ESR 78.13. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Firefox ESR &lt; 78.14, Thunderbird &lt; 78.14, and Firefox &lt; 92.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T05:55:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.14" test_ref="oval:com.gfi:tst:1469"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.14" test_ref="oval:com.gfi:tst:1471"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 92.0" test_ref="oval:com.gfi:tst:1473"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1475.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1475.xml
@@ -1,0 +1,53 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1475" version="0" class="vulnerability">
+  <metadata>
+    <title>When delegating navigations to the operating system, Firefox would accept the `mk` scheme which might allow attackers to launch pages and execute scripts in Internet Explorer in unprivileged mode.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+    </affected>
+    <reference ref_id="CVE-2021-38492" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38492" source="CVE"/>
+    <description>When delegating navigations to the operating system, Firefox would accept the `mk` scheme which might allow attackers to launch pages and execute scripts in Internet Explorer in unprivileged mode. *This bug only affects Firefox for Windows. Other operating systems are unaffected.*. This vulnerability affects Firefox &lt; 92, Thunderbird &lt; 91.1, Thunderbird &lt; 78.14, Firefox ESR &lt; 78.14, and Firefox ESR &lt; 91.1.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T07:14:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 92.0" test_ref="oval:com.gfi:tst:1476"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 91.1" test_ref="oval:com.gfi:tst:1478"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.14" test_ref="oval:com.gfi:tst:1480"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.14" test_ref="oval:com.gfi:tst:1482"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 91.1" test_ref="oval:com.gfi:tst:1484"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1486.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1486.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1486" version="0" class="vulnerability">
+  <metadata>
+    <title>Mixed-content checks were unable to analyze opaque origins which led to some mixed content being loaded.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-38491" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38491" source="CVE"/>
+    <description>Mixed-content checks were unable to analyze opaque origins which led to some mixed content being loaded. This vulnerability affects Firefox &lt; 92.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T07:44:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 92.0" test_ref="oval:com.gfi:tst:1487"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1489.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1489.xml
@@ -1,0 +1,40 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1489" version="0" class="vulnerability">
+  <metadata>
+    <title>Firefox incorrectly accepted a newline in a HTTP/3 header, interpretting it as two separate headers.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+    </affected>
+    <reference ref_id="CVE-2021-29991" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29991" source="CVE"/>
+    <description>Firefox incorrectly accepted a newline in a HTTP/3 header, interpretting it as two separate headers. This allowed for a header splitting attack against servers using HTTP/3. This vulnerability affects Firefox &lt; 91.0.1 and Thunderbird &lt; 91.0.1.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T10:08:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 91.0.1" test_ref="oval:com.gfi:tst:1490"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 91.0.1" test_ref="oval:com.gfi:tst:1492"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1494.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1494.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1494" version="0" class="vulnerability">
+  <metadata>
+    <title>By causing a transition on a parent node by removing a CSS rule, an invalid property for a marker could have been applied, resulting in memory corruption and a potentially exploitable crash.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-23983" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23983" source="CVE"/>
+    <description>By causing a transition on a parent node by removing a CSS rule, an invalid property for a marker could have been applied, resulting in memory corruption and a potentially exploitable crash. This vulnerability affects Firefox &lt; 87.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T10:50:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 87.0" test_ref="oval:com.gfi:tst:1495"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1497.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1497.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1497" version="0" class="vulnerability">
+  <metadata>
+    <title>Using techniques that built on the slipstream research, a malicious webpage could have scanned both an internal network's hosts as well as services running on the user's local machine utilizing WebRTC connections.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+    </affected>
+    <reference ref_id="CVE-2021-23982" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23982" source="CVE"/>
+    <description>Using techniques that built on the slipstream research, a malicious webpage could have scanned both an internal network's hosts as well as services running on the user's local machine utilizing WebRTC connections. This vulnerability affects Firefox ESR &lt; 78.9, Firefox &lt; 87, and Thunderbird &lt; 78.9.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T11:24:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.9" test_ref="oval:com.gfi:tst:1498"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 87.0" test_ref="oval:com.gfi:tst:1500"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.9" test_ref="oval:com.gfi:tst:1502"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1504.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1504.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1504" version="0" class="vulnerability">
+  <metadata>
+    <title>A texture upload of a Pixel Buffer Object could have confused the WebGL code to skip binding the buffer used to unpack it, resulting in memory corruption and a potentially exploitable information leak or crash.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox ESR</product>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+    </affected>
+    <reference ref_id="CVE-2021-23981" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23981" source="CVE"/>
+    <description>A texture upload of a Pixel Buffer Object could have confused the WebGL code to skip binding the buffer used to unpack it, resulting in memory corruption and a potentially exploitable information leak or crash. This vulnerability affects Firefox ESR &lt; 78.9, Firefox &lt; 87, and Thunderbird &lt; 78.9.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T11:54:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.9" test_ref="oval:com.gfi:tst:1505"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 87.0" test_ref="oval:com.gfi:tst:1507"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.9" test_ref="oval:com.gfi:tst:1509"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1511.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1511.xml
@@ -1,0 +1,33 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1511" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in Firefox 85.</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+    </affected>
+    <reference ref_id="CVE-2021-23979" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23979" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in Firefox 85. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Firefox &lt; 86.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T12:20:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+    <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+    <criterion comment="Check if Mozilla Firefox Mainline version less than 86.0" test_ref="oval:com.gfi:tst:1512"/>
+  </criteria>
+</definition>

--- a/repository/definitions/vulnerability/oval_com.gfi_def_1514.xml
+++ b/repository/definitions/vulnerability/oval_com.gfi_def_1514.xml
@@ -1,0 +1,45 @@
+<definition xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" id="oval:com.gfi:def:1514" version="0" class="vulnerability">
+  <metadata>
+    <title>Mozilla developers reported memory safety bugs present in Firefox 85 and Firefox ESR 78.7</title>
+    <affected family="windows">
+      <platform>Microsoft Windows 7</platform>
+      <platform>Microsoft Windows 8</platform>
+      <platform>Microsoft Windows 8.1</platform>
+      <platform>Microsoft Windows 10</platform>
+      <platform>Microsoft Windows Server 2008</platform>
+      <platform>Microsoft Windows Server 2008 R2</platform>
+      <platform>Microsoft Windows Server 2012</platform>
+      <platform>Microsoft Windows Server 2012 R2</platform>
+      <platform>Microsoft Windows Server 2016</platform>
+      <platform>Microsoft Windows Server 2019</platform>
+      <product>Mozilla Firefox</product>
+      <product>Mozilla Thunderbird</product>
+      <product>Mozilla Firefox ESR</product>
+    </affected>
+    <reference ref_id="CVE-2021-23978" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23978" source="CVE"/>
+    <description>Mozilla developers reported memory safety bugs present in Firefox 85 and Firefox ESR 78.7. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code. This vulnerability affects Firefox &lt; 86, Thunderbird &lt; 78.8, and Firefox ESR &lt; 78.8.</description>
+    <oval_repository>
+      <dates>
+        <submitted date="2021-11-08T12:48:00+00:00">
+          <contributor organization="GFI">Glenn Lugod</contributor>
+        </submitted>
+      </dates>
+      <status>INITIAL SUBMISSION</status>
+      <min_schema_version>5.10</min_schema_version>
+    </oval_repository>
+  </metadata>
+  <criteria operator="OR">
+    <criteria comment="Mozilla Firefox Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22259"/>
+      <criterion comment="Check if Mozilla Firefox Mainline version less than 86.0" test_ref="oval:com.gfi:tst:1515"/>
+    </criteria>
+    <criteria comment="Mozilla Thunderbird Mainline release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Thunderbird Mainline release is installed" definition_ref="oval:org.mitre.oval:def:22093"/>
+      <criterion comment="Check if Mozilla Thunderbird Mainline version less than 78.8" test_ref="oval:com.gfi:tst:1517"/>
+    </criteria>
+    <criteria comment="Mozilla Firefox ESR release is installed + version" operator="AND">
+      <extend_definition comment="Mozilla Firefox ESR is installed" definition_ref="oval:org.mitre.oval:def:22414"/>
+      <criterion comment="Check if Mozilla Firefox ESR version is less than 78.8" test_ref="oval:com.gfi:tst:1519"/>
+    </criteria>
+  </criteria>
+</definition>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1434.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1434.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 93.0" id="oval:com.gfi:ste:1434" version="0">
+  <product_version datatype="version" operation="less than">93.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1437.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1437.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 93.0" id="oval:com.gfi:ste:1437" version="0">
+  <product_version datatype="version" operation="less than">93.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1439.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1439.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1439" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1441.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1441.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1441" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1444.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1444.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 93.0" id="oval:com.gfi:ste:1444" version="0">
+  <product_version datatype="version" operation="less than">93.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1446.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1446.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1446" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1448.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1448.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1448" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1451.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1451.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.15" id="oval:com.gfi:ste:1451" version="0">
+  <product_version datatype="version" operation="less than">78.15</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1453.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1453.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1453" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1455.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1455.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.2" id="oval:com.gfi:ste:1455" version="0">
+  <product_version datatype="version" operation="less than">91.2</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1457.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1457.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.15" id="oval:com.gfi:ste:1457" version="0">
+  <product_version datatype="version" operation="less than">78.15</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1459.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1459.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 93.0" id="oval:com.gfi:ste:1459" version="0">
+  <product_version datatype="version" operation="less than">93.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1462.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1462.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.1" id="oval:com.gfi:ste:1462" version="0">
+  <product_version datatype="version" operation="less than">91.1</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1464.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1464.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.1" id="oval:com.gfi:ste:1464" version="0">
+  <product_version datatype="version" operation="less than">91.1</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1467.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1467.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 92.0" id="oval:com.gfi:ste:1467" version="0">
+  <product_version datatype="version" operation="less than">92.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1470.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1470.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.14" id="oval:com.gfi:ste:1470" version="0">
+  <product_version datatype="version" operation="less than">78.14</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1472.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1472.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.14" id="oval:com.gfi:ste:1472" version="0">
+  <product_version datatype="version" operation="less than">78.14</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1474.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1474.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 92.0" id="oval:com.gfi:ste:1474" version="0">
+  <product_version datatype="version" operation="less than">92.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1477.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1477.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 92.0" id="oval:com.gfi:ste:1477" version="0">
+  <product_version datatype="version" operation="less than">92.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1479.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1479.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.1" id="oval:com.gfi:ste:1479" version="0">
+  <product_version datatype="version" operation="less than">91.1</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1481.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1481.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.14" id="oval:com.gfi:ste:1481" version="0">
+  <product_version datatype="version" operation="less than">78.14</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1483.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1483.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.14" id="oval:com.gfi:ste:1483" version="0">
+  <product_version datatype="version" operation="less than">78.14</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1485.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1485.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.1" id="oval:com.gfi:ste:1485" version="0">
+  <product_version datatype="version" operation="less than">91.1</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1488.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1488.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 92.0" id="oval:com.gfi:ste:1488" version="0">
+  <product_version datatype="version" operation="less than">92.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1491.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1491.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.0.1" id="oval:com.gfi:ste:1491" version="0">
+  <product_version datatype="version" operation="less than">91.0.1</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1493.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1493.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 91.0.1" id="oval:com.gfi:ste:1493" version="0">
+  <product_version datatype="version" operation="less than">91.0.1</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1496.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1496.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 87.0" id="oval:com.gfi:ste:1496" version="0">
+  <product_version datatype="version" operation="less than">87.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1499.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1499.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.9" id="oval:com.gfi:ste:1499" version="0">
+  <product_version datatype="version" operation="less than">78.9</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1501.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1501.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 87.0" id="oval:com.gfi:ste:1501" version="0">
+  <product_version datatype="version" operation="less than">87.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1503.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1503.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.9" id="oval:com.gfi:ste:1503" version="0">
+  <product_version datatype="version" operation="less than">78.9</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1506.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1506.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.9" id="oval:com.gfi:ste:1506" version="0">
+  <product_version datatype="version" operation="less than">78.9</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1508.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1508.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 87.0" id="oval:com.gfi:ste:1508" version="0">
+  <product_version datatype="version" operation="less than">87.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1510.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1510.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.9" id="oval:com.gfi:ste:1510" version="0">
+  <product_version datatype="version" operation="less than">78.9</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1513.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1513.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 86.0" id="oval:com.gfi:ste:1513" version="0">
+  <product_version datatype="version" operation="less than">86.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1516.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1516.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 86.0" id="oval:com.gfi:ste:1516" version="0">
+  <product_version datatype="version" operation="less than">86.0</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1518.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1518.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.8" id="oval:com.gfi:ste:1518" version="0">
+  <product_version datatype="version" operation="less than">78.8</product_version>
+</file_state>

--- a/repository/states/windows/file_state/1000/oval_com.gfi_ste_1520.xml
+++ b/repository/states/windows/file_state/1000/oval_com.gfi_ste_1520.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 78.8" id="oval:com.gfi:ste:1520" version="0">
+  <product_version datatype="version" operation="less than">78.8</product_version>
+</file_state>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1433.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1433.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 93.0" id="oval:com.gfi:tst:1433" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1434"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1436.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1436.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 93.0" id="oval:com.gfi:tst:1436" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1437"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1438.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1438.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 91.2" id="oval:com.gfi:tst:1438" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1439"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1440.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1440.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 91.2" id="oval:com.gfi:tst:1440" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1441"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1443.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1443.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 93.0" id="oval:com.gfi:tst:1443" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1444"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1445.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1445.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 91.2" id="oval:com.gfi:tst:1445" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1446"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1447.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1447.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 91.2" id="oval:com.gfi:tst:1447" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1448"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1450.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1450.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.15" id="oval:com.gfi:tst:1450" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1451"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1452.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1452.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 91.2" id="oval:com.gfi:tst:1452" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1453"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1454.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1454.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 91.2" id="oval:com.gfi:tst:1454" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1455"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1456.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1456.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.15" id="oval:com.gfi:tst:1456" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1457"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1458.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1458.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 93.0" id="oval:com.gfi:tst:1458" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1459"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1461.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1461.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 91.1" id="oval:com.gfi:tst:1461" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1462"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1463.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1463.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 91.1" id="oval:com.gfi:tst:1463" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1464"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1466.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1466.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 92.0" id="oval:com.gfi:tst:1466" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1467"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1469.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1469.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.14" id="oval:com.gfi:tst:1469" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1470"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1471.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1471.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.14" id="oval:com.gfi:tst:1471" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1472"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1473.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1473.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 92.0" id="oval:com.gfi:tst:1473" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1474"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1476.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1476.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 92.0" id="oval:com.gfi:tst:1476" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1477"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1478.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1478.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 91.1" id="oval:com.gfi:tst:1478" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1479"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1480.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1480.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.14" id="oval:com.gfi:tst:1480" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1481"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1482.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1482.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.14" id="oval:com.gfi:tst:1482" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1483"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1484.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1484.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 91.1" id="oval:com.gfi:tst:1484" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1485"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1487.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1487.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 92.0" id="oval:com.gfi:tst:1487" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1488"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1490.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1490.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 91.0.1" id="oval:com.gfi:tst:1490" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1491"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1492.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1492.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 91.0.1" id="oval:com.gfi:tst:1492" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1493"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1495.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1495.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 87.0" id="oval:com.gfi:tst:1495" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1496"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1498.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1498.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.9" id="oval:com.gfi:tst:1498" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1499"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1500.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1500.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 87.0" id="oval:com.gfi:tst:1500" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1501"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1502.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1502.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.9" id="oval:com.gfi:tst:1502" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1503"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1505.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1505.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.9" id="oval:com.gfi:tst:1505" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1506"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1507.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1507.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 87.0" id="oval:com.gfi:tst:1507" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1508"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1509.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1509.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.9" id="oval:com.gfi:tst:1509" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1510"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1512.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1512.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 86.0" id="oval:com.gfi:tst:1512" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1513"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1515.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1515.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox Mainline version less than 86.0" id="oval:com.gfi:tst:1515" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30321"/>
+  <state state_ref="oval:com.gfi:ste:1516"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1517.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1517.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Thunderbird Mainline version less than 78.8" id="oval:com.gfi:tst:1517" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30072"/>
+  <state state_ref="oval:com.gfi:ste:1518"/>
+</file_test>

--- a/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1519.xml
+++ b/repository/tests/windows/file_test/1000/oval_com.gfi_tst_1519.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Mozilla Firefox ESR version is less than 78.8" id="oval:com.gfi:tst:1519" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:30347"/>
+  <state state_ref="oval:com.gfi:ste:1520"/>
+</file_test>


### PR DESCRIPTION
Includes CVE-2021-38499, CVE-2021-38498, CVE-2021-38497, CVE-2021-38496, CVE-2021-38495, CVE-2021-38494, CVE-2021-38493, CVE-2021-38492, CVE-2021-38491, CVE-2021-29991, CVE-2021-23983, CVE-2021-23982, CVE-2021-23981, CVE-2021-23979, CVE-2021-23978