### PR TITLE
Modify CVE-2018-0886

### DIFF
--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4708.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4708.xml
@@ -21,8 +21,13 @@
         <status_change date="2018-03-23T23:58:08.265-04:00">DRAFT</status_change>
         <status_change date="2018-04-06T04:00:06.144-04:00">INTERIM</status_change>
         <status_change date="2018-04-20T04:00:08.177-04:00">ACCEPTED</status_change>
+        <modified date="2022-10-24">
+            <contributor organization="N/A">Christopher Eastridge</contributor>
+        </modified>
+        <status_change date="2022-10-24">DRAFT</status_change>
       </dates>
-      <status>ACCEPTED</status>
+      <status>DRAFT</status>
+        
       <min_schema_version>5.10</min_schema_version>
     </oval_repository>
   </metadata>

--- a/repository/definitions/vulnerability/oval_org.cisecurity_def_4708.xml
+++ b/repository/definitions/vulnerability/oval_org.cisecurity_def_4708.xml
@@ -34,8 +34,8 @@
         <extend_definition comment="Microsoft Windows Server 2008 (ia-64) is installed" definition_ref="oval:org.mitre.oval:def:5667" />
       </criteria>
       <criteria operator="OR">
-        <criterion comment="the 32-bit version of credssp.dll is less than 6.0.6002.24306" test_ref="oval:org.cisecurity:tst:6439" />
-        <criterion comment="the 64-bit WOW version of credssp.dll is less than 6.0.6002.24306" test_ref="oval:org.cisecurity:tst:6438" />
+        <criterion comment="the 32-bit version of tspkg.dll is less than 6.0.6002.24306" test_ref="oval:org.cisecurity:tst:6439" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 6.0.6002.24306" test_ref="oval:org.cisecurity:tst:6438" />
       </criteria>
     </criteria>
     <criteria comment="Win7/R2 + file version" operator="AND">
@@ -46,13 +46,13 @@
         <extend_definition comment="Microsoft Windows Server 2008 R2 Itanium-Based Edition Service Pack 1 is installed " definition_ref="oval:org.mitre.oval:def:12583" />
       </criteria>
       <criteria operator="OR">
-        <criterion comment="the 32-bit version of credssp.dll is less than 6.1.7601.24059" test_ref="oval:org.cisecurity:tst:6442" />
-        <criterion comment="the 64-bit WOW version of credssp.dll is less than 6.1.7601.24059" test_ref="oval:org.cisecurity:tst:6443" />
+        <criterion comment="the 32-bit version of tspkg.dll is less than 6.1.7601.24117" test_ref="oval:org.cisecurity:tst:6442" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 6.1.7601.24117" test_ref="oval:org.cisecurity:tst:6443" />
       </criteria>
     </criteria>
     <criteria comment="2012 + file version" operator="AND">
       <extend_definition comment="Microsoft Windows Server 2012 (64-bit) is installed" definition_ref="oval:org.mitre.oval:def:15585" />
-      <criterion comment="the 64-bit WOW version of credssp.dll is less than 6.2.9200.21703" test_ref="oval:org.cisecurity:tst:6447" />
+      <criterion comment="the 64-bit WOW version of tspkg.dll is less than 6.2.9200.22432" test_ref="oval:org.cisecurity:tst:6447" />
     </criteria>
     <criteria comment="Win8.1/2012R2 + file version" operator="AND">
       <criteria comment="Win8.1/2012R2" operator="OR">
@@ -61,16 +61,16 @@
         <extend_definition comment="Microsoft Windows Server 2012 R2 is installed" definition_ref="oval:org.mitre.oval:def:18858" />
       </criteria>
       <criteria operator="OR">
-        <criterion comment="the 32-bit version of credssp.dll is less than 6.3.9600.18939" test_ref="oval:org.cisecurity:tst:6446" />
-        <criterion comment="the 64-bit WOW version of credssp.dll is less than 6.3.9600.18939" test_ref="oval:org.cisecurity:tst:6441" />
+        <criterion comment="the 32-bit version of tspkg.dll is less than 6.3.9600.18999" test_ref="oval:org.cisecurity:tst:6446" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 6.3.9600.18999" test_ref="oval:org.cisecurity:tst:6441" />
       </criteria>
     </criteria>
     <criteria comment="Win10 + file version" operator="AND">
       <extend_definition comment="Microsoft Windows 10 (32-bit) is installed" definition_ref="oval:org.cisecurity:def:380" />
       <extend_definition comment="Microsoft Windows 10 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:377" />
       <criteria operator="OR">
-        <criterion comment="the 32-bit version of credssp.dll is less than 10.0.10240.17797" test_ref="oval:org.cisecurity:tst:6440" />
-        <criterion comment="the 64-bit WOW version of credssp.dll is less than 10.0.10240.17797" test_ref="oval:org.cisecurity:tst:6448" />
+        <criterion comment="the 32-bit version of tspkg.dll is less than 10.0.10240.17861" test_ref="oval:org.cisecurity:tst:6440" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 10.0.10240.17861" test_ref="oval:org.cisecurity:tst:6448" />
       </criteria>
     </criteria>
     <criteria comment="1511 + file version" operator="AND">
@@ -79,8 +79,8 @@
         <extend_definition comment="Microsoft Windows 10 Version 1511 (64-bit) is installed" definition_ref="oval:org.cisecurity:def:378" />
       </criteria>
       <criteria operator="OR">
-        <criterion comment="the 32-bit version of credssp.dll is less than 10.0.10586.1478" test_ref="oval:org.cisecurity:tst:6450" />
-        <criterion comment="the 64-bit WOW version of credssp.dll is less than 10.0.10586.1478" test_ref="oval:org.cisecurity:tst:6449" />
+        <criterion comment="the 32-bit version of tspkg.dll is less than 10.0.10586.1478" test_ref="oval:org.cisecurity:tst:6450" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 10.0.10586.1478" test_ref="oval:org.cisecurity:tst:6449" />
       </criteria>
     </criteria>
     <criteria comment="1607/2016 + file version" operator="AND">
@@ -90,8 +90,8 @@
         <extend_definition comment="Microsoft Windows Server 2016 is installed" definition_ref="oval:org.cisecurity:def:1269" />
       </criteria>
       <criteria operator="OR">
-        <criterion comment="the 32-bit version of credssp.dll is less than 10.0.14393.2125" test_ref="oval:org.cisecurity:tst:6444" />
-        <criterion comment="the 64-bit WOW version of credssp.dll is less than 10.0.14393.2125" test_ref="oval:org.cisecurity:tst:6452" />
+        <criterion comment="the 32-bit version of tspkg.dll is less than 10.0.14393.2248" test_ref="oval:org.cisecurity:tst:6444" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 10.0.14393.2248" test_ref="oval:org.cisecurity:tst:6452" />
       </criteria>
     </criteria>
     <criteria comment="1703 + file version" operator="AND">
@@ -100,8 +100,8 @@
         <extend_definition comment="Microsoft Windows 10 Version 1703 (x64) is installed" definition_ref="oval:org.cisecurity:def:2083" />
       </criteria>
       <criteria operator="OR">
-        <criterion comment="the 32-bit version of credssp.dll is less than 10.0.15063.966" test_ref="oval:org.cisecurity:tst:6437" />
-        <criterion comment="the 64-bit WOW version of credssp.dll is less than 10.0.15063.966" test_ref="oval:org.cisecurity:tst:6445" />
+        <criterion comment="the 32-bit version of tspkg.dll is less than 10.0.15063.1088" test_ref="oval:org.cisecurity:tst:6437" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 10.0.15063.1088" test_ref="oval:org.cisecurity:tst:6445" />
       </criteria>
     </criteria>
     <criteria comment="1709 + file version" operator="AND">
@@ -110,8 +110,18 @@
         <extend_definition comment="Microsoft Windows 10 Version 1709 (x64) is installed" definition_ref="oval:org.cisecurity:def:3481" />
       </criteria>
       <criteria operator="OR">
-        <criterion comment="the 32-bit version of credssp.dll is less than 10.0.16299.309" test_ref="oval:org.cisecurity:tst:6436" />
-        <criterion comment="the 64-bit WOW version of credssp.dll is less than 10.0.16299.309" test_ref="oval:org.cisecurity:tst:6451" />
+        <criterion comment="the 32-bit version of tspkg.dll is less than 10.0.16299.431" test_ref="oval:org.cisecurity:tst:6436" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 10.0.16299.431" test_ref="oval:org.cisecurity:tst:6451" />
+      </criteria>
+    </criteria>
+    <criteria comment="1803 + file version" operator="AND">
+      <criteria comment="1803" operator="OR">
+        <extend_definition comment="Microsoft Windows 10 Version 1803 (x86) is installed" definition_ref="oval:org.cisecurity:def:?" />
+        <extend_definition comment="Microsoft Windows 10 Version 1803 (x64) is installed" definition_ref="oval:org.cisecurity:def:?" />
+      </criteria>
+      <criteria operator="OR">
+        <criterion comment="the 32-bit version of tspkg.dll is less than 10.0.17134.48" test_ref="oval:org.cisecurity:tst:?" />
+        <criterion comment="the 64-bit WOW version of tspkg.dll is less than 10.0.17134.48" test_ref="oval:org.cisecurity:tst:?" />
       </criteria>
     </criteria>
   </criteria>


### PR DESCRIPTION
Current definition is incorrectly checking against credssp.dll instead of tspkg.dll per Microsoft. (https://github.com/CISecurity/OVALRepo/issues/1922)

Completed Changes:

Server 2008 : tspkg.dll is less than 6.0.6002.24306

Win7/R2: tspkg.dll is less than 6.1.7601.24117

2012: tspkg.dll is less than 6.2.9200.22432

Win8.1/2012R2: tspkg.dll is less than 6.3.9600.18999

Win 10: tspkg.dll is less than 10.0.10240.17861

1511: tspkg.dll is less than 10.0.10586.1478

1607/2016: tspkg.dll is less than 10.0.14393.2248

1703: tspkg.dll is less than 10.0.15063.1088

1709: tspkg.dll is less than 10.0.16299.431

Added 1803 section: tspkg.dll is less than 10.0.17134.48
Needs definition ref and test ref.